### PR TITLE
fix: skip above-normal-level windows from tiling (e.g. PiP)

### DIFF
--- a/Sources/OmniWM/Core/Controller/AXEventHandler.swift
+++ b/Sources/OmniWM/Core/Controller/AXEventHandler.swift
@@ -76,6 +76,12 @@ final class AXEventHandler: CGSEventDelegate {
         }
 
         let pid = windowInfo.pid
+
+        // Skip windows above the normal level (e.g. Picture-in-Picture overlays)
+        if windowInfo.level > 0 {
+            return
+        }
+
         CGSEventObserver.shared.subscribeToWindows([windowId])
 
         if let axRef = AXWindowService.axWindowRef(for: windowId, pid: pid) {

--- a/Sources/OmniWM/Core/Controller/LayoutRefreshController.swift
+++ b/Sources/OmniWM/Core/Controller/LayoutRefreshController.swift
@@ -502,6 +502,11 @@ import QuartzCore
         let focusedWorkspaceId = controller.activeWorkspace()?.id
 
         for (ax, pid, winId) in windows {
+            // Skip windows above the normal level (e.g. Picture-in-Picture overlays)
+            if let info = SkyLight.shared.queryWindowInfo(UInt32(winId)), info.level > 0 {
+                continue
+            }
+
             if let bundleId = controller.appInfoCache.bundleId(for: pid) {
                 if bundleId == LockScreenObserver.lockScreenAppBundleId {
                     continue


### PR DESCRIPTION
## Summary

Picture-in-Picture windows (e.g. from Zen Browser) were being tiled instead of staying floating. This happened because PiP windows report as standard windows with all buttons present, so the existing subrole/button heuristics didn't catch them.

The fix checks the window server level — normal windows are level 0, while PiP and other overlay windows sit above that. Windows with level > 0 are now skipped from tiling in both:

- **`AXEventHandler`** — when a new window is created
- **`LayoutRefreshController`** — during full window discovery on startup/refresh

This covers PiP from any app (Zen, Firefox, Chrome, etc.) as well as other above-normal overlay windows.