### PR TITLE
feat: workspace bar theming (custom colors & font size)

### DIFF
--- a/Sources/OmniWM/Core/Config/MonitorBarSettings.swift
+++ b/Sources/OmniWM/Core/Config/MonitorBarSettings.swift
@@ -119,4 +119,13 @@ struct ResolvedBarSettings {
     let backgroundOpacity: Double
     let xOffset: Double
     let yOffset: Double
+    let accentColorRed: Double
+    let accentColorGreen: Double
+    let accentColorBlue: Double
+    let accentColorAlpha: Double
+    let textColorRed: Double
+    let textColorGreen: Double
+    let textColorBlue: Double
+    let textColorAlpha: Double
+    let labelFontSize: Double
 }

--- a/Sources/OmniWM/Core/Config/SettingsExport.swift
+++ b/Sources/OmniWM/Core/Config/SettingsExport.swift
@@ -84,6 +84,15 @@ struct SettingsExport: Codable {
     var workspaceBarBackgroundOpacity: Double
     var workspaceBarXOffset: Double
     var workspaceBarYOffset: Double
+    var workspaceBarAccentColorRed: Double
+    var workspaceBarAccentColorGreen: Double
+    var workspaceBarAccentColorBlue: Double
+    var workspaceBarAccentColorAlpha: Double
+    var workspaceBarTextColorRed: Double
+    var workspaceBarTextColorGreen: Double
+    var workspaceBarTextColorBlue: Double
+    var workspaceBarTextColorAlpha: Double
+    var workspaceBarLabelFontSize: Double
     var monitorBarSettings: [MonitorBarSettings]
 
     var appRules: [AppRule]
@@ -175,6 +184,15 @@ extension SettingsExport {
             workspaceBarBackgroundOpacity: 0.1,
             workspaceBarXOffset: 0.0,
             workspaceBarYOffset: 0.0,
+            workspaceBarAccentColorRed: -1,
+            workspaceBarAccentColorGreen: -1,
+            workspaceBarAccentColorBlue: -1,
+            workspaceBarAccentColorAlpha: 1,
+            workspaceBarTextColorRed: -1,
+            workspaceBarTextColorGreen: -1,
+            workspaceBarTextColorBlue: -1,
+            workspaceBarTextColorAlpha: 1,
+            workspaceBarLabelFontSize: 12,
             monitorBarSettings: [],
             appRules: BuiltInSettingsDefaults.appRules,
             monitorOrientationSettings: [],
@@ -365,6 +383,15 @@ extension SettingsStore {
             workspaceBarBackgroundOpacity: workspaceBarBackgroundOpacity,
             workspaceBarXOffset: workspaceBarXOffset,
             workspaceBarYOffset: workspaceBarYOffset,
+            workspaceBarAccentColorRed: workspaceBarAccentColorRed,
+            workspaceBarAccentColorGreen: workspaceBarAccentColorGreen,
+            workspaceBarAccentColorBlue: workspaceBarAccentColorBlue,
+            workspaceBarAccentColorAlpha: workspaceBarAccentColorAlpha,
+            workspaceBarTextColorRed: workspaceBarTextColorRed,
+            workspaceBarTextColorGreen: workspaceBarTextColorGreen,
+            workspaceBarTextColorBlue: workspaceBarTextColorBlue,
+            workspaceBarTextColorAlpha: workspaceBarTextColorAlpha,
+            workspaceBarLabelFontSize: workspaceBarLabelFontSize,
             monitorBarSettings: monitorBarSettings,
             appRules: appRules,
             monitorOrientationSettings: monitorOrientationSettings,
@@ -486,6 +513,15 @@ extension SettingsStore {
         workspaceBarBackgroundOpacity = export.workspaceBarBackgroundOpacity
         workspaceBarXOffset = export.workspaceBarXOffset
         workspaceBarYOffset = export.workspaceBarYOffset
+        workspaceBarAccentColorRed = export.workspaceBarAccentColorRed
+        workspaceBarAccentColorGreen = export.workspaceBarAccentColorGreen
+        workspaceBarAccentColorBlue = export.workspaceBarAccentColorBlue
+        workspaceBarAccentColorAlpha = export.workspaceBarAccentColorAlpha
+        workspaceBarTextColorRed = export.workspaceBarTextColorRed
+        workspaceBarTextColorGreen = export.workspaceBarTextColorGreen
+        workspaceBarTextColorBlue = export.workspaceBarTextColorBlue
+        workspaceBarTextColorAlpha = export.workspaceBarTextColorAlpha
+        workspaceBarLabelFontSize = export.workspaceBarLabelFontSize
         monitorBarSettings = Self.reboundMonitorBarSettings(
             export.monitorBarSettings,
             monitors: monitors

--- a/Sources/OmniWM/Core/Config/SettingsStore.swift
+++ b/Sources/OmniWM/Core/Config/SettingsStore.swift
@@ -183,6 +183,42 @@ final class SettingsStore {
         didSet { defaults.set(workspaceBarYOffset, forKey: Keys.workspaceBarYOffset) }
     }
 
+    var workspaceBarAccentColorRed: Double {
+        didSet { defaults.set(workspaceBarAccentColorRed, forKey: Keys.workspaceBarAccentColorRed) }
+    }
+
+    var workspaceBarAccentColorGreen: Double {
+        didSet { defaults.set(workspaceBarAccentColorGreen, forKey: Keys.workspaceBarAccentColorGreen) }
+    }
+
+    var workspaceBarAccentColorBlue: Double {
+        didSet { defaults.set(workspaceBarAccentColorBlue, forKey: Keys.workspaceBarAccentColorBlue) }
+    }
+
+    var workspaceBarAccentColorAlpha: Double {
+        didSet { defaults.set(workspaceBarAccentColorAlpha, forKey: Keys.workspaceBarAccentColorAlpha) }
+    }
+
+    var workspaceBarTextColorRed: Double {
+        didSet { defaults.set(workspaceBarTextColorRed, forKey: Keys.workspaceBarTextColorRed) }
+    }
+
+    var workspaceBarTextColorGreen: Double {
+        didSet { defaults.set(workspaceBarTextColorGreen, forKey: Keys.workspaceBarTextColorGreen) }
+    }
+
+    var workspaceBarTextColorBlue: Double {
+        didSet { defaults.set(workspaceBarTextColorBlue, forKey: Keys.workspaceBarTextColorBlue) }
+    }
+
+    var workspaceBarTextColorAlpha: Double {
+        didSet { defaults.set(workspaceBarTextColorAlpha, forKey: Keys.workspaceBarTextColorAlpha) }
+    }
+
+    var workspaceBarLabelFontSize: Double {
+        didSet { defaults.set(workspaceBarLabelFontSize, forKey: Keys.workspaceBarLabelFontSize) }
+    }
+
     var monitorBarSettings: [MonitorBarSettings] {
         didSet { MonitorSettingsStore.save(monitorBarSettings, to: defaults, key: Keys.monitorBarSettings) }
     }
@@ -467,6 +503,24 @@ final class SettingsStore {
             baseline.workspaceBarBackgroundOpacity
         workspaceBarXOffset = defaults.object(forKey: Keys.workspaceBarXOffset) as? Double ?? baseline.workspaceBarXOffset
         workspaceBarYOffset = defaults.object(forKey: Keys.workspaceBarYOffset) as? Double ?? baseline.workspaceBarYOffset
+        workspaceBarAccentColorRed = defaults.object(forKey: Keys.workspaceBarAccentColorRed) as? Double ??
+            baseline.workspaceBarAccentColorRed
+        workspaceBarAccentColorGreen = defaults.object(forKey: Keys.workspaceBarAccentColorGreen) as? Double ??
+            baseline.workspaceBarAccentColorGreen
+        workspaceBarAccentColorBlue = defaults.object(forKey: Keys.workspaceBarAccentColorBlue) as? Double ??
+            baseline.workspaceBarAccentColorBlue
+        workspaceBarAccentColorAlpha = defaults.object(forKey: Keys.workspaceBarAccentColorAlpha) as? Double ??
+            baseline.workspaceBarAccentColorAlpha
+        workspaceBarTextColorRed = defaults.object(forKey: Keys.workspaceBarTextColorRed) as? Double ??
+            baseline.workspaceBarTextColorRed
+        workspaceBarTextColorGreen = defaults.object(forKey: Keys.workspaceBarTextColorGreen) as? Double ??
+            baseline.workspaceBarTextColorGreen
+        workspaceBarTextColorBlue = defaults.object(forKey: Keys.workspaceBarTextColorBlue) as? Double ??
+            baseline.workspaceBarTextColorBlue
+        workspaceBarTextColorAlpha = defaults.object(forKey: Keys.workspaceBarTextColorAlpha) as? Double ??
+            baseline.workspaceBarTextColorAlpha
+        workspaceBarLabelFontSize = defaults.object(forKey: Keys.workspaceBarLabelFontSize) as? Double ??
+            baseline.workspaceBarLabelFontSize
         monitorBarSettings = MonitorSettingsStore.load(from: defaults, key: Keys.monitorBarSettings)
         let loadedAppRules = Self.loadAppRules(from: defaults)
         appRules = loadedAppRules
@@ -746,7 +800,16 @@ final class SettingsStore {
             height: override?.height ?? workspaceBarHeight,
             backgroundOpacity: override?.backgroundOpacity ?? workspaceBarBackgroundOpacity,
             xOffset: override?.xOffset ?? workspaceBarXOffset,
-            yOffset: override?.yOffset ?? workspaceBarYOffset
+            yOffset: override?.yOffset ?? workspaceBarYOffset,
+            accentColorRed: workspaceBarAccentColorRed,
+            accentColorGreen: workspaceBarAccentColorGreen,
+            accentColorBlue: workspaceBarAccentColorBlue,
+            accentColorAlpha: workspaceBarAccentColorAlpha,
+            textColorRed: workspaceBarTextColorRed,
+            textColorGreen: workspaceBarTextColorGreen,
+            textColorBlue: workspaceBarTextColorBlue,
+            textColorAlpha: workspaceBarTextColorAlpha,
+            labelFontSize: workspaceBarLabelFontSize
         )
     }
 
@@ -997,6 +1060,15 @@ private enum Keys {
     static let workspaceBarBackgroundOpacity = "settings.workspaceBar.backgroundOpacity"
     static let workspaceBarXOffset = "settings.workspaceBar.xOffset"
     static let workspaceBarYOffset = "settings.workspaceBar.yOffset"
+    static let workspaceBarAccentColorRed = "settings.workspaceBar.accentColorRed"
+    static let workspaceBarAccentColorGreen = "settings.workspaceBar.accentColorGreen"
+    static let workspaceBarAccentColorBlue = "settings.workspaceBar.accentColorBlue"
+    static let workspaceBarAccentColorAlpha = "settings.workspaceBar.accentColorAlpha"
+    static let workspaceBarTextColorRed = "settings.workspaceBar.textColorRed"
+    static let workspaceBarTextColorGreen = "settings.workspaceBar.textColorGreen"
+    static let workspaceBarTextColorBlue = "settings.workspaceBar.textColorBlue"
+    static let workspaceBarTextColorAlpha = "settings.workspaceBar.textColorAlpha"
+    static let workspaceBarLabelFontSize = "settings.workspaceBar.labelFontSize"
     static let monitorBarSettings = "settings.workspaceBar.monitorSettings"
 
     static let appRules = "settings.appRules"

--- a/Sources/OmniWM/UI/WorkspaceBar/WorkspaceBarManager.swift
+++ b/Sources/OmniWM/UI/WorkspaceBar/WorkspaceBarManager.swift
@@ -361,11 +361,32 @@ final class WorkspaceBarManager {
             projection: resolved.projectionOptions
         ) ?? []
 
+        let accentColorComponents: ColorComponents? = resolved.accentColorRed >= 0
+            ? ColorComponents(
+                red: resolved.accentColorRed,
+                green: resolved.accentColorGreen,
+                blue: resolved.accentColorBlue,
+                alpha: resolved.accentColorAlpha
+            )
+            : nil
+
+        let textColorComponents: ColorComponents? = resolved.textColorRed >= 0
+            ? ColorComponents(
+                red: resolved.textColorRed,
+                green: resolved.textColorGreen,
+                blue: resolved.textColorBlue,
+                alpha: resolved.textColorAlpha
+            )
+            : nil
+
         return WorkspaceBarSnapshot(
             items: items,
             showLabels: resolved.showLabels,
             backgroundOpacity: resolved.backgroundOpacity,
-            barHeight: geometry.barHeight
+            barHeight: geometry.barHeight,
+            accentColorComponents: accentColorComponents,
+            textColorComponents: textColorComponents,
+            labelFontSize: CGFloat(resolved.labelFontSize)
         )
     }
 

--- a/Sources/OmniWM/UI/WorkspaceBar/WorkspaceBarView.swift
+++ b/Sources/OmniWM/UI/WorkspaceBar/WorkspaceBarView.swift
@@ -47,6 +47,23 @@ struct WorkspaceBarSnapshot: Equatable {
     let showLabels: Bool
     let backgroundOpacity: Double
     let barHeight: CGFloat
+    let accentColorComponents: ColorComponents?
+    let textColorComponents: ColorComponents?
+    let labelFontSize: CGFloat
+
+    var accentColor: Color? { accentColorComponents?.color }
+    var textColor: Color? { textColorComponents?.color }
+}
+
+struct ColorComponents: Equatable {
+    let red: Double
+    let green: Double
+    let blue: Double
+    let alpha: Double
+
+    var color: Color {
+        Color(red: red, green: green, blue: blue, opacity: alpha)
+    }
 }
 
 @MainActor @Observable
@@ -122,6 +139,9 @@ private struct WorkspaceBarContentView: View {
                     cornerRadius: cornerRadius,
                     animationsEnabled: animationsEnabled,
                     showLabels: snapshot.showLabels,
+                    accentColor: snapshot.accentColor,
+                    textColor: snapshot.textColor,
+                    labelFontSize: snapshot.labelFontSize,
                     onFocusWorkspace: { onFocusWorkspace(item) },
                     onFocusWindow: onFocusWindow
                 )
@@ -146,17 +166,23 @@ private struct WorkspaceItemView: View {
     let cornerRadius: CGFloat
     let animationsEnabled: Bool
     let showLabels: Bool
+    let accentColor: Color?
+    let textColor: Color?
+    let labelFontSize: CGFloat
     let onFocusWorkspace: () -> Void
     let onFocusWindow: (WindowToken) -> Void
 
     @State private var isHovered = false
 
+    private var resolvedAccentColor: Color { accentColor ?? .accentColor }
+    private var resolvedTextColor: Color { textColor ?? .primary }
+
     var body: some View {
         HStack(spacing: windowSpacing) {
             if showLabels {
                 Text(item.name)
-                    .font(.system(size: 12, weight: .medium, design: .monospaced))
-                    .foregroundColor(item.isFocused ? .accentColor : .secondary)
+                    .font(.system(size: labelFontSize, weight: .medium, design: .monospaced))
+                    .foregroundColor(item.isFocused ? resolvedAccentColor : (textColor?.opacity(0.6) ?? .secondary))
                     .frame(minWidth: 16)
 
                 if !item.windows.isEmpty {
@@ -173,6 +199,7 @@ private struct WorkspaceItemView: View {
                     isFocused: window.isFocused,
                     isInFocusedWorkspace: item.isFocused,
                     animationsEnabled: animationsEnabled,
+                    accentColor: accentColor,
                     onFocusWindow: onFocusWindow
                 )
             }
@@ -190,6 +217,7 @@ private struct WorkspaceItemView: View {
                     isFocused: window.isFocused,
                     isInFocusedWorkspace: item.isFocused,
                     animationsEnabled: animationsEnabled,
+                    accentColor: accentColor,
                     onFocusWindow: onFocusWindow
                 )
             }
@@ -204,7 +232,7 @@ private struct WorkspaceItemView: View {
                     .overlay {
                         if item.isFocused {
                             RoundedRectangle(cornerRadius: cornerRadius)
-                                .strokeBorder(Color.accentColor, lineWidth: 1)
+                                .strokeBorder(resolvedAccentColor, lineWidth: 1)
                         }
                     }
             }
@@ -225,10 +253,13 @@ private struct WindowIconView: View {
     let isFocused: Bool
     let isInFocusedWorkspace: Bool
     let animationsEnabled: Bool
+    let accentColor: Color?
     let onFocusWindow: (WindowToken) -> Void
 
     @State private var isHovered = false
     @State private var showingWindowList = false
+
+    private var resolvedAccentColor: Color { accentColor ?? .accentColor }
 
     var body: some View {
         ZStack(alignment: .topTrailing) {
@@ -245,7 +276,7 @@ private struct WindowIconView: View {
             }
             .frame(width: iconSize, height: iconSize)
             .opacity(opacity)
-            .shadow(color: Color.accentColor.opacity(glowOpacity), radius: glowRadius)
+            .shadow(color: resolvedAccentColor.opacity(glowOpacity), radius: glowRadius)
 
             if window.windowCount > 1 {
                 Text("\(window.windowCount)")
@@ -348,7 +379,7 @@ private struct WindowListSheet: View {
                         Spacer()
                         if windowInfo.isFocused {
                             Image(systemName: "checkmark.circle.fill")
-                                .foregroundColor(.accentColor)
+                                .foregroundColor(.accentColor)  // Sheet uses system accent
                         }
                     }
                 }

--- a/Sources/OmniWM/UI/WorkspaceBarSettingsTab.swift
+++ b/Sources/OmniWM/UI/WorkspaceBarSettingsTab.swift
@@ -245,10 +245,149 @@ private struct GlobalBarSettingsSection: View {
                         controller.updateWorkspaceBarSettings()
                     }
                 }
+
+                Divider()
+
+                SectionHeader("Theme")
+                VStack(alignment: .leading, spacing: 8) {
+                    WorkspaceBarAccentColorPicker(settings: settings, controller: controller)
+                    WorkspaceBarTextColorPicker(settings: settings, controller: controller)
+
+                    HStack {
+                        Text("Label Font Size")
+                        Slider(value: $settings.workspaceBarLabelFontSize, in: 10 ... 16, step: 1)
+                        Text("\(Int(settings.workspaceBarLabelFontSize)) pt")
+                            .font(.system(size: 12, weight: .medium, design: .monospaced))
+                            .frame(width: 48, alignment: .trailing)
+                    }
+                    .onChange(of: settings.workspaceBarLabelFontSize) { _, _ in
+                        controller.updateWorkspaceBarSettings()
+                    }
+                }
             }
         }
     }
 
+}
+
+private struct WorkspaceBarAccentColorPicker: View {
+    @Bindable var settings: SettingsStore
+    @Bindable var controller: WMController
+
+    private var useCustomAccent: Bool {
+        settings.workspaceBarAccentColorRed >= 0
+    }
+
+    private var accentBinding: Binding<Color> {
+        Binding(
+            get: {
+                guard settings.workspaceBarAccentColorRed >= 0 else { return .accentColor }
+                return Color(
+                    red: settings.workspaceBarAccentColorRed,
+                    green: settings.workspaceBarAccentColorGreen,
+                    blue: settings.workspaceBarAccentColorBlue,
+                    opacity: settings.workspaceBarAccentColorAlpha
+                )
+            },
+            set: { newColor in
+                if let components = NSColor(newColor).usingColorSpace(.sRGB) {
+                    settings.workspaceBarAccentColorRed = Double(components.redComponent)
+                    settings.workspaceBarAccentColorGreen = Double(components.greenComponent)
+                    settings.workspaceBarAccentColorBlue = Double(components.blueComponent)
+                    settings.workspaceBarAccentColorAlpha = Double(components.alphaComponent)
+                    controller.updateWorkspaceBarSettings()
+                }
+            }
+        )
+    }
+
+    var body: some View {
+        HStack {
+            Toggle("Custom Accent Color", isOn: Binding(
+                get: { useCustomAccent },
+                set: { enabled in
+                    if enabled {
+                        let ns = NSColor.controlAccentColor.usingColorSpace(.sRGB) ?? .blue
+                        settings.workspaceBarAccentColorRed = Double(ns.redComponent)
+                        settings.workspaceBarAccentColorGreen = Double(ns.greenComponent)
+                        settings.workspaceBarAccentColorBlue = Double(ns.blueComponent)
+                        settings.workspaceBarAccentColorAlpha = Double(ns.alphaComponent)
+                    } else {
+                        settings.workspaceBarAccentColorRed = -1
+                        settings.workspaceBarAccentColorGreen = -1
+                        settings.workspaceBarAccentColorBlue = -1
+                        settings.workspaceBarAccentColorAlpha = 1
+                    }
+                    controller.updateWorkspaceBarSettings()
+                }
+            ))
+            Spacer()
+            if useCustomAccent {
+                ColorPicker("", selection: accentBinding, supportsOpacity: true)
+                    .labelsHidden()
+            }
+        }
+    }
+}
+
+private struct WorkspaceBarTextColorPicker: View {
+    @Bindable var settings: SettingsStore
+    @Bindable var controller: WMController
+
+    private var useCustomText: Bool {
+        settings.workspaceBarTextColorRed >= 0
+    }
+
+    private var textBinding: Binding<Color> {
+        Binding(
+            get: {
+                guard settings.workspaceBarTextColorRed >= 0 else { return .primary }
+                return Color(
+                    red: settings.workspaceBarTextColorRed,
+                    green: settings.workspaceBarTextColorGreen,
+                    blue: settings.workspaceBarTextColorBlue,
+                    opacity: settings.workspaceBarTextColorAlpha
+                )
+            },
+            set: { newColor in
+                if let components = NSColor(newColor).usingColorSpace(.sRGB) {
+                    settings.workspaceBarTextColorRed = Double(components.redComponent)
+                    settings.workspaceBarTextColorGreen = Double(components.greenComponent)
+                    settings.workspaceBarTextColorBlue = Double(components.blueComponent)
+                    settings.workspaceBarTextColorAlpha = Double(components.alphaComponent)
+                    controller.updateWorkspaceBarSettings()
+                }
+            }
+        )
+    }
+
+    var body: some View {
+        HStack {
+            Toggle("Custom Text Color", isOn: Binding(
+                get: { useCustomText },
+                set: { enabled in
+                    if enabled {
+                        let ns = NSColor.labelColor.usingColorSpace(.sRGB) ?? .white
+                        settings.workspaceBarTextColorRed = Double(ns.redComponent)
+                        settings.workspaceBarTextColorGreen = Double(ns.greenComponent)
+                        settings.workspaceBarTextColorBlue = Double(ns.blueComponent)
+                        settings.workspaceBarTextColorAlpha = Double(ns.alphaComponent)
+                    } else {
+                        settings.workspaceBarTextColorRed = -1
+                        settings.workspaceBarTextColorGreen = -1
+                        settings.workspaceBarTextColorBlue = -1
+                        settings.workspaceBarTextColorAlpha = 1
+                    }
+                    controller.updateWorkspaceBarSettings()
+                }
+            ))
+            Spacer()
+            if useCustomText {
+                ColorPicker("", selection: textBinding, supportsOpacity: true)
+                    .labelsHidden()
+            }
+        }
+    }
 }
 
 private struct MonitorBarSettingsSection: View {

--- a/Tests/OmniWMTests/MenuBarRecoveryTests.swift
+++ b/Tests/OmniWMTests/MenuBarRecoveryTests.swift
@@ -31,7 +31,16 @@ private func makeBarSettings(
         height: height,
         backgroundOpacity: 0.1,
         xOffset: xOffset,
-        yOffset: yOffset
+        yOffset: yOffset,
+        accentColorRed: -1,
+        accentColorGreen: -1,
+        accentColorBlue: -1,
+        accentColorAlpha: 1,
+        textColorRed: -1,
+        textColorGreen: -1,
+        textColorBlue: -1,
+        textColorAlpha: 1,
+        labelFontSize: 12
     )
 }
 


### PR DESCRIPTION
## Summary

Adds configurable theming for the workspace bar — custom accent color, text color, and label font size. All default to system values so nothing changes for existing users.

## What's new

- **Custom accent color** — replaces `.accentColor` for focused workspace borders, glow, and labels. Toggle + ColorPicker in Settings.
- **Custom text color** — replaces `.primary`/`.secondary` for workspace labels and window titles. Toggle + ColorPicker in Settings.
- **Label font size** — slider from 10–16pt (default 12), replaces hardcoded `12`.
- **JSON export/import** — theme colors are included in settings export (RGBA format, matching existing `borderColor` pattern).

## Design decisions

- **`-1` sentinel for "use system default"** — when accent/text red component is `< 0`, the color is `nil` and falls back to system accent/secondary. Matches existing convention.
- **`ColorComponents` struct** — avoids putting SwiftUI `Color` (not `Equatable`) in `WorkspaceBarSnapshot`. Stores raw doubles for reliable equality.
- **Global-only** (not per-monitor) — keeps scope small. Per-monitor theming can be added later by extending `MonitorBarSettings` with optional color overrides.

## Files changed (7)

| File | Change |
|------|--------|
| `SettingsStore.swift` | 9 new `@Published` properties + Keys + init |
| `SettingsExport.swift` | Export/import for 9 new fields |
| `MonitorBarSettings.swift` | Extended `ResolvedBarSettings` with color fields |
| `WorkspaceBarView.swift` | `ColorComponents` struct, snapshot expansion, dynamic colors |
| `WorkspaceBarManager.swift` | Pass colors from resolved settings → snapshot |
| `WorkspaceBarSettingsTab.swift` | New "Theme" section with ColorPickers + font slider |
| `MenuBarRecoveryTests.swift` | Updated `makeBarSettings()` helper |

## Screenshots

N/A (no build environment with Zig + libghostty available, but all changes follow existing patterns exactly)

## Test plan

- [ ] Enable custom accent color → workspace bar borders/glow/labels change
- [ ] Disable custom accent color → reverts to system accent
- [ ] Enable custom text color → workspace labels change
- [ ] Font size slider → labels resize from 10–16pt
- [ ] Export settings → JSON includes theme colors
- [ ] Import settings → theme colors apply
- [ ] Fresh install → defaults to system colors (no visual change)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Workspace bar appearance is now fully customizable: configure custom accent colors, text colors, and adjust label font sizes (10–16pt) to match your preferences. Settings persist across sessions and are included in configuration exports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->