### PR TITLE
Fix overview scroll direction

### DIFF
--- a/Sources/OmniWM/Core/Overview/OverviewController.swift
+++ b/Sources/OmniWM/Core/Overview/OverviewController.swift
@@ -464,7 +464,7 @@ final class OverviewController {
         activeInteractionMonitorId = monitorId
         mutateLayout(for: monitorId) { layout in
             let screenFrame = viewportFrame(for: monitorId)
-            let nextOffset = layout.scrollOffset - delta
+            let nextOffset = layout.scrollOffset + delta
             layout.scrollOffset = OverviewLayoutCalculator.clampedScrollOffset(
                 nextOffset,
                 layout: layout,


### PR DESCRIPTION
## Summary
- Fix inverted scroll direction in overview: `adjustScrollOffset` used subtraction (`offset - delta`) which caused scrolling down on the wheel to scroll up in the overview
- Changed to addition (`offset + delta`) so scroll direction matches user expectation

## Test plan
- [ ] Open overview with enough windows to require scrolling
- [ ] Scroll down on scroll wheel — overview should scroll down
- [ ] Scroll up — overview should scroll up
- [ ] Test with trackpad (natural scrolling) — direction should be correct