### PR TITLE
Use dynamic thumbnail resolution based on screen DPI

### DIFF
--- a/Sources/OmniWM/Core/Overview/OverviewController.swift
+++ b/Sources/OmniWM/Core/Overview/OverviewController.swift
@@ -341,7 +341,8 @@ final class OverviewController {
         let filter = SCContentFilter(desktopIndependentWindow: scWindow)
         let config = SCStreamConfiguration()
 
-        let maxDimension: CGFloat = 400
+        let scaleFactor = screenScaleFactor(for: scWindow.frame)
+        let maxDimension = max(scWindow.frame.width, scWindow.frame.height) * scaleFactor
         let aspectRatio = scWindow.frame.width / max(1, scWindow.frame.height)
         if aspectRatio > 1 {
             config.width = Int(maxDimension)
@@ -364,6 +365,13 @@ final class OverviewController {
         } catch {
             return nil
         }
+    }
+
+    private func screenScaleFactor(for windowFrame: CGRect) -> CGFloat {
+        let screen = NSScreen.screens.first(where: { $0.frame.intersects(windowFrame) })
+            ?? NSScreen.main
+            ?? NSScreen.screens.first
+        return screen?.backingScaleFactor ?? 2.0
     }
 
     func updateAnimationProgress(_ progress: Double, state: OverviewState) {


### PR DESCRIPTION
## Summary
- Replace hardcoded 400px max thumbnail dimension with `max(windowWidth, windowHeight) * backingScaleFactor`
- Captures at native resolution on Retina (2x) displays, avoids wasting memory on non-Retina (1x)
- Each window uses the scale factor of the screen it's on (via frame intersection lookup)

## Test plan
- [ ] Open overview on a Retina display — thumbnails should be sharp/crisp
- [ ] Open overview on a non-Retina display — thumbnails should look normal, not oversized
- [ ] Test with windows spanning multiple monitors with different DPIs