### PR TITLE
Add workspace indicator to the status bar

### DIFF
--- a/Sources/OmniWM/App/AppDelegate.swift
+++ b/Sources/OmniWM/App/AppDelegate.swift
@@ -65,6 +65,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             defaults: defaults
         )
         statusBarController?.setup()
+        controller.statusBarController = statusBarController
     }
 
     private func runStartupResetGate(storedEpoch: Int?, defaults: UserDefaults) {

--- a/Sources/OmniWM/Core/Config/SettingsStore.swift
+++ b/Sources/OmniWM/Core/Config/SettingsStore.swift
@@ -252,6 +252,10 @@ final class SettingsStore {
         didSet { defaults.set(statusBarShowAppNames, forKey: Keys.statusBarShowAppNames) }
     }
 
+    var statusBarUseWorkspaceId: Bool {
+        didSet { defaults.set(statusBarUseWorkspaceId, forKey: Keys.statusBarUseWorkspaceId) }
+    }
+
     var commandPaletteLastMode: CommandPaletteMode {
         didSet { defaults.set(commandPaletteLastMode.rawValue, forKey: Keys.commandPaletteLastMode) }
     }
@@ -436,6 +440,7 @@ final class SettingsStore {
 
         statusBarShowWorkspaceName = defaults.object(forKey: Keys.statusBarShowWorkspaceName) as? Bool ?? true
         statusBarShowAppNames = defaults.object(forKey: Keys.statusBarShowAppNames) as? Bool ?? true
+        statusBarUseWorkspaceId = defaults.object(forKey: Keys.statusBarUseWorkspaceId) as? Bool ?? false
 
         commandPaletteLastMode = CommandPaletteMode(
             rawValue: defaults.string(forKey: Keys.commandPaletteLastMode) ?? ""
@@ -912,6 +917,7 @@ private enum Keys {
 
     static let statusBarShowWorkspaceName = "settings.statusBarShowWorkspaceName"
     static let statusBarShowAppNames = "settings.statusBarShowAppNames"
+    static let statusBarUseWorkspaceId = "settings.statusBarUseWorkspaceId"
 
     static let commandPaletteLastMode = "settings.commandPalette.lastMode"
 

--- a/Sources/OmniWM/Core/Config/SettingsStore.swift
+++ b/Sources/OmniWM/Core/Config/SettingsStore.swift
@@ -244,6 +244,14 @@ final class SettingsStore {
         didSet { defaults.set(gestureInvertDirection, forKey: Keys.gestureInvertDirection) }
     }
 
+    var statusBarShowWorkspaceName: Bool {
+        didSet { defaults.set(statusBarShowWorkspaceName, forKey: Keys.statusBarShowWorkspaceName) }
+    }
+
+    var statusBarShowAppNames: Bool {
+        didSet { defaults.set(statusBarShowAppNames, forKey: Keys.statusBarShowAppNames) }
+    }
+
     var commandPaletteLastMode: CommandPaletteMode {
         didSet { defaults.set(commandPaletteLastMode.rawValue, forKey: Keys.commandPaletteLastMode) }
     }
@@ -425,6 +433,9 @@ final class SettingsStore {
             .optionShift
         gestureFingerCount = GestureFingerCount(rawValue: defaults.integer(forKey: Keys.gestureFingerCount)) ?? .three
         gestureInvertDirection = defaults.object(forKey: Keys.gestureInvertDirection) as? Bool ?? true
+
+        statusBarShowWorkspaceName = defaults.object(forKey: Keys.statusBarShowWorkspaceName) as? Bool ?? true
+        statusBarShowAppNames = defaults.object(forKey: Keys.statusBarShowAppNames) as? Bool ?? true
 
         commandPaletteLastMode = CommandPaletteMode(
             rawValue: defaults.string(forKey: Keys.commandPaletteLastMode) ?? ""
@@ -898,6 +909,9 @@ private enum Keys {
     static let scrollModifierKey = "settings.scrollModifierKey"
     static let gestureFingerCount = "settings.gestureFingerCount"
     static let gestureInvertDirection = "settings.gestureInvertDirection"
+
+    static let statusBarShowWorkspaceName = "settings.statusBarShowWorkspaceName"
+    static let statusBarShowAppNames = "settings.statusBarShowAppNames"
 
     static let commandPaletteLastMode = "settings.commandPalette.lastMode"
 

--- a/Sources/OmniWM/Core/Controller/WMController.swift
+++ b/Sources/OmniWM/Core/Controller/WMController.swift
@@ -113,6 +113,7 @@ final class WMController {
 
     let animationClock = AnimationClock()
     private let windowFocusOperations: WindowFocusOperations
+    weak var statusBarController: StatusBarController?
 
     init(
         settings: SettingsStore,
@@ -204,6 +205,7 @@ final class WMController {
     func applyCurrentAppearanceMode() {
         settings.appearanceMode.apply()
         workspaceBarManager.updateSettings()
+        statusBarController?.rebuildMenu()
     }
 
     func setEnabled(_ enabled: Bool) {
@@ -303,7 +305,7 @@ final class WMController {
     func requestWorkspaceBarRefresh() {
         workspaceBarRefreshDebugState.requestCount += 1
 
-        guard workspaceBarRefreshIsEnabled else { return }
+        guard anyBarRefreshIsEnabled else { return }
         guard pendingWorkspaceBarRefreshGeneration == nil else { return }
 
         let generation = workspaceBarRefreshGeneration
@@ -331,6 +333,10 @@ final class WMController {
 
     func isManagedWindowSuspendedForNativeFullscreen(_ token: WindowToken) -> Bool {
         workspaceManager.isNativeFullscreenSuspended(token)
+    }
+
+    func refreshStatusBar() {
+        statusBarController?.refreshWorkspaces()
     }
 
     func updateWorkspaceBarSettings() {
@@ -482,6 +488,10 @@ final class WMController {
         settings.workspaceBarEnabled || settings.monitorBarSettings.contains(where: { $0.enabled == true })
     }
 
+    private var anyBarRefreshIsEnabled: Bool {
+        workspaceBarRefreshIsEnabled || statusBarController != nil
+    }
+
     private func flushRequestedWorkspaceBarRefresh(expectedGeneration: UInt64) {
         guard pendingWorkspaceBarRefreshGeneration == expectedGeneration,
               workspaceBarRefreshGeneration == expectedGeneration
@@ -492,11 +502,15 @@ final class WMController {
         pendingWorkspaceBarRefreshGeneration = nil
         workspaceBarRefreshDebugState.isQueued = false
 
-        guard workspaceBarRefreshIsEnabled else { return }
+        guard anyBarRefreshIsEnabled else { return }
 
         workspaceBarRefreshDebugState.executionCount += 1
         workspaceBarRefreshExecutionHookForTests?()
-        workspaceBarManager.update()
+
+        if workspaceBarRefreshIsEnabled {
+            workspaceBarManager.update()
+        }
+        statusBarController?.refreshWorkspaces()
     }
 
     private func cancelPendingWorkspaceBarRefresh() {

--- a/Sources/OmniWM/UI/SettingsView.swift
+++ b/Sources/OmniWM/UI/SettingsView.swift
@@ -43,10 +43,15 @@ struct GeneralSettingsTab: View {
             }
 
             Section("Status Bar") {
-                Toggle("Show Workspace Name", isOn: $settings.statusBarShowWorkspaceName)
+                Toggle("Show Workspace", isOn: $settings.statusBarShowWorkspaceName)
                     .onChange(of: settings.statusBarShowWorkspaceName) { _, _ in
                         controller.refreshStatusBar()
                     }
+                Toggle("Use Workspace Number", isOn: $settings.statusBarUseWorkspaceId)
+                    .onChange(of: settings.statusBarUseWorkspaceId) { _, _ in
+                        controller.refreshStatusBar()
+                    }
+                    .disabled(!settings.statusBarShowWorkspaceName)
                 Toggle("Show Focused App", isOn: $settings.statusBarShowAppNames)
                     .onChange(of: settings.statusBarShowAppNames) { _, _ in
                         controller.refreshStatusBar()

--- a/Sources/OmniWM/UI/SettingsView.swift
+++ b/Sources/OmniWM/UI/SettingsView.swift
@@ -42,6 +42,21 @@ struct GeneralSettingsTab: View {
                     .foregroundColor(.secondary)
             }
 
+            Section("Status Bar") {
+                Toggle("Show Workspace Name", isOn: $settings.statusBarShowWorkspaceName)
+                    .onChange(of: settings.statusBarShowWorkspaceName) { _, _ in
+                        controller.refreshStatusBar()
+                    }
+                Toggle("Show Focused App", isOn: $settings.statusBarShowAppNames)
+                    .onChange(of: settings.statusBarShowAppNames) { _, _ in
+                        controller.refreshStatusBar()
+                    }
+                    .disabled(!settings.statusBarShowWorkspaceName)
+                Text("Shows the active workspace and focused app beside the menu bar icon")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            }
+
             Section("Layout") {
                 HStack {
                     Text("Inner Gaps")

--- a/Sources/OmniWM/UI/StatusBar/StatusBarController.swift
+++ b/Sources/OmniWM/UI/StatusBar/StatusBarController.swift
@@ -95,6 +95,42 @@ final class StatusBarController: NSObject {
         menu = menuBuilder?.buildMenu()
     }
 
+    func refreshWorkspaces() {
+        guard let controller else { return }
+
+        // Gather workspace items from the first/primary monitor
+        let monitors = controller.workspaceManager.monitors
+        guard let monitor = monitors.first else { return }
+
+        let items = controller.workspaceBarItems(for: monitor, deduplicate: true, hideEmpty: false)
+
+        // Update button title to focused workspace name
+        if let button = statusItem?.button {
+            // Always keep the icon
+            if button.image == nil {
+                button.image = NSImage(systemSymbolName: "o.circle", accessibilityDescription: "OmniWM")
+                button.image?.isTemplate = true
+            }
+            if settings.statusBarShowWorkspaceName,
+               let focused = items.first(where: \.isFocused)
+            {
+                var title = " \(focused.name)"
+                if settings.statusBarShowAppNames,
+                   let focusedApp = focused.windows.first(where: \.isFocused)?.appName
+                {
+                    let appName = focusedApp.count > 15
+                        ? String(focusedApp.prefix(15)) + "\u{2026}"
+                        : focusedApp
+                    title += " \u{2013} \(appName)"
+                }
+                button.title = title
+                button.imagePosition = .imageLeft
+            } else {
+                button.title = ""
+            }
+        }
+    }
+
     func cleanup() {
         cleanupOwnedStatusItems()
     }

--- a/Sources/OmniWM/UI/StatusBar/StatusBarController.swift
+++ b/Sources/OmniWM/UI/StatusBar/StatusBarController.swift
@@ -114,7 +114,8 @@ final class StatusBarController: NSObject {
             if settings.statusBarShowWorkspaceName,
                let focused = items.first(where: \.isFocused)
             {
-                var title = " \(focused.name)"
+                let workspaceLabel = settings.statusBarUseWorkspaceId ? focused.rawName : focused.name
+                var title = " \(workspaceLabel)"
                 if settings.statusBarShowAppNames,
                    let focusedApp = focused.windows.first(where: \.isFocused)?.appName
                 {

--- a/Sources/OmniWM/UI/WorkspaceBar/WorkspaceBarDataSource.swift
+++ b/Sources/OmniWM/UI/WorkspaceBar/WorkspaceBarDataSource.swift
@@ -61,6 +61,7 @@ enum WorkspaceBarDataSource {
             return WorkspaceBarItem(
                 id: snapshot.workspace.id,
                 name: settings.displayName(for: snapshot.workspace.name),
+                rawName: snapshot.workspace.name,
                 isFocused: snapshot.workspace.id == activeWorkspaceId,
                 windows: windows
             )

--- a/Sources/OmniWM/UI/WorkspaceBar/WorkspaceBarView.swift
+++ b/Sources/OmniWM/UI/WorkspaceBar/WorkspaceBarView.swift
@@ -5,6 +5,8 @@ import SwiftUI
 struct WorkspaceBarItem: Identifiable {
     let id: WorkspaceDescriptor.ID
     let name: String
+    /// The raw workspace name (e.g. "3") before display-name mapping.
+    let rawName: String
     let isFocused: Bool
     let windows: [WorkspaceBarWindowItem]
 }


### PR DESCRIPTION
## Summary
- Show the focused workspace beside the OmniWM menu bar icon (compact, AeroSpace-style)
- Three toggles in Settings → General → Status Bar:
  - **Show Workspace** — enables/disables the workspace indicator
  - **Use Workspace Number** — show raw ID ("3") instead of display name ("Code")
  - **Show Focused App** — appends the focused app name ("3 – Safari")
- Follows dark/light mode via OmniWM's appearance setting (menu rebuilds on theme change)
- No workspace list in the dropdown menu — keeps it clean

## Details
- Wire `WMController` to the status bar controller so workspace changes update the menu bar item
- Reuse workspace bar data to populate the button title with the focused workspace
- Keep the existing OmniWM icon and append the workspace info beside it when enabled
- App names truncated at 15 characters to keep the status item compact

## Testing
- `swift test` *(fails in this temp PR worktree because `Frameworks/GhosttyKit.xcframework` is not available locally)*