### PR TITLE
feat(settings.json): incremental export/import & human-readable hotkey encoding

### DIFF
--- a/Sources/OmniWM/Core/Config/SettingsExport.swift
+++ b/Sources/OmniWM/Core/Config/SettingsExport.swift
@@ -1,5 +1,7 @@
 import Foundation
 
+// MARK: - SettingsExport
+
 struct SettingsExport: Codable {
     var version: Int = 1
 
@@ -83,6 +85,90 @@ struct SettingsExport: Codable {
     var appearanceMode: String
 }
 
+// MARK: - Defaults & Diffing
+
+extension SettingsExport {
+    static func defaults() -> SettingsExport {
+        SettingsExport(
+            hotkeysEnabled: true,
+            focusFollowsMouse: false,
+            moveMouseToFocusedWindow: false,
+            mouseWarpEnabled: false,
+            mouseWarpMonitorOrder: [],
+            mouseWarpMargin: 2,
+            gapSize: 8,
+            outerGapLeft: 0,
+            outerGapRight: 0,
+            outerGapTop: 0,
+            outerGapBottom: 0,
+            niriMaxWindowsPerColumn: 3,
+            niriMaxVisibleColumns: 2,
+            niriInfiniteLoop: false,
+            niriCenterFocusedColumn: CenterFocusedColumn.never.rawValue,
+            niriAlwaysCenterSingleColumn: true,
+            niriSingleWindowAspectRatio: SingleWindowAspectRatio.ratio4x3.rawValue,
+            niriColumnWidthPresets: [1.0 / 3.0, 0.5, 2.0 / 3.0],
+            persistentWorkspacesRaw: "",
+            workspaceAssignmentsRaw: "",
+            workspaceConfigurations: [],
+            defaultLayoutType: LayoutType.niri.rawValue,
+            bordersEnabled: false,
+            borderWidth: 4.0,
+            borderColorRed: 0.0,
+            borderColorGreen: 0.5,
+            borderColorBlue: 1.0,
+            borderColorAlpha: 1.0,
+            hotkeyBindings: DefaultHotkeyBindings.all(),
+            workspaceBarEnabled: false,
+            workspaceBarShowLabels: true,
+            workspaceBarWindowLevel: WorkspaceBarWindowLevel.popup.rawValue,
+            workspaceBarPosition: WorkspaceBarPosition.overlappingMenuBar.rawValue,
+            workspaceBarNotchAware: false,
+            workspaceBarDeduplicateAppIcons: false,
+            workspaceBarHideEmptyWorkspaces: false,
+            workspaceBarHeight: 24.0,
+            workspaceBarBackgroundOpacity: 0.1,
+            workspaceBarXOffset: 0.0,
+            workspaceBarYOffset: 0.0,
+            monitorBarSettings: [],
+            appRules: [],
+            monitorOrientationSettings: [],
+            monitorNiriSettings: [],
+            dwindleSmartSplit: false,
+            dwindleDefaultSplitRatio: 1.0,
+            dwindleSplitWidthMultiplier: 1.0,
+            dwindleSingleWindowAspectRatio: DwindleSingleWindowAspectRatio.ratio4x3.rawValue,
+            dwindleUseGlobalGaps: true,
+            dwindleMoveToRootStable: true,
+            monitorDwindleSettings: [],
+            preventSleepEnabled: false,
+            scrollGestureEnabled: true,
+            scrollSensitivity: 1.0,
+            scrollModifierKey: ScrollModifierKey.optionShift.rawValue,
+            gestureFingerCount: GestureFingerCount.three.rawValue,
+            gestureInvertDirection: true,
+            menuAnywhereNativeEnabled: true,
+            menuAnywherePaletteEnabled: true,
+            menuAnywherePosition: MenuAnywherePosition.cursor.rawValue,
+            menuAnywhereShowShortcuts: true,
+            hiddenBarEnabled: false,
+            hiddenBarIsCollapsed: false,
+            quakeTerminalOpacity: 1.0,
+            quakeTerminalMonitorMode: QuakeTerminalMonitorMode.mouseCursor.rawValue,
+            appearanceMode: AppearanceMode.automatic.rawValue
+        )
+    }
+}
+
+private func jsonValuesEqual(_ lhs: Any, _ rhs: Any) -> Bool {
+    guard let lData = try? JSONSerialization.data(withJSONObject: ["_": lhs], options: .sortedKeys),
+          let rData = try? JSONSerialization.data(withJSONObject: ["_": rhs], options: .sortedKeys)
+    else { return false }
+    return lData == rData
+}
+
+// MARK: - Export & Import
+
 extension SettingsStore {
     static var exportURL: URL {
         FileManager.default.homeDirectoryForCurrentUser
@@ -93,7 +179,7 @@ extension SettingsStore {
         FileManager.default.fileExists(atPath: Self.exportURL.path)
     }
 
-    func exportSettings() throws {
+    func exportSettings(incrementalOnly: Bool = true) throws {
         let export = SettingsExport(
             hotkeysEnabled: hotkeysEnabled,
             focusFollowsMouse: focusFollowsMouse,
@@ -167,16 +253,94 @@ extension SettingsStore {
         encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
         let data = try encoder.encode(export)
 
+        let outputData: Data
+        if incrementalOnly {
+            let defaultsData = try encoder.encode(SettingsExport.defaults())
+            guard let currentDict = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+                  let defaultsDict = try JSONSerialization.jsonObject(with: defaultsData) as? [String: Any]
+            else {
+                outputData = data
+                let directory = Self.exportURL.deletingLastPathComponent()
+                try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+                try outputData.write(to: Self.exportURL)
+                return
+            }
+            var filtered: [String: Any] = ["version": export.version]
+            for (key, value) in currentDict where key != "version" && key != "hotkeyBindings" {
+                if let defaultValue = defaultsDict[key], jsonValuesEqual(value, defaultValue) {
+                    continue
+                }
+                filtered[key] = value
+            }
+
+            // Element-wise diff for hotkeyBindings by id
+            if let currentBindings = currentDict["hotkeyBindings"] as? [[String: Any]],
+               let defaultBindings = defaultsDict["hotkeyBindings"] as? [[String: Any]] {
+                let defaultsByID = Dictionary(
+                    defaultBindings.compactMap { b in (b["id"] as? String).map { ($0, b) } },
+                    uniquingKeysWith: { _, last in last }
+                )
+                let changedBindings = currentBindings.filter { binding in
+                    guard let id = binding["id"] as? String,
+                          let defaultBinding = defaultsByID[id] else { return true }
+                    return !jsonValuesEqual(binding, defaultBinding)
+                }
+                if !changedBindings.isEmpty {
+                    filtered["hotkeyBindings"] = changedBindings
+                }
+            }
+            outputData = try JSONSerialization.data(
+                withJSONObject: filtered,
+                options: [.prettyPrinted, .sortedKeys]
+            )
+        } else {
+            outputData = data
+        }
+
         let directory = Self.exportURL.deletingLastPathComponent()
         try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
-        try data.write(to: Self.exportURL)
+        try outputData.write(to: Self.exportURL)
     }
 
     func importSettings() throws {
-        let data = try Data(contentsOf: Self.exportURL)
-        let export = try JSONDecoder().decode(SettingsExport.self, from: data)
+        let rawData = try Data(contentsOf: Self.exportURL)
 
-        hotkeysEnabled = export.hotkeysEnabled
+        let encoder = JSONEncoder()
+        let defaultsData = try encoder.encode(SettingsExport.defaults())
+
+        guard var defaultsDict = try JSONSerialization.jsonObject(with: defaultsData) as? [String: Any],
+              let importedDict = try JSONSerialization.jsonObject(with: rawData) as? [String: Any]
+        else {
+            let export = try JSONDecoder().decode(SettingsExport.self, from: rawData)
+            applyImport(export)
+            return
+        }
+
+        for (key, value) in importedDict where key != "hotkeyBindings" {
+            defaultsDict[key] = value
+        }
+
+        // Element-wise merge for hotkeyBindings by id
+        if let importedBindings = importedDict["hotkeyBindings"] as? [[String: Any]],
+           let defaultBindings = defaultsDict["hotkeyBindings"] as? [[String: Any]] {
+            let importedByID = Dictionary(
+                importedBindings.compactMap { b in (b["id"] as? String).map { ($0, b) } },
+                uniquingKeysWith: { _, last in last }
+            )
+            let merged = defaultBindings.map { defaultBinding -> [String: Any] in
+                guard let id = defaultBinding["id"] as? String,
+                      let imported = importedByID[id] else { return defaultBinding }
+                return imported
+            }
+            defaultsDict["hotkeyBindings"] = merged
+        }
+
+        let mergedData = try JSONSerialization.data(withJSONObject: defaultsDict)
+        let export = try JSONDecoder().decode(SettingsExport.self, from: mergedData)
+        applyImport(export)
+    }
+
+    private func applyImport(_ export: SettingsExport) {        hotkeysEnabled = export.hotkeysEnabled
         focusFollowsMouse = export.focusFollowsMouse
         moveMouseToFocusedWindow = export.moveMouseToFocusedWindow
         mouseWarpEnabled = export.mouseWarpEnabled

--- a/Sources/OmniWM/Core/Input/HotkeyBinding.swift
+++ b/Sources/OmniWM/Core/Input/HotkeyBinding.swift
@@ -1,7 +1,7 @@
 import Carbon
 import Foundation
 
-struct KeyBinding: Codable, Equatable, Hashable {
+struct KeyBinding: Equatable, Hashable {
     let keyCode: UInt32
     let modifiers: UInt32
 
@@ -28,6 +28,35 @@ struct KeyBinding: Codable, Equatable, Hashable {
     func conflicts(with other: KeyBinding) -> Bool {
         guard !isUnassigned, !other.isUnassigned else { return false }
         return keyCode == other.keyCode && modifiers == other.modifiers
+    }
+}
+
+extension KeyBinding: Codable {
+    private enum CodingKeys: String, CodingKey {
+        case keyCode, modifiers
+    }
+
+    init(from decoder: Decoder) throws {
+        if let container = try? decoder.singleValueContainer(),
+           let string = try? container.decode(String.self),
+           let binding = KeySymbolMapper.fromHumanReadable(string) {
+            self = binding
+            return
+        }
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        keyCode = try container.decode(UInt32.self, forKey: .keyCode)
+        modifiers = try container.decode(UInt32.self, forKey: .modifiers)
+    }
+
+    func encode(to encoder: Encoder) throws {
+        if isUnassigned || KeySymbolMapper.keyName(keyCode) != "?" {
+            var container = encoder.singleValueContainer()
+            try container.encode(humanReadableString)
+        } else {
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            try container.encode(keyCode, forKey: .keyCode)
+            try container.encode(modifiers, forKey: .modifiers)
+        }
     }
 }
 

--- a/Sources/OmniWM/Core/Input/KeySymbolMapper.swift
+++ b/Sources/OmniWM/Core/Input/KeySymbolMapper.swift
@@ -187,4 +187,32 @@ enum KeySymbolMapper {
         let key = keyName(keyCode)
         return mods.isEmpty ? key : mods + "+" + key
     }
+
+    static let nameToKeyCode: [String: UInt32] = {
+        var map: [String: UInt32] = [:]
+        for code: UInt32 in 0...127 {
+            let name = keyName(code)
+            if name != "?" { map[name] = code }
+        }
+        return map
+    }()
+
+    static let nameToModifier: [String: UInt32] = [
+        "Control": UInt32(controlKey),
+        "Option": UInt32(optionKey),
+        "Shift": UInt32(shiftKey),
+        "Command": UInt32(cmdKey),
+    ]
+
+    static func fromHumanReadable(_ string: String) -> KeyBinding? {
+        if string == "Unassigned" { return .unassigned }
+        let parts = string.components(separatedBy: "+")
+        guard let keyPart = parts.last, let keyCode = nameToKeyCode[keyPart] else { return nil }
+        var modifiers: UInt32 = 0
+        for part in parts.dropLast() {
+            guard let flag = nameToModifier[part] else { return nil }
+            modifiers |= flag
+        }
+        return KeyBinding(keyCode: keyCode, modifiers: modifiers)
+    }
 }


### PR DESCRIPTION
Hi! I really enjoy using OmniWM. It contains all the features I desired for a window manager, and more than I expected. I‘ve made some changes to the export/import function of settings:

---

## Summary

  1.  Settings export now only writes non-default values (incremental diff) so the exported json file is much shorter and editable.
      - Import merges partial JSON back onto full defaults, so users can share minimal config snippets
  2.  `KeyBinding` now encodes as a human-readable string (e.g. `"Control+Option+K"` instead of `{"keyCode":40,"modifiers":6144}`), making exported json human-readable and hand-editable.
      - Decoding is backward-compatible: the old `{keyCode, modifiers}` format still works

  ## Known limitations
  - `SettingsExport.defaults()` is hardcoded separately from `@AppStorage` default values;
     These two sources could drift if one is updated independently. A future refactor could unify them into a single source, but I haven't worked out a good way to do that yet.
  - Import only merges bindings whose `id` exists in current defaults — bindings with
    unknown IDs (e.g. from a newer app version) are silently dropped. This is acceptable for now
    since the binding set is fixed, but worth noting if custom bindings are ever supported.