### PR TITLE
fix: preserve tiling layout and borders through monitor reconnect

### DIFF
--- a/Sources/OmniWM/Core/Controller/ServiceLifecycleManager.swift
+++ b/Sources/OmniWM/Core/Controller/ServiceLifecycleManager.swift
@@ -159,6 +159,9 @@ final class ServiceLifecycleManager {
 
     private func handleMonitorConfigurationChanged() {
         guard let controller else { return }
+        // Invalidate border cache so it gets fully recomputed after monitor change
+        // (prevents stale geometry when display ID or coordinate space changes, e.g. KVM switch)
+        controller.borderManager.hideBorder()
         let workspaceSnapshots = captureWorkspaceSnapshotsBeforeMonitorUpdate()
         let currentMonitors = Monitor.current()
         guard !currentMonitors.isEmpty else { return }

--- a/Sources/OmniWM/Core/Layout/Niri/NiriLayoutEngine.swift
+++ b/Sources/OmniWM/Core/Layout/Niri/NiriLayoutEngine.swift
@@ -102,6 +102,10 @@ final class NiriLayoutEngine {
 
     var roots: [WorkspaceDescriptor.ID: NiriRoot] = [:]
 
+    /// Viewport states rescued from monitors removed during display ID changes (e.g. KVM switch).
+    /// Consumed by moveWorkspace when re-associating workspaces to new monitors.
+    var orphanedViewportStates: [WorkspaceDescriptor.ID: ViewportState] = [:]
+
     var handleToNode: [WindowHandle: NiriWindow] = [:]
 
     var closingHandles: Set<WindowHandle> = []


### PR DESCRIPTION
## Summary

Builds on the workspace-to-monitor restore fix from #93 / f3701a6 to also preserve the actual **tiling layout** (column arrangement, window grouping, viewport state) and **border geometry** when monitors disconnect and reconnect, such as during a KVM switch.

### Problem
When a monitor reconnects via KVM switch, the `CGDirectDisplayID` often changes. This caused:
   - `updateMonitors()` to filter out the old `NiriMonitor` objects holding workspace roots (column/window trees)
   - `moveWorkspace()` to create fresh empty roots, triggering a full re-tile from scratch
   - `BorderManager` dedup guard to skip border recalculation since the logical frame appeared unchanged, leaving stale border geometry

### Changes
   - **`NiriLayoutEngine+Monitors.swift`**: Save workspace roots and viewport states to engine-level storage before removing monitors with stale IDs; always preserve at engine level during cleanup so they survive even when all monitor IDs change; recover orphaned viewport states in `moveWorkspace()` instead of creating blank ones
   - **`NiriLayoutEngine.swift`**: Add `orphanedViewportStates` dict to hold viewport states rescued from removed monitors
   - **`ServiceLifecycleManager.swift`**: Invalidate border cache on monitor configuration change so borders get recomputed with fresh coordinates

### Testing
Tested with a KVM switch (disconnect → reconnect with potentially different display IDs):
   - Window tiling arrangement is preserved through the switch
   - Window borders update correctly after reconnect
   - Workspace-to-monitor assignments continue to work (from the original fix)

Fixes #93