### PR TITLE
Fix status bar menu keyboard accessibility

### DIFF
--- a/Sources/OmniWM/UI/StatusBar/StatusBarController.swift
+++ b/Sources/OmniWM/UI/StatusBar/StatusBarController.swift
@@ -5,9 +5,11 @@ final class StatusBarController: NSObject {
     nonisolated static let mainAutosaveName = "omniwm_main"
 
     private var statusItem: NSStatusItem?
-    private var menuBuilder: StatusBarMenuBuilder?
-    private var menu: NSMenu?
+    private var menuViewModel: StatusBarMenuViewModel?
+    private var panelController: StatusBarPanelController?
     private var isRebuildingOwnedItems = false
+    private var eventMonitor: Any?
+    private var restoreApplication: NSRunningApplication?
 
     private let defaults: UserDefaults
     private let hiddenBarController: HiddenBarController
@@ -55,8 +57,17 @@ final class StatusBarController: NSObject {
 
         statusItem?.autosaveName = Self.mainAutosaveName
 
-        menuBuilder = StatusBarMenuBuilder(settings: settings, controller: controller)
-        rebuildMenu()
+        let menuViewModel = StatusBarMenuViewModel(settings: settings, controller: controller)
+        let panelController = StatusBarPanelController()
+        panelController.onDismiss = { [weak self] restoreFocus in
+            self?.dismissMenu(restoreFocus: restoreFocus)
+        }
+        menuViewModel.setDismissHandler { [weak self] restoreFocus in
+            self?.dismissMenu(restoreFocus: restoreFocus)
+        }
+
+        self.menuViewModel = menuViewModel
+        self.panelController = panelController
 
         hiddenBarController.bind(
             omniButton: button,
@@ -78,21 +89,33 @@ final class StatusBarController: NSObject {
     }
 
     private func showMenu() {
-        rebuildMenu()
-        guard let button = statusItem?.button, let menu else { return }
-        menu.popUp(positioning: nil, at: NSPoint(x: 0, y: button.bounds.height + 5), in: button)
+        guard let button = statusItem?.button,
+              let menuViewModel,
+              let panelController
+        else {
+            return
+        }
+
+        if panelController.panel?.isVisible == true {
+            dismissMenu(restoreFocus: true)
+            return
+        }
+
+        restoreApplication = NSWorkspace.shared.frontmostApplication
+        installEventMonitor()
+        panelController.show(using: menuViewModel, anchoredTo: button)
+        NSApp.activate(ignoringOtherApps: true)
     }
 
     private func handleRightClick() {
+        dismissMenu(restoreFocus: false)
         controller?.toggleHiddenBar()
     }
 
     func refreshMenu() {
-        menuBuilder?.updateToggles()
-    }
-
-    func rebuildMenu() {
-        menu = menuBuilder?.buildMenu()
+        if panelController?.panel?.isVisible == true {
+            menuViewModel?.resetFocus()
+        }
     }
 
     func cleanup() {
@@ -100,13 +123,16 @@ final class StatusBarController: NSObject {
     }
 
     private func cleanupOwnedStatusItems() {
+        removeEventMonitor()
+        panelController?.hideWithoutCallbacks()
         hiddenBarController.cleanup()
         if let item = statusItem {
             NSStatusBar.system.removeStatusItem(item)
             statusItem = nil
         }
-        menuBuilder = nil
-        menu = nil
+        menuViewModel = nil
+        panelController = nil
+        restoreApplication = nil
     }
 
     private func rebuildOwnedStatusItemsAfterUnsafeOrdering() {
@@ -118,5 +144,50 @@ final class StatusBarController: NSObject {
         Self.clearOwnedPreferredPositions(defaults: defaults)
         cleanupOwnedStatusItems()
         installOwnedStatusItems()
+    }
+
+    private func installEventMonitor() {
+        removeEventMonitor()
+        eventMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [weak self] event in
+            guard let self,
+                  self.panelController?.panel?.isVisible == true,
+                  let menuViewModel
+            else {
+                return event
+            }
+
+            return menuViewModel.handleKeyDown(event) ? nil : event
+        }
+    }
+
+    private func removeEventMonitor() {
+        if let eventMonitor {
+            NSEvent.removeMonitor(eventMonitor)
+            self.eventMonitor = nil
+        }
+    }
+
+    private func dismissMenu(restoreFocus: Bool) {
+        removeEventMonitor()
+        panelController?.hideWithoutCallbacks()
+        menuViewModel?.resetFocus()
+
+        if restoreFocus {
+            restorePreviousApplicationFocusIfNeeded()
+        } else {
+            restoreApplication = nil
+        }
+    }
+
+    private func restorePreviousApplicationFocusIfNeeded() {
+        defer { restoreApplication = nil }
+        guard let restoreApplication,
+              !restoreApplication.isTerminated,
+              restoreApplication.bundleIdentifier != Bundle.main.bundleIdentifier
+        else {
+            return
+        }
+
+        restoreApplication.activate(options: [])
     }
 }

--- a/Sources/OmniWM/UI/StatusBar/StatusBarMenu.swift
+++ b/Sources/OmniWM/UI/StatusBar/StatusBarMenu.swift
@@ -86,6 +86,11 @@ final class StatusBarMenuViewModel {
     @discardableResult
     func handleKeyDown(_ event: NSEvent) -> Bool {
         let modifiers = event.modifierFlags.intersection([.shift, .command, .control, .option])
+        let allowsNavigationShortcut = modifiers.isEmpty || modifiers == [.shift]
+
+        guard allowsNavigationShortcut else {
+            return false
+        }
 
         switch event.keyCode {
         case 48:

--- a/Sources/OmniWM/UI/StatusBar/StatusBarMenu.swift
+++ b/Sources/OmniWM/UI/StatusBar/StatusBarMenu.swift
@@ -1,707 +1,599 @@
 import AppKit
+import Observation
+import SwiftUI
 
-private let menuWidth: CGFloat = 280
+let statusBarMenuWidth: CGFloat = 280
 
-@MainActor
-private func applyCurrentAppAppearance(to view: NSView) {
-    view.appearance = NSApplication.shared.appearance
+private let menuCornerRadius: CGFloat = 14
+private let rowCornerRadius: CGFloat = 6
+
+enum StatusBarMenuItemID: String, CaseIterable {
+    case focusFollowsMouse
+    case followWindowToWorkspace
+    case mouseToFocused
+    case windowBorders
+    case workspaceBar
+    case keepAwake
+    case appRules
+    case settings
+    case github
+    case sponsorGithub
+    case sponsorPaypal
+    case sponsors
+    case quit
+
+    static let interactiveItems: [StatusBarMenuItemID] = [
+        .focusFollowsMouse,
+        .followWindowToWorkspace,
+        .mouseToFocused,
+        .windowBorders,
+        .workspaceBar,
+        .keepAwake,
+        .appRules,
+        .settings,
+        .github,
+        .sponsorGithub,
+        .sponsorPaypal,
+        .sponsors,
+        .quit,
+    ]
 }
 
-@MainActor
-final class StatusBarMenuBuilder {
-    private let settings: SettingsStore
-    private weak var controller: WMController?
+@MainActor @Observable
+final class StatusBarMenuViewModel {
+    let settings: SettingsStore
 
-    private var toggleViews: [String: MenuToggleRowView] = [:]
+    private weak var controller: WMController?
+    private var dismissMenu: ((Bool) -> Void)?
+
+    var focusedItemID: StatusBarMenuItemID?
 
     init(settings: SettingsStore, controller: WMController) {
         self.settings = settings
         self.controller = controller
+        focusedItemID = StatusBarMenuItemID.interactiveItems.first
     }
 
-    func buildMenu() -> NSMenu {
-        toggleViews.removeAll(keepingCapacity: true)
-
-        let menu = NSMenu()
-        menu.autoenablesItems = false
-        menu.appearance = NSApplication.shared.appearance
-
-        let headerItem = NSMenuItem()
-        headerItem.view = createHeaderView()
-        menu.addItem(headerItem)
-
-        menu.addItem(createDivider())
-
-        menu.addItem(createSectionLabel("CONTROLS"))
-        addControlsSection(to: menu)
-
-        menu.addItem(createDivider())
-
-        menu.addItem(createSectionLabel("SETTINGS"))
-        addSettingsSection(to: menu)
-
-        menu.addItem(createDivider())
-
-        menu.addItem(createSectionLabel("LINKS"))
-        addLinksSection(to: menu)
-
-        menu.addItem(createDivider())
-
-        addSponsorsSection(to: menu)
-
-        menu.addItem(createDivider())
-
-        addQuitSection(to: menu)
-
-        return menu
+    func setDismissHandler(_ dismiss: @escaping (Bool) -> Void) {
+        dismissMenu = dismiss
     }
 
-    func updateToggles() {
-        toggleViews["focusFollowsMouse"]?.isOn = settings.focusFollowsMouse
-        toggleViews["focusFollowsWindowToMonitor"]?.isOn = settings.focusFollowsWindowToMonitor
-        toggleViews["moveMouseToFocusedWindow"]?.isOn = settings.moveMouseToFocusedWindow
-        toggleViews["bordersEnabled"]?.isOn = settings.bordersEnabled
-        toggleViews["workspaceBarEnabled"]?.isOn = settings.workspaceBarEnabled
-        toggleViews["preventSleepEnabled"]?.isOn = settings.preventSleepEnabled
+    func resetFocus() {
+        focusedItemID = StatusBarMenuItemID.interactiveItems.first
     }
 
-    private func createHeaderView() -> NSView {
-        MenuHeaderView()
+    func focus(_ itemID: StatusBarMenuItemID) {
+        focusedItemID = itemID
     }
 
-    private func createDivider() -> NSMenuItem {
-        let item = NSMenuItem()
-        item.view = MenuDividerView()
-        return item
+    func moveFocus(by delta: Int) {
+        let items = StatusBarMenuItemID.interactiveItems
+        guard !items.isEmpty else { return }
+
+        let currentIndex = focusedItemID.flatMap { items.firstIndex(of: $0) } ?? 0
+        let nextIndex = (currentIndex + delta + items.count) % items.count
+        focusedItemID = items[nextIndex]
     }
 
-    private func createSectionLabel(_ text: String) -> NSMenuItem {
-        let item = NSMenuItem()
-        item.view = MenuSectionLabelView(text: text)
-        return item
+    func focusFirstItem() {
+        focusedItemID = StatusBarMenuItemID.interactiveItems.first
     }
 
-    private func addControlsSection(to menu: NSMenu) {
-        let focusToggle = MenuToggleRowView(
-            icon: "cursorarrow.motionlines",
-            label: "Focus Follows Mouse",
-            isOn: settings.focusFollowsMouse
-        ) { [weak self] newValue in
-            self?.settings.focusFollowsMouse = newValue
-            self?.controller?.setFocusFollowsMouse(newValue)
-        }
-        toggleViews["focusFollowsMouse"] = focusToggle
-        let focusItem = NSMenuItem()
-        focusItem.view = focusToggle
-        menu.addItem(focusItem)
-
-        let followMoveToggle = MenuToggleRowView(
-            icon: "arrow.right.square",
-            label: "Follow Window to Workspace",
-            isOn: settings.focusFollowsWindowToMonitor
-        ) { [weak self] newValue in
-            self?.settings.focusFollowsWindowToMonitor = newValue
-        }
-        toggleViews["focusFollowsWindowToMonitor"] = followMoveToggle
-        let followMoveItem = NSMenuItem()
-        followMoveItem.view = followMoveToggle
-        menu.addItem(followMoveItem)
-
-        let mouseToFocusedToggle = MenuToggleRowView(
-            icon: "arrow.up.left.and.down.right.magnifyingglass",
-            label: "Mouse to Focused",
-            isOn: settings.moveMouseToFocusedWindow
-        ) { [weak self] newValue in
-            self?.settings.moveMouseToFocusedWindow = newValue
-            self?.controller?.setMoveMouseToFocusedWindow(newValue)
-        }
-        toggleViews["moveMouseToFocusedWindow"] = mouseToFocusedToggle
-        let mouseItem = NSMenuItem()
-        mouseItem.view = mouseToFocusedToggle
-        menu.addItem(mouseItem)
-
-        let bordersToggle = MenuToggleRowView(
-            icon: "square.dashed",
-            label: "Window Borders",
-            isOn: settings.bordersEnabled
-        ) { [weak self] newValue in
-            self?.settings.bordersEnabled = newValue
-            self?.controller?.setBordersEnabled(newValue)
-        }
-        toggleViews["bordersEnabled"] = bordersToggle
-        let bordersItem = NSMenuItem()
-        bordersItem.view = bordersToggle
-        menu.addItem(bordersItem)
-
-        let workspaceBarToggle = MenuToggleRowView(
-            icon: "menubar.rectangle",
-            label: "Workspace Bar",
-            isOn: settings.workspaceBarEnabled
-        ) { [weak self] newValue in
-            self?.settings.workspaceBarEnabled = newValue
-            self?.controller?.setWorkspaceBarEnabled(newValue)
-        }
-        toggleViews["workspaceBarEnabled"] = workspaceBarToggle
-        let workspaceItem = NSMenuItem()
-        workspaceItem.view = workspaceBarToggle
-        menu.addItem(workspaceItem)
-
-        let keepAwakeToggle = MenuToggleRowView(
-            icon: "moon.zzz",
-            label: "Keep Awake",
-            isOn: settings.preventSleepEnabled
-        ) { [weak self] newValue in
-            self?.settings.preventSleepEnabled = newValue
-            self?.controller?.setPreventSleepEnabled(newValue)
-        }
-        toggleViews["preventSleepEnabled"] = keepAwakeToggle
-        let keepAwakeItem = NSMenuItem()
-        keepAwakeItem.view = keepAwakeToggle
-        menu.addItem(keepAwakeItem)
+    func focusLastItem() {
+        focusedItemID = StatusBarMenuItemID.interactiveItems.last
     }
 
-    private func addSettingsSection(to menu: NSMenu) {
-        let appRulesRow = MenuActionRowView(
-            icon: "slider.horizontal.3",
-            label: "App Rules",
-            showChevron: true
-        ) { [weak self] in
-            guard let self, let controller = self.controller else { return }
-            AppRulesWindowController.shared.show(settings: self.settings, controller: controller)
-        }
-        let appRulesItem = NSMenuItem()
-        appRulesItem.view = appRulesRow
-        menu.addItem(appRulesItem)
+    @discardableResult
+    func handleKeyDown(_ event: NSEvent) -> Bool {
+        let modifiers = event.modifierFlags.intersection([.shift, .command, .control, .option])
 
-        let settingsRow = MenuActionRowView(
-            icon: "gearshape",
-            label: "Settings",
-            showChevron: true
-        ) { [weak self] in
-            guard let self, let controller = self.controller else { return }
-            SettingsWindowController.shared.show(settings: self.settings, controller: controller)
+        switch event.keyCode {
+        case 48:
+            moveFocus(by: modifiers.contains(.shift) ? -1 : 1)
+            return true
+        case 125:
+            moveFocus(by: 1)
+            return true
+        case 126:
+            moveFocus(by: -1)
+            return true
+        case 115:
+            focusFirstItem()
+            return true
+        case 119:
+            focusLastItem()
+            return true
+        case 49, 36, 76:
+            activateFocusedItem()
+            return true
+        case 53:
+            dismissMenu?(true)
+            return true
+        default:
+            return false
         }
-        let settingsItem = NSMenuItem()
-        settingsItem.view = settingsRow
-        menu.addItem(settingsItem)
     }
 
-    private func addLinksSection(to menu: NSMenu) {
-        let githubRow = MenuActionRowView(
-            icon: "link",
-            label: "GitHub",
-            isExternal: true
-        ) {
-            if let url = URL(string: "https://github.com/BarutSRB/OmniWM") {
+    func activateFocusedItem() {
+        guard let focusedItemID else { return }
+        activate(itemID: focusedItemID)
+    }
+
+    func activate(itemID: StatusBarMenuItemID) {
+        focus(itemID)
+
+        switch itemID {
+        case .focusFollowsMouse:
+            settings.focusFollowsMouse.toggle()
+            controller?.setFocusFollowsMouse(settings.focusFollowsMouse)
+        case .followWindowToWorkspace:
+            settings.focusFollowsWindowToMonitor.toggle()
+        case .mouseToFocused:
+            settings.moveMouseToFocusedWindow.toggle()
+            controller?.setMoveMouseToFocusedWindow(settings.moveMouseToFocusedWindow)
+        case .windowBorders:
+            settings.bordersEnabled.toggle()
+            controller?.setBordersEnabled(settings.bordersEnabled)
+        case .workspaceBar:
+            settings.workspaceBarEnabled.toggle()
+            controller?.setWorkspaceBarEnabled(settings.workspaceBarEnabled)
+        case .keepAwake:
+            settings.preventSleepEnabled.toggle()
+            controller?.setPreventSleepEnabled(settings.preventSleepEnabled)
+        case .appRules:
+            dismissAndPerform { [weak self] in
+                guard let self, let controller = self.controller else { return }
+                AppRulesWindowController.shared.show(settings: self.settings, controller: controller)
+            }
+        case .settings:
+            dismissAndPerform { [weak self] in
+                guard let self, let controller = self.controller else { return }
+                SettingsWindowController.shared.show(settings: self.settings, controller: controller)
+            }
+        case .github:
+            dismissAndPerform {
+                guard let url = URL(string: "https://github.com/BarutSRB/OmniWM") else { return }
                 NSWorkspace.shared.open(url)
             }
-        }
-        let githubItem = NSMenuItem()
-        githubItem.view = githubRow
-        menu.addItem(githubItem)
-
-        let sponsorGithubRow = MenuActionRowView(
-            icon: "heart",
-            label: "Sponsor on GitHub",
-            isExternal: true
-        ) {
-            if let url = URL(string: "https://github.com/sponsors/BarutSRB") {
+        case .sponsorGithub:
+            dismissAndPerform {
+                guard let url = URL(string: "https://github.com/sponsors/BarutSRB") else { return }
                 NSWorkspace.shared.open(url)
             }
-        }
-        let sponsorGithubItem = NSMenuItem()
-        sponsorGithubItem.view = sponsorGithubRow
-        menu.addItem(sponsorGithubItem)
-
-        let sponsorPaypalRow = MenuActionRowView(
-            icon: "heart",
-            label: "Sponsor on PayPal",
-            isExternal: true
-        ) {
-            if let url = URL(string: "https://paypal.me/beacon2024") {
+        case .sponsorPaypal:
+            dismissAndPerform {
+                guard let url = URL(string: "https://paypal.me/beacon2024") else { return }
                 NSWorkspace.shared.open(url)
             }
+        case .sponsors:
+            dismissAndPerform {
+                SponsorsWindowController.shared.show()
+            }
+        case .quit:
+            dismissAndPerform {
+                NSApplication.shared.terminate(nil)
+            }
         }
-        let sponsorPaypalItem = NSMenuItem()
-        sponsorPaypalItem.view = sponsorPaypalRow
-        menu.addItem(sponsorPaypalItem)
     }
 
-    private func addSponsorsSection(to menu: NSMenu) {
-        let sponsorsRow = MenuActionRowView(
-            icon: "sparkles",
-            label: "Omni Sponsors"
-        ) {
-            SponsorsWindowController.shared.show()
-        }
-        let sponsorsItem = NSMenuItem()
-        sponsorsItem.view = sponsorsRow
-        menu.addItem(sponsorsItem)
-    }
-
-    private func addQuitSection(to menu: NSMenu) {
-        let quitRow = MenuActionRowView(
-            icon: "power",
-            label: "Quit OmniWM",
-            isDestructive: true
-        ) {
-            NSApplication.shared.terminate(nil)
-        }
-        let quitItem = NSMenuItem()
-        quitItem.view = quitRow
-        menu.addItem(quitItem)
+    private func dismissAndPerform(_ action: @escaping () -> Void) {
+        dismissMenu?(false)
+        action()
     }
 }
 
-final class MenuHeaderView: NSView {
+struct StatusBarMenuView: View {
+    let viewModel: StatusBarMenuViewModel
+
+    private var settings: SettingsStore { viewModel.settings }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            StatusBarMenuHeaderView()
+            StatusBarMenuDividerView()
+            StatusBarMenuSectionLabelView(text: "CONTROLS")
+
+            StatusBarMenuToggleRow(
+                itemID: .focusFollowsMouse,
+                icon: "cursorarrow.motionlines",
+                label: "Focus Follows Mouse",
+                isOn: settings.focusFollowsMouse,
+                viewModel: viewModel
+            )
+            StatusBarMenuToggleRow(
+                itemID: .followWindowToWorkspace,
+                icon: "arrow.right.square",
+                label: "Follow Window to Workspace",
+                isOn: settings.focusFollowsWindowToMonitor,
+                viewModel: viewModel
+            )
+            StatusBarMenuToggleRow(
+                itemID: .mouseToFocused,
+                icon: "arrow.up.left.and.down.right.magnifyingglass",
+                label: "Mouse to Focused",
+                isOn: settings.moveMouseToFocusedWindow,
+                viewModel: viewModel
+            )
+            StatusBarMenuToggleRow(
+                itemID: .windowBorders,
+                icon: "square.dashed",
+                label: "Window Borders",
+                isOn: settings.bordersEnabled,
+                viewModel: viewModel
+            )
+            StatusBarMenuToggleRow(
+                itemID: .workspaceBar,
+                icon: "menubar.rectangle",
+                label: "Workspace Bar",
+                isOn: settings.workspaceBarEnabled,
+                viewModel: viewModel
+            )
+            StatusBarMenuToggleRow(
+                itemID: .keepAwake,
+                icon: "moon.zzz",
+                label: "Keep Awake",
+                isOn: settings.preventSleepEnabled,
+                viewModel: viewModel
+            )
+
+            StatusBarMenuDividerView()
+            StatusBarMenuSectionLabelView(text: "SETTINGS")
+
+            StatusBarMenuActionRow(
+                itemID: .appRules,
+                icon: "slider.horizontal.3",
+                label: "App Rules",
+                accessory: .chevron,
+                viewModel: viewModel
+            )
+            StatusBarMenuActionRow(
+                itemID: .settings,
+                icon: "gearshape",
+                label: "Settings",
+                accessory: .chevron,
+                viewModel: viewModel
+            )
+
+            StatusBarMenuDividerView()
+            StatusBarMenuSectionLabelView(text: "LINKS")
+
+            StatusBarMenuActionRow(
+                itemID: .github,
+                icon: "link",
+                label: "GitHub",
+                accessory: .external,
+                viewModel: viewModel
+            )
+            StatusBarMenuActionRow(
+                itemID: .sponsorGithub,
+                icon: "heart",
+                label: "Sponsor on GitHub",
+                accessory: .external,
+                viewModel: viewModel
+            )
+            StatusBarMenuActionRow(
+                itemID: .sponsorPaypal,
+                icon: "heart",
+                label: "Sponsor on PayPal",
+                accessory: .external,
+                viewModel: viewModel
+            )
+
+            StatusBarMenuDividerView()
+
+            StatusBarMenuActionRow(
+                itemID: .sponsors,
+                icon: "sparkles",
+                label: "Omni Sponsors",
+                accessory: .none,
+                viewModel: viewModel
+            )
+
+            StatusBarMenuDividerView()
+
+            StatusBarMenuActionRow(
+                itemID: .quit,
+                icon: "power",
+                label: "Quit OmniWM",
+                accessory: .none,
+                isDestructive: true,
+                viewModel: viewModel
+            )
+        }
+        .padding(8)
+        .frame(width: statusBarMenuWidth)
+        .background(
+            RoundedRectangle(cornerRadius: menuCornerRadius, style: .continuous)
+                .fill(Color(nsColor: .windowBackgroundColor))
+                .overlay(
+                    RoundedRectangle(cornerRadius: menuCornerRadius, style: .continuous)
+                        .stroke(Color(nsColor: .separatorColor).opacity(0.45), lineWidth: 1)
+                )
+        )
+    }
+}
+
+private struct StatusBarMenuHeaderView: View {
     private var appVersion: String {
         Bundle.main.appVersion ?? "0.3.1"
     }
 
-    override init(frame frameRect: NSRect) {
-        super.init(frame: NSRect(x: 0, y: 0, width: menuWidth, height: 56))
-        applyCurrentAppAppearance(to: self)
-        setupViews()
-    }
+    var body: some View {
+        HStack(spacing: 12) {
+            ZStack {
+                Circle()
+                    .fill(Color(nsColor: NSColor(calibratedRed: 0.3, green: 0.4, blue: 0.8, alpha: 0.2)))
+                    .frame(width: 36, height: 36)
 
-    @available(*, unavailable)
-    required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-    }
+                Image(systemName: "square.grid.2x2")
+                    .font(.system(size: 18, weight: .medium))
+                    .foregroundStyle(Color(nsColor: .labelColor))
+            }
 
-    private func setupViews() {
-        let iconContainer = NSView(frame: NSRect(x: 12, y: 10, width: 36, height: 36))
-        iconContainer.wantsLayer = true
-        iconContainer.layer?.cornerRadius = 18
-        iconContainer.layer?.backgroundColor = NSColor(calibratedRed: 0.3, green: 0.4, blue: 0.8, alpha: 0.2).cgColor
-        addSubview(iconContainer)
+            VStack(alignment: .leading, spacing: 4) {
+                HStack(spacing: 6) {
+                    Text("OmniWM")
+                        .font(.system(size: 15, weight: .semibold))
+                        .foregroundStyle(Color(nsColor: .labelColor))
 
-        let iconImageView = NSImageView(frame: NSRect(x: 9, y: 9, width: 18, height: 18))
-        if let iconImage = NSImage(systemSymbolName: "square.grid.2x2", accessibilityDescription: nil) {
-            let config = NSImage.SymbolConfiguration(pointSize: 18, weight: .medium)
-            iconImageView.image = iconImage.withSymbolConfiguration(config)
-            iconImageView.contentTintColor = .labelColor
+                    Circle()
+                        .fill(Color(nsColor: .systemGreen))
+                        .frame(width: 6, height: 6)
+                }
+
+                Text("v\(appVersion)")
+                    .font(.system(size: 11, weight: .regular, design: .monospaced))
+                    .foregroundStyle(Color(nsColor: .secondaryLabelColor))
+            }
+
+            Spacer(minLength: 0)
         }
-        iconContainer.addSubview(iconImageView)
-
-        let titleLabel = NSTextField(labelWithString: "OmniWM")
-        titleLabel.font = .systemFont(ofSize: 15, weight: .semibold)
-        titleLabel.textColor = .labelColor
-        titleLabel.frame = NSRect(x: 56, y: 28, width: 80, height: 18)
-        addSubview(titleLabel)
-
-        let statusDot = NSView(frame: NSRect(x: 140, y: 33, width: 6, height: 6))
-        statusDot.wantsLayer = true
-        statusDot.layer?.cornerRadius = 3
-        statusDot.layer?.backgroundColor = NSColor.systemGreen.cgColor
-        addSubview(statusDot)
-
-        let versionLabel = NSTextField(labelWithString: "v\(appVersion)")
-        versionLabel.font = .monospacedSystemFont(ofSize: 11, weight: .regular)
-        versionLabel.textColor = .secondaryLabelColor
-        versionLabel.frame = NSRect(x: 56, y: 10, width: 80, height: 14)
-        addSubview(versionLabel)
+        .padding(.horizontal, 12)
+        .padding(.vertical, 10)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("OmniWM version \(appVersion)")
     }
 }
 
-final class MenuSectionLabelView: NSView {
-    init(text: String) {
-        super.init(frame: NSRect(x: 0, y: 0, width: menuWidth, height: 24))
-        applyCurrentAppAppearance(to: self)
+private struct StatusBarMenuSectionLabelView: View {
+    let text: String
 
-        let label = NSTextField(labelWithString: text)
-        label.font = .systemFont(ofSize: 10, weight: .medium)
-        label.textColor = .tertiaryLabelColor
-        label.frame = NSRect(x: 14, y: 4, width: menuWidth - 28, height: 12)
-        addSubview(label)
-    }
-
-    @available(*, unavailable)
-    required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
+    var body: some View {
+        Text(text)
+            .font(.system(size: 10, weight: .medium))
+            .foregroundStyle(Color(nsColor: .tertiaryLabelColor))
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.horizontal, 14)
+            .padding(.top, 7)
+            .padding(.bottom, 5)
+            .accessibilityHidden(true)
     }
 }
 
-final class MenuDividerView: NSView {
-    override init(frame frameRect: NSRect) {
-        super.init(frame: NSRect(x: 0, y: 0, width: menuWidth, height: 9))
-        applyCurrentAppAppearance(to: self)
-
-        let divider = NSBox(frame: NSRect(x: 8, y: 4, width: menuWidth - 16, height: 1))
-        divider.boxType = .separator
-        addSubview(divider)
-    }
-
-    @available(*, unavailable)
-    required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
+private struct StatusBarMenuDividerView: View {
+    var body: some View {
+        Divider()
+            .padding(.horizontal, 8)
+            .padding(.vertical, 4)
+            .accessibilityHidden(true)
     }
 }
 
-final class MenuToggleSwitchView: NSView {
-    var isOn: Bool {
-        didSet {
-            guard oldValue != isOn else { return }
-            updateAppearance(animated: true)
-        }
-    }
-
-    var onToggle: ((Bool) -> Void)?
-
-    private let trackLayer = CALayer()
-    private let thumbLayer = CALayer()
-    private var trackingAreaRef: NSTrackingArea?
-    private var isHovered: Bool = false
-
-    override var isFlipped: Bool { true }
-
-    init(isOn: Bool) {
-        self.isOn = isOn
-        super.init(frame: NSRect(x: 0, y: 0, width: 42, height: 22))
-        applyCurrentAppAppearance(to: self)
-        wantsLayer = true
-        layer?.backgroundColor = NSColor.clear.cgColor
-
-        trackLayer.cornerCurve = .continuous
-        thumbLayer.cornerCurve = .continuous
-        thumbLayer.backgroundColor = NSColor.white.cgColor
-        thumbLayer.shadowColor = NSColor.black.withAlphaComponent(0.18).cgColor
-        thumbLayer.shadowOpacity = 1
-        thumbLayer.shadowRadius = 1.8
-        thumbLayer.shadowOffset = CGSize(width: 0, height: 0.6)
-
-        layer?.addSublayer(trackLayer)
-        layer?.addSublayer(thumbLayer)
-        updateAppearance(animated: false)
-        updateTrackingAreas()
-    }
-
-    @available(*, unavailable)
-    required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-    }
-
-    override func layout() {
-        super.layout()
-        updateAppearance(animated: false)
-    }
-
-    override func updateTrackingAreas() {
-        if let existing = trackingAreaRef {
-            removeTrackingArea(existing)
-        }
-        let area = NSTrackingArea(
-            rect: bounds,
-            options: [.activeAlways, .inVisibleRect, .mouseEnteredAndExited, .mouseMoved],
-            owner: self,
-            userInfo: nil
-        )
-        addTrackingArea(area)
-        trackingAreaRef = area
-    }
-
-    override func mouseEntered(with event: NSEvent) {
-        isHovered = true
-        updateAppearance(animated: true)
-    }
-
-    override func mouseMoved(with event: NSEvent) {
-        let point = convert(event.locationInWindow, from: nil)
-        let hoveredNow = bounds.contains(point)
-        guard hoveredNow != isHovered else { return }
-        isHovered = hoveredNow
-        updateAppearance(animated: true)
-    }
-
-    override func mouseExited(with event: NSEvent) {
-        isHovered = false
-        updateAppearance(animated: true)
-    }
-
-    override func mouseDown(with event: NSEvent) {
-        isOn.toggle()
-        onToggle?(isOn)
-    }
-
-    private func updateAppearance(animated: Bool) {
-        let inset: CGFloat = 2
-        let thumbSize = max(0, bounds.height - inset * 2)
-        let thumbX = isOn
-            ? bounds.width - inset - thumbSize
-            : inset
-
-        let onColor = NSColor.systemGreen.withAlphaComponent(isHovered ? 1.0 : 0.95).cgColor
-        let offColor = NSColor(white: isHovered ? 0.32 : 0.26, alpha: 1.0).cgColor
-        let targetTrack = isOn ? onColor : offColor
-
-        CATransaction.begin()
-        CATransaction.setDisableActions(!animated)
-        CATransaction.setAnimationDuration(animated ? 0.14 : 0)
-        CATransaction.setAnimationTimingFunction(CAMediaTimingFunction(name: .easeOut))
-        trackLayer.frame = bounds
-        trackLayer.cornerRadius = bounds.height / 2
-        trackLayer.backgroundColor = targetTrack
-
-        thumbLayer.frame = NSRect(x: thumbX, y: inset, width: thumbSize, height: thumbSize)
-        thumbLayer.cornerRadius = thumbSize / 2
-        CATransaction.commit()
-    }
+private enum StatusBarMenuAccessory {
+    case none
+    case chevron
+    case external
 }
 
-final class MenuToggleRowView: NSView {
-    var isOn: Bool {
-        get { toggle.isOn }
-        set {
-            toggle.isOn = newValue
-        }
-    }
-
-    private let toggle: MenuToggleSwitchView
-    private let onChange: (Bool) -> Void
-    private var trackingArea: NSTrackingArea?
-    private var backgroundLayer: CALayer?
-    private var iconView: NSImageView?
-    private var labelField: NSTextField?
-
-    init(icon: String, label: String, isOn: Bool, onChange: @escaping (Bool) -> Void) {
-        self.onChange = onChange
-        self.toggle = MenuToggleSwitchView(isOn: isOn)
-        super.init(frame: NSRect(x: 0, y: 0, width: menuWidth, height: 28))
-        applyCurrentAppAppearance(to: self)
-
-        wantsLayer = true
-
-        backgroundLayer = CALayer()
-        backgroundLayer?.cornerRadius = 6
-        backgroundLayer?.cornerCurve = .continuous
-        backgroundLayer?.backgroundColor = .clear
-        layer?.addSublayer(backgroundLayer!)
-
-        if let iconImage = NSImage(systemSymbolName: icon, accessibilityDescription: nil) {
-            let iconView = NSImageView(frame: NSRect(x: 12, y: 6, width: 16, height: 16))
-            let config = NSImage.SymbolConfiguration(pointSize: 12, weight: .regular)
-            iconView.image = iconImage.withSymbolConfiguration(config)
-            iconView.contentTintColor = .secondaryLabelColor
-            addSubview(iconView)
-            self.iconView = iconView
-        }
-
-        let labelField = NSTextField(labelWithString: label)
-        labelField.font = .systemFont(ofSize: 13)
-        labelField.textColor = .labelColor
-        labelField.frame = NSRect(x: 38, y: 5, width: menuWidth - 100, height: 18)
-        addSubview(labelField)
-        self.labelField = labelField
-
-        toggle.frame = NSRect(x: menuWidth - 54, y: 3, width: 42, height: 22)
-        toggle.onToggle = { [weak self] newValue in
-            self?.onChange(newValue)
-        }
-        addSubview(toggle)
-
-        updateTrackingAreas()
-    }
-
-    @available(*, unavailable)
-    required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-    }
-
-    override func updateTrackingAreas() {
-        if let existing = trackingArea {
-            removeTrackingArea(existing)
-        }
-        trackingArea = NSTrackingArea(
-            rect: bounds,
-            options: [.activeAlways, .inVisibleRect, .mouseEnteredAndExited, .mouseMoved],
-            owner: self,
-            userInfo: nil
-        )
-        addTrackingArea(trackingArea!)
-    }
-
-    override func mouseEntered(with event: NSEvent) {
-        setHovered(true)
-    }
-
-    override func mouseMoved(with event: NSEvent) {
-        let point = convert(event.locationInWindow, from: nil)
-        setHovered(bounds.contains(point))
-    }
-
-    override func mouseExited(with event: NSEvent) {
-        setHovered(false)
-    }
-
-    override func layout() {
-        super.layout()
-        backgroundLayer?.frame = NSRect(x: 4, y: 2, width: menuWidth - 8, height: 24)
-    }
-
-    private func setHovered(_ hovered: Bool) {
-        backgroundLayer?.frame = NSRect(x: 4, y: 2, width: menuWidth - 8, height: 24)
-        let targetBackground = hovered
-            ? NSColor.controlAccentColor.withAlphaComponent(0.34).cgColor
-            : NSColor.clear.cgColor
-
-        CATransaction.begin()
-        CATransaction.setAnimationDuration(0.12)
-        CATransaction.setAnimationTimingFunction(CAMediaTimingFunction(name: .easeOut))
-        backgroundLayer?.backgroundColor = targetBackground
-        CATransaction.commit()
-
-        iconView?.contentTintColor = hovered ? .white : .secondaryLabelColor
-        labelField?.textColor = hovered ? .white : .labelColor
-    }
-}
-
-final class MenuActionRowView: NSView {
-    private let action: () -> Void
-    private let isDestructive: Bool
-    private var trackingArea: NSTrackingArea?
-    private var backgroundLayer: CALayer?
-    private var iconView: NSImageView?
-    private var labelField: NSTextField?
-    private var isHovered = false
+private struct StatusBarMenuActionRow: View {
+    let itemID: StatusBarMenuItemID
+    let icon: String
+    let label: String
+    let accessory: StatusBarMenuAccessory
+    let isDestructive: Bool
+    let viewModel: StatusBarMenuViewModel
 
     init(
+        itemID: StatusBarMenuItemID,
         icon: String,
         label: String,
-        showChevron: Bool = false,
-        isExternal: Bool = false,
+        accessory: StatusBarMenuAccessory,
         isDestructive: Bool = false,
-        action: @escaping () -> Void
+        viewModel: StatusBarMenuViewModel
     ) {
-        self.action = action
+        self.itemID = itemID
+        self.icon = icon
+        self.label = label
+        self.accessory = accessory
         self.isDestructive = isDestructive
-        super.init(frame: NSRect(x: 0, y: 0, width: menuWidth, height: 28))
-        applyCurrentAppAppearance(to: self)
+        self.viewModel = viewModel
+    }
 
-        wantsLayer = true
+    private var isFocused: Bool {
+        viewModel.focusedItemID == itemID
+    }
 
-        backgroundLayer = CALayer()
-        backgroundLayer?.cornerRadius = 6
-        backgroundLayer?.backgroundColor = .clear
-        layer?.addSublayer(backgroundLayer!)
+    var body: some View {
+        Button {
+            viewModel.activate(itemID: itemID)
+        } label: {
+            HStack(spacing: 10) {
+                Image(systemName: icon)
+                    .font(.system(size: 13, weight: .regular))
+                    .foregroundStyle(iconColor)
+                    .frame(width: 16)
 
-        if let iconImage = NSImage(systemSymbolName: icon, accessibilityDescription: nil) {
-            let iv = NSImageView(frame: NSRect(x: 12, y: 6, width: 16, height: 16))
-            let config = NSImage.SymbolConfiguration(pointSize: 13, weight: .regular)
-            iv.image = iconImage.withSymbolConfiguration(config)
-            iv.contentTintColor = .secondaryLabelColor
-            addSubview(iv)
-            iconView = iv
+                Text(label)
+                    .font(.system(size: 13))
+                    .foregroundStyle(labelColor)
+
+                Spacer(minLength: 8)
+
+                accessoryView
+            }
+            .padding(.horizontal, 12)
+            .frame(height: 28)
+            .frame(maxWidth: .infinity)
+            .background(rowBackground)
+            .contentShape(Rectangle())
         }
-
-        let lf = NSTextField(labelWithString: label)
-        lf.font = .systemFont(ofSize: 13)
-        lf.textColor = .labelColor
-        lf.frame = NSRect(x: 38, y: 5, width: menuWidth - 70, height: 18)
-        addSubview(lf)
-        labelField = lf
-
-        if showChevron {
-            if let chevronImage = NSImage(systemSymbolName: "chevron.right", accessibilityDescription: nil) {
-                let chevronView = NSImageView(frame: NSRect(x: menuWidth - 24, y: 8, width: 10, height: 12))
-                let config = NSImage.SymbolConfiguration(pointSize: 10, weight: .semibold)
-                chevronView.image = chevronImage.withSymbolConfiguration(config)
-                chevronView.contentTintColor = .tertiaryLabelColor
-                addSubview(chevronView)
+        .buttonStyle(.plain)
+        .focusEffectDisabled()
+        .onHover { hovered in
+            if hovered {
+                viewModel.focus(itemID)
             }
         }
-
-        if isExternal {
-            if let externalImage = NSImage(systemSymbolName: "arrow.up.right", accessibilityDescription: nil) {
-                let externalView = NSImageView(frame: NSRect(x: menuWidth - 24, y: 8, width: 10, height: 12))
-                let config = NSImage.SymbolConfiguration(pointSize: 10, weight: .medium)
-                externalView.image = externalImage.withSymbolConfiguration(config)
-                externalView.contentTintColor = .tertiaryLabelColor
-                addSubview(externalView)
-            }
-        }
-
-        updateTrackingAreas()
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(label)
+        .accessibilityHint(accessibilityHint)
     }
 
-    @available(*, unavailable)
-    required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-    }
-
-    override func updateTrackingAreas() {
-        if let existing = trackingArea {
-            removeTrackingArea(existing)
-        }
-        trackingArea = NSTrackingArea(
-            rect: bounds,
-            options: [.activeAlways, .inVisibleRect, .mouseEnteredAndExited, .mouseMoved],
-            owner: self,
-            userInfo: nil
-        )
-        addTrackingArea(trackingArea!)
-    }
-
-    override func mouseEntered(with event: NSEvent) {
-        isHovered = true
-        setHoveredStyle(true)
-    }
-
-    override func mouseMoved(with event: NSEvent) {
-        let point = convert(event.locationInWindow, from: nil)
-        let hoveredNow = bounds.contains(point)
-        guard hoveredNow != isHovered else { return }
-        isHovered = hoveredNow
-        setHoveredStyle(hoveredNow)
-    }
-
-    override func mouseExited(with event: NSEvent) {
-        isHovered = false
-        setHoveredStyle(false)
-    }
-
-    override func mouseUp(with event: NSEvent) {
-        let location = convert(event.locationInWindow, from: nil)
-        if bounds.contains(location) {
-            if let menu = enclosingMenuItem?.menu {
-                menu.cancelTracking()
-            }
-            DispatchQueue.main.async { [weak self] in
-                self?.action()
-            }
+    @ViewBuilder
+    private var accessoryView: some View {
+        switch accessory {
+        case .none:
+            EmptyView()
+        case .chevron:
+            Image(systemName: "chevron.right")
+                .font(.system(size: 10, weight: .semibold))
+                .foregroundStyle(accessoryColor)
+        case .external:
+            Image(systemName: "arrow.up.right")
+                .font(.system(size: 10, weight: .medium))
+                .foregroundStyle(accessoryColor)
         }
     }
 
-    override func layout() {
-        super.layout()
-        backgroundLayer?.frame = NSRect(x: 4, y: 2, width: menuWidth - 8, height: 24)
+    private var rowBackground: some View {
+        RoundedRectangle(cornerRadius: rowCornerRadius, style: .continuous)
+            .fill(backgroundColor)
     }
 
-    private func setHoveredStyle(_ hovered: Bool) {
-        backgroundLayer?.frame = NSRect(x: 4, y: 2, width: menuWidth - 8, height: 24)
-
-        let background: CGColor
-        if hovered {
+    private var backgroundColor: Color {
+        if isFocused {
             if isDestructive {
-                background = NSColor.systemRed.withAlphaComponent(0.14).cgColor
-            } else {
-                background = NSColor.controlAccentColor.withAlphaComponent(0.32).cgColor
+                return Color(nsColor: .systemRed).opacity(0.14)
             }
-        } else {
-            background = NSColor.clear.cgColor
+            return Color(nsColor: .controlAccentColor).opacity(0.32)
         }
+        return .clear
+    }
 
-        CATransaction.begin()
-        CATransaction.setAnimationDuration(0.12)
-        CATransaction.setAnimationTimingFunction(CAMediaTimingFunction(name: .easeOut))
-        backgroundLayer?.backgroundColor = background
-        CATransaction.commit()
-
-        if isDestructive && hovered {
-            iconView?.contentTintColor = .systemRed
-            labelField?.textColor = .systemRed
-        } else {
-            iconView?.contentTintColor = hovered ? .white : .secondaryLabelColor
-            labelField?.textColor = hovered ? .white : .labelColor
+    private var iconColor: Color {
+        if isDestructive, isFocused {
+            return Color(nsColor: .systemRed)
         }
+        return isFocused ? Color(nsColor: .alternateSelectedControlTextColor) : Color(nsColor: .secondaryLabelColor)
+    }
+
+    private var labelColor: Color {
+        if isDestructive, isFocused {
+            return Color(nsColor: .systemRed)
+        }
+        return isFocused ? Color(nsColor: .alternateSelectedControlTextColor) : Color(nsColor: .labelColor)
+    }
+
+    private var accessoryColor: Color {
+        isFocused ? Color(nsColor: .alternateSelectedControlTextColor) : Color(nsColor: .tertiaryLabelColor)
+    }
+
+    private var accessibilityHint: String {
+        switch accessory {
+        case .external:
+            return "Opens in your browser"
+        case .chevron:
+            return "Opens a window"
+        case .none:
+            return isDestructive ? "Quits OmniWM" : "Activates this action"
+        }
+    }
+}
+
+private struct StatusBarMenuToggleRow: View {
+    let itemID: StatusBarMenuItemID
+    let icon: String
+    let label: String
+    let isOn: Bool
+    let viewModel: StatusBarMenuViewModel
+
+    private var isFocused: Bool {
+        viewModel.focusedItemID == itemID
+    }
+
+    var body: some View {
+        Button {
+            viewModel.activate(itemID: itemID)
+        } label: {
+            HStack(spacing: 10) {
+                Image(systemName: icon)
+                    .font(.system(size: 12, weight: .regular))
+                    .foregroundStyle(
+                        isFocused ? Color(nsColor: .alternateSelectedControlTextColor) : Color(nsColor: .secondaryLabelColor)
+                    )
+                    .frame(width: 16)
+
+                Text(label)
+                    .font(.system(size: 13))
+                    .foregroundStyle(isFocused ? Color(nsColor: .alternateSelectedControlTextColor) : Color(nsColor: .labelColor))
+
+                Spacer(minLength: 8)
+
+                StatusBarMenuSwitch(isOn: isOn, isFocused: isFocused)
+            }
+            .padding(.horizontal, 12)
+            .frame(height: 28)
+            .frame(maxWidth: .infinity)
+            .background(
+                RoundedRectangle(cornerRadius: rowCornerRadius, style: .continuous)
+                    .fill(isFocused ? Color(nsColor: .controlAccentColor).opacity(0.34) : .clear)
+            )
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .focusEffectDisabled()
+        .onHover { hovered in
+            if hovered {
+                viewModel.focus(itemID)
+            }
+        }
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(label)
+        .accessibilityValue(isOn ? "On" : "Off")
+        .accessibilityHint("Press Space to toggle")
+    }
+}
+
+private struct StatusBarMenuSwitch: View {
+    let isOn: Bool
+    let isFocused: Bool
+
+    var body: some View {
+        ZStack(alignment: isOn ? .trailing : .leading) {
+            Capsule(style: .continuous)
+                .fill(trackColor)
+                .frame(width: 42, height: 22)
+
+            Circle()
+                .fill(.white)
+                .frame(width: 18, height: 18)
+                .shadow(color: Color.black.opacity(0.18), radius: 1.8, x: 0, y: 0.6)
+                .padding(2)
+        }
+        .overlay {
+            if isFocused {
+                Capsule(style: .continuous)
+                    .stroke(Color(nsColor: .keyboardFocusIndicatorColor), lineWidth: 1)
+            }
+        }
+        .animation(.easeOut(duration: 0.14), value: isOn)
+        .accessibilityHidden(true)
+    }
+
+    private var trackColor: Color {
+        if isOn {
+            return Color(nsColor: .systemGreen).opacity(0.95)
+        }
+        return Color(nsColor: NSColor(white: 0.26, alpha: 1.0))
     }
 }

--- a/Sources/OmniWM/UI/StatusBar/StatusBarPanel.swift
+++ b/Sources/OmniWM/UI/StatusBar/StatusBarPanel.swift
@@ -1,0 +1,102 @@
+import AppKit
+import SwiftUI
+
+@MainActor
+final class StatusBarPanel: NSPanel {
+    override var canBecomeKey: Bool { true }
+    override var canBecomeMain: Bool { false }
+}
+
+@MainActor
+final class StatusBarPanelController: NSObject, NSWindowDelegate {
+    private weak var statusButton: NSStatusBarButton?
+    private let ownedWindowRegistry = OwnedWindowRegistry.shared
+
+    private(set) var panel: StatusBarPanel?
+
+    var onDismiss: ((Bool) -> Void)?
+
+    func show(using viewModel: StatusBarMenuViewModel, anchoredTo button: NSStatusBarButton) {
+        statusButton = button
+
+        if panel == nil {
+            panel = makePanel(viewModel: viewModel)
+        } else if let panel {
+            let hosting = NSHostingView(rootView: StatusBarMenuView(viewModel: viewModel))
+            hosting.translatesAutoresizingMaskIntoConstraints = false
+            panel.contentView = hosting
+            panel.setContentSize(hosting.fittingSize)
+        }
+
+        guard let panel else { return }
+
+        panel.contentView?.layoutSubtreeIfNeeded()
+        position(panel: panel, relativeTo: button)
+        viewModel.resetFocus()
+        panel.orderFrontRegardless()
+        panel.makeKey()
+        ownedWindowRegistry.register(panel)
+    }
+
+    func close(restoreFocus: Bool) {
+        hideWithoutCallbacks()
+        onDismiss?(restoreFocus)
+    }
+
+    func hideWithoutCallbacks() {
+        guard let panel else { return }
+        panel.orderOut(nil)
+        ownedWindowRegistry.unregister(panel)
+    }
+
+    func windowDidResignKey(_: Notification) {
+        close(restoreFocus: true)
+    }
+
+    private func makePanel(viewModel: StatusBarMenuViewModel) -> StatusBarPanel {
+        let hosting = NSHostingView(rootView: StatusBarMenuView(viewModel: viewModel))
+        hosting.translatesAutoresizingMaskIntoConstraints = false
+
+        let panel = StatusBarPanel(
+            contentRect: NSRect(x: 0, y: 0, width: statusBarMenuWidth, height: 10),
+            styleMask: [.borderless, .nonactivatingPanel],
+            backing: .buffered,
+            defer: false
+        )
+        panel.delegate = self
+        panel.level = .statusBar
+        panel.isFloatingPanel = true
+        panel.becomesKeyOnlyIfNeeded = false
+        panel.hidesOnDeactivate = true
+        panel.isOpaque = false
+        panel.backgroundColor = .clear
+        panel.hasShadow = true
+        panel.collectionBehavior = [.transient, .ignoresCycle]
+        panel.animationBehavior = .utilityWindow
+        panel.isMovable = false
+        panel.isReleasedWhenClosed = false
+        panel.contentView = hosting
+        panel.setContentSize(hosting.fittingSize)
+        return panel
+    }
+
+    private func position(panel: StatusBarPanel, relativeTo button: NSStatusBarButton) {
+        guard let screen = button.window?.screen ?? NSScreen.main,
+              let buttonWindow = button.window
+        else {
+            return
+        }
+
+        let buttonFrame = button.convert(button.bounds, to: nil)
+        let buttonFrameOnScreen = buttonWindow.convertToScreen(buttonFrame)
+        let panelSize = panel.contentView?.fittingSize ?? NSSize(width: statusBarMenuWidth, height: 380)
+
+        let x = min(
+            max(screen.visibleFrame.minX + 8, buttonFrameOnScreen.maxX - panelSize.width),
+            screen.visibleFrame.maxX - panelSize.width - 8
+        )
+        let y = buttonFrameOnScreen.minY - panelSize.height - 8
+
+        panel.setFrame(NSRect(origin: NSPoint(x: x, y: y), size: panelSize), display: true)
+    }
+}

--- a/Tests/OmniWMTests/StatusBarMenuTests.swift
+++ b/Tests/OmniWMTests/StatusBarMenuTests.swift
@@ -1,29 +1,28 @@
 import AppKit
+import SwiftUI
 import Testing
 
 @testable import OmniWM
 
 @Suite(.serialized) @MainActor struct StatusBarMenuTests {
-    @Test func buildMenuUsesCurrentAppAppearanceForMenuAndViews() throws {
+    @Test func hostedMenuViewUsesCurrentAppAppearance() throws {
         let application = NSApplication.shared
         let originalAppearance = application.appearance
         defer { application.appearance = originalAppearance }
 
         let controller = makeLayoutPlanTestController()
-        let builder = StatusBarMenuBuilder(settings: controller.settings, controller: controller)
+        let viewModel = StatusBarMenuViewModel(settings: controller.settings, controller: controller)
 
         application.appearance = NSAppearance(named: .aqua)
-        let lightMenu = builder.buildMenu()
+        let lightHost = NSHostingView(rootView: StatusBarMenuView(viewModel: viewModel))
+        lightHost.appearance = application.appearance
 
-        #expect(lightMenu.appearance?.name == .aqua)
-        #expect(try #require(lightMenu.items.first?.view).appearance?.name == .aqua)
-        #expect(try #require(lightMenu.items.dropFirst(3).first?.view).appearance?.name == .aqua)
+        #expect(lightHost.effectiveAppearance.bestMatch(from: [.aqua, .darkAqua]) == .aqua)
 
         application.appearance = NSAppearance(named: .darkAqua)
-        let darkMenu = builder.buildMenu()
+        let darkHost = NSHostingView(rootView: StatusBarMenuView(viewModel: viewModel))
+        darkHost.appearance = application.appearance
 
-        #expect(darkMenu.appearance?.name == .darkAqua)
-        #expect(try #require(darkMenu.items.first?.view).appearance?.name == .darkAqua)
-        #expect(try #require(darkMenu.items.dropFirst(3).first?.view).appearance?.name == .darkAqua)
+        #expect(darkHost.effectiveAppearance.bestMatch(from: [.aqua, .darkAqua]) == .darkAqua)
     }
 }

--- a/Tests/OmniWMTests/StatusBarMenuViewModelTests.swift
+++ b/Tests/OmniWMTests/StatusBarMenuViewModelTests.swift
@@ -1,0 +1,115 @@
+import AppKit
+import Foundation
+import Testing
+
+@testable import OmniWM
+
+private func makeStatusBarMenuTestDefaults() -> UserDefaults {
+    let suiteName = "com.omniwm.statusbar-menu.test.\(UUID().uuidString)"
+    return UserDefaults(suiteName: suiteName)!
+}
+
+@MainActor
+private func makeStatusBarMenuTestController(defaults: UserDefaults) -> WMController {
+    let operations = WindowFocusOperations(
+        activateApp: { _ in },
+        focusSpecificWindow: { _, _, _ in },
+        raiseWindow: { _ in }
+    )
+    return WMController(
+        settings: SettingsStore(defaults: defaults),
+        windowFocusOperations: operations
+    )
+}
+
+private func makeKeyEvent(
+    keyCode: UInt16,
+    characters: String,
+    modifierFlags: NSEvent.ModifierFlags = []
+) -> NSEvent {
+    guard let event = NSEvent.keyEvent(
+        with: .keyDown,
+        location: .zero,
+        modifierFlags: modifierFlags,
+        timestamp: 0,
+        windowNumber: 0,
+        context: nil,
+        characters: characters,
+        charactersIgnoringModifiers: characters,
+        isARepeat: false,
+        keyCode: keyCode
+    ) else {
+        fatalError("Failed to create key event for tests")
+    }
+
+    return event
+}
+
+@Suite @MainActor struct StatusBarMenuViewModelTests {
+    @Test func tabArrowHomeAndEndMoveFocusAcrossInteractiveItems() {
+        let defaults = makeStatusBarMenuTestDefaults()
+        let controller = makeStatusBarMenuTestController(defaults: defaults)
+        let viewModel = StatusBarMenuViewModel(settings: controller.settings, controller: controller)
+
+        #expect(viewModel.focusedItemID == .focusFollowsMouse)
+
+        #expect(viewModel.handleKeyDown(makeKeyEvent(keyCode: 48, characters: "\t")))
+        #expect(viewModel.focusedItemID == .followWindowToWorkspace)
+
+        #expect(viewModel.handleKeyDown(makeKeyEvent(keyCode: 48, characters: "\t", modifierFlags: .shift)))
+        #expect(viewModel.focusedItemID == .focusFollowsMouse)
+
+        #expect(viewModel.handleKeyDown(makeKeyEvent(keyCode: 126, characters: "")))
+        #expect(viewModel.focusedItemID == .quit)
+
+        #expect(viewModel.handleKeyDown(makeKeyEvent(keyCode: 125, characters: "")))
+        #expect(viewModel.focusedItemID == .focusFollowsMouse)
+
+        #expect(viewModel.handleKeyDown(makeKeyEvent(keyCode: 119, characters: "")))
+        #expect(viewModel.focusedItemID == .quit)
+
+        #expect(viewModel.handleKeyDown(makeKeyEvent(keyCode: 115, characters: "")))
+        #expect(viewModel.focusedItemID == .focusFollowsMouse)
+    }
+
+    @Test func spaceAndEnterToggleFocusedSwitchAndUpdateControllerState() {
+        let defaults = makeStatusBarMenuTestDefaults()
+        let controller = makeStatusBarMenuTestController(defaults: defaults)
+        let settings = controller.settings
+        settings.focusFollowsMouse = false
+
+        let viewModel = StatusBarMenuViewModel(settings: settings, controller: controller)
+        viewModel.focus(.focusFollowsMouse)
+
+        #expect(viewModel.handleKeyDown(makeKeyEvent(keyCode: 49, characters: " ")))
+        #expect(settings.focusFollowsMouse)
+        #expect(controller.focusFollowsMouseEnabled)
+
+        #expect(viewModel.handleKeyDown(makeKeyEvent(keyCode: 36, characters: "\r")))
+        #expect(settings.focusFollowsMouse == false)
+        #expect(controller.focusFollowsMouseEnabled == false)
+    }
+
+    @Test func escapeRequestsDismissWithFocusRestore() {
+        let defaults = makeStatusBarMenuTestDefaults()
+        let controller = makeStatusBarMenuTestController(defaults: defaults)
+        let viewModel = StatusBarMenuViewModel(settings: controller.settings, controller: controller)
+
+        var dismissRestoreFocus: Bool?
+        viewModel.setDismissHandler { restoreFocus in
+            dismissRestoreFocus = restoreFocus
+        }
+
+        #expect(viewModel.handleKeyDown(makeKeyEvent(keyCode: 53, characters: "")))
+        #expect(dismissRestoreFocus == true)
+    }
+
+    @Test func unhandledKeysAreIgnored() {
+        let defaults = makeStatusBarMenuTestDefaults()
+        let controller = makeStatusBarMenuTestController(defaults: defaults)
+        let viewModel = StatusBarMenuViewModel(settings: controller.settings, controller: controller)
+
+        #expect(viewModel.handleKeyDown(makeKeyEvent(keyCode: 0, characters: "a")) == false)
+        #expect(viewModel.focusedItemID == .focusFollowsMouse)
+    }
+}

--- a/Tests/OmniWMTests/StatusBarMenuViewModelTests.swift
+++ b/Tests/OmniWMTests/StatusBarMenuViewModelTests.swift
@@ -112,4 +112,22 @@ private func makeKeyEvent(
         #expect(viewModel.handleKeyDown(makeKeyEvent(keyCode: 0, characters: "a")) == false)
         #expect(viewModel.focusedItemID == .focusFollowsMouse)
     }
+
+    @Test func modifiedAccessibilityShortcutsPassThrough() {
+        let defaults = makeStatusBarMenuTestDefaults()
+        let controller = makeStatusBarMenuTestController(defaults: defaults)
+        let viewModel = StatusBarMenuViewModel(settings: controller.settings, controller: controller)
+
+        #expect(
+            viewModel.handleKeyDown(
+                makeKeyEvent(keyCode: 126, characters: "", modifierFlags: [.control, .option])
+            ) == false
+        )
+        #expect(
+            viewModel.handleKeyDown(
+                makeKeyEvent(keyCode: 49, characters: " ", modifierFlags: [.control, .option])
+            ) == false
+        )
+        #expect(viewModel.focusedItemID == .focusFollowsMouse)
+    }
 }


### PR DESCRIPTION
## Summary

Tries to fix: https://github.com/BarutSRB/OmniWM/issues/131

Admittedly helped by some AI tools as I don't write swift, but testing locally seems to work. Raising this for others to review and potentially use as a starting point if any proper Swift dev wants to do a tidy up.

![omni-ezgif com-optimize](https://github.com/user-attachments/assets/04e3dc2c-4e48-4088-b472-f067b7434832)


- replace the custom `NSMenu` popup with an anchored status bar panel so the menu can keep its custom visuals while supporting real keyboard handling
- add keyboard navigation, focus restoration, and accessibility-safe shortcut passthrough for the status bar menu interactions
- update and extend status bar tests to cover the hosted menu appearance and keyboard navigation behavior

