### PR TITLE
Fix CLI completion build timeout and stabilize async IPC tests

### DIFF
--- a/Sources/OmniWM/App/AppCLIManager.swift
+++ b/Sources/OmniWM/App/AppCLIManager.swift
@@ -138,7 +138,7 @@ final class AppCLIManager {
     private func preferredUserBinDirectory() -> URL {
         let homeDirectory = homeDirectoryURLProvider().standardizedFileURL
         let pathDirectories = pathDirectoriesFromEnvironment()
-            .filter { $0.path.hasPrefix(homeDirectory.path) }
+            .filter { isWithinHomeDirectory($0, homeDirectory: homeDirectory) }
         let fallbacks = [
             homeDirectory.appendingPathComponent(".local/bin", isDirectory: true),
             homeDirectory.appendingPathComponent("bin", isDirectory: true)
@@ -180,7 +180,21 @@ final class AppCLIManager {
             return fileManager.isWritableFile(atPath: directory.path)
         }
 
-        return directory.deletingLastPathComponent().path.hasPrefix(homeDirectoryURLProvider().path)
+        return isWithinHomeDirectory(
+            directory.deletingLastPathComponent(),
+            homeDirectory: homeDirectoryURLProvider().standardizedFileURL
+        )
+    }
+
+    private func isWithinHomeDirectory(_ directory: URL, homeDirectory: URL) -> Bool {
+        let directoryPathComponents = directory.standardizedFileURL.pathComponents
+        let homePathComponents = homeDirectory.standardizedFileURL.pathComponents
+
+        guard directoryPathComponents.count >= homePathComponents.count else {
+            return false
+        }
+
+        return Array(directoryPathComponents.prefix(homePathComponents.count)) == homePathComponents
     }
 
     private func symlinkResolvesToBundledCLI(at url: URL) -> Bool {

--- a/Sources/OmniWMCtl/CLICompletionGenerator.swift
+++ b/Sources/OmniWMCtl/CLICompletionGenerator.swift
@@ -315,26 +315,25 @@ enum CLICompletionGenerator {
             "complete -c omniwmctl -f -n '__fish_seen_subcommand_from completion' -a '\(shell.rawValue)'"
         }
 
-        return (
-            [helperFunctions]
-                + baseLines
-                + queryLines
-                + queryFlagLines.sorted()
-                + queryFieldLines.sorted()
-                + commandRootLines
-                + commandNestedLines.sorted()
-                + commandPathArgumentLines.sorted()
-                + commandFallbackLines.sorted()
-                + commandSecondArgumentLines.sorted()
-                + ruleLines
-                + ruleApplyLines
-                + subscribeLines
-                + watchLines
-                + workspaceLines
-                + windowLines
-                + shellLines
-        )
-        .joined(separator: "\n")
+        var lines = [helperFunctions]
+        lines.append(contentsOf: baseLines)
+        lines.append(contentsOf: queryLines)
+        lines.append(contentsOf: queryFlagLines.sorted())
+        lines.append(contentsOf: queryFieldLines.sorted())
+        lines.append(contentsOf: commandRootLines)
+        lines.append(contentsOf: commandNestedLines.sorted())
+        lines.append(contentsOf: commandPathArgumentLines.sorted())
+        lines.append(contentsOf: commandFallbackLines.sorted())
+        lines.append(contentsOf: commandSecondArgumentLines.sorted())
+        lines.append(contentsOf: ruleLines)
+        lines.append(contentsOf: ruleApplyLines)
+        lines.append(contentsOf: subscribeLines)
+        lines.append(contentsOf: watchLines)
+        lines.append(contentsOf: workspaceLines)
+        lines.append(contentsOf: windowLines)
+        lines.append(contentsOf: shellLines)
+
+        return lines.joined(separator: "\n")
     }
 
     private static var topLevelCommands: [String] {

--- a/Tests/OmniWMTests/AppCLIManagerTests.swift
+++ b/Tests/OmniWMTests/AppCLIManagerTests.swift
@@ -87,6 +87,33 @@ private func makeCLIManager(
         #expect(manager.exposureStatus() == .appManaged(linkURL: expectedLinkURL, directoryOnPath: false))
     }
 
+    @Test func installCLIIgnoresPathDirectoriesThatOnlyShareHomePrefix() throws {
+        let root = makeAppCLIManagerTestDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let homeDirectory = root.appendingPathComponent("home", isDirectory: true)
+        try FileManager.default.createDirectory(at: homeDirectory, withIntermediateDirectories: true)
+
+        let siblingHomePrefixDirectory = root.appendingPathComponent("home-other/bin", isDirectory: true)
+        try FileManager.default.createDirectory(at: siblingHomePrefixDirectory, withIntermediateDirectories: true)
+
+        let appBundleURL = try makeBundledCLIAppBundle(in: root)
+        let manager = makeCLIManager(
+            homeDirectory: homeDirectory,
+            bundleURL: appBundleURL,
+            pathDirectories: [siblingHomePrefixDirectory]
+        )
+
+        let expectedLinkURL = homeDirectory
+            .appendingPathComponent(".local/bin", isDirectory: true)
+            .appendingPathComponent("omniwmctl", isDirectory: false)
+        let result = try manager.installCLIToPATH()
+
+        #expect(result == .installed(linkURL: expectedLinkURL, directoryOnPath: false))
+        #expect(FileManager.default.fileExists(atPath: siblingHomePrefixDirectory.appendingPathComponent("omniwmctl").path) == false)
+        #expect(manager.exposureStatus() == .appManaged(linkURL: expectedLinkURL, directoryOnPath: false))
+    }
+
     @Test func installAndRemoveCLITrackAppManagedLinkLifecycle() throws {
         let root = makeAppCLIManagerTestDirectory()
         defer { try? FileManager.default.removeItem(at: root) }

--- a/Tests/OmniWMTests/IPCEventBrokerTests.swift
+++ b/Tests/OmniWMTests/IPCEventBrokerTests.swift
@@ -46,7 +46,8 @@ import OmniWMIPC
         )
 
         var iterator = stream.makeAsyncIterator()
-        let event = try await #require(iterator.next())
+        let nextEvent = await iterator.next()
+        let event = try #require(nextEvent)
 
         #expect(event.id == "evt-2")
         if case let .focusedWindow(payload) = event.result.payload {

--- a/Tests/OmniWMTests/IPCServerTests.swift
+++ b/Tests/OmniWMTests/IPCServerTests.swift
@@ -807,7 +807,8 @@ private func makeTestFocusEvent(id: String, title: String) -> IPCEventEnvelope {
 
         let events = await connection.eventStream()
         var iterator = events.makeAsyncIterator()
-        let initialEvent = try await #require(iterator.next())
+        let initialNextEvent = try await iterator.next()
+        let initialEvent = try #require(initialNextEvent)
         #expect(initialEvent.channel == .focus)
         if case let .focusedWindow(payload) = initialEvent.result.payload {
             #expect(payload.window?.title == "Initial Focus")
@@ -817,7 +818,8 @@ private func makeTestFocusEvent(id: String, title: String) -> IPCEventEnvelope {
 
         _ = controller.workspaceManager.setManagedFocus(updatedToken, in: workspaceId)
 
-        let event = try await #require(iterator.next())
+        let nextEvent = try await iterator.next()
+        let event = try #require(nextEvent)
         #expect(event.channel == .focus)
         #expect(event.ok)
         #expect(event.status == .success)
@@ -885,7 +887,8 @@ private func makeTestFocusEvent(id: String, title: String) -> IPCEventEnvelope {
         #expect(subscribeResponse.kind == .subscribe)
         #expect(subscribeResponse.status == .subscribed)
 
-        let event = try await #require(connection.readEvent())
+        let nextEvent = try await connection.readEvent()
+        let event = try #require(nextEvent)
         #expect(event.channel == .focus)
         #expect(event.id == bufferedEvent.id)
         if case let .focusedWindow(payload) = event.result.payload {
@@ -963,7 +966,8 @@ private func makeTestFocusEvent(id: String, title: String) -> IPCEventEnvelope {
         #expect(subscribeResponse.kind == .subscribe)
         #expect(subscribeResponse.status == .subscribed)
 
-        let initialEvent = try await #require(connection.readEvent())
+        let initialNextEvent = try await connection.readEvent()
+        let initialEvent = try #require(initialNextEvent)
         #expect(initialEvent.channel == .focus)
         if case let .focusedWindow(payload) = initialEvent.result.payload {
             #expect(payload.window?.title == "Initial Focus")
@@ -971,7 +975,8 @@ private func makeTestFocusEvent(id: String, title: String) -> IPCEventEnvelope {
             Issue.record("Expected initial focused-window payload")
         }
 
-        let liveEvent = try await #require(connection.readEvent())
+        let liveNextEvent = try await connection.readEvent()
+        let liveEvent = try #require(liveNextEvent)
         #expect(liveEvent.channel == .focus)
         #expect(liveEvent.id == bufferedEvent.id)
         if case let .focusedWindow(payload) = liveEvent.result.payload {
@@ -1015,7 +1020,8 @@ private func makeTestFocusEvent(id: String, title: String) -> IPCEventEnvelope {
         #expect(subscribeResponse.kind == .subscribe)
         #expect(subscribeResponse.status == .subscribed)
 
-        let initialEvent = try await #require(connection.readEvent())
+        let initialNextEvent = try await connection.readEvent()
+        let initialEvent = try #require(initialNextEvent)
         #expect(initialEvent.channel == .focusedMonitor)
         if case let .focusedMonitor(payload) = initialEvent.result.payload {
             #expect(payload.display?.id == "display:\(fixture.primaryMonitor.displayId)")
@@ -1026,7 +1032,8 @@ private func makeTestFocusEvent(id: String, title: String) -> IPCEventEnvelope {
 
         fixture.controller.workspaceNavigationHandler.focusMonitorCyclic(previous: false)
 
-        let event = try await #require(connection.readEvent())
+        let nextEvent = try await connection.readEvent()
+        let event = try #require(nextEvent)
         #expect(event.channel == .focusedMonitor)
         if case let .focusedMonitor(payload) = event.result.payload {
             #expect(payload.display?.id == "display:\(fixture.secondaryMonitor.displayId)")
@@ -1077,7 +1084,8 @@ private func makeTestFocusEvent(id: String, title: String) -> IPCEventEnvelope {
         let workspaceId = try #require(controller.workspaceManager.workspaceId(for: "2", createIfMissing: false))
         #expect(controller.workspaceManager.setActiveWorkspace(workspaceId, on: monitor.id))
 
-        let firstEvent = try await #require(connection.readEvent())
+        let firstNextEvent = try await connection.readEvent()
+        let firstEvent = try #require(firstNextEvent)
         #expect(firstEvent.channel == .activeWorkspace)
         if case let .activeWorkspace(payload) = firstEvent.result.payload {
             #expect(payload.workspace?.rawName == "2")
@@ -1125,9 +1133,12 @@ private func makeTestFocusEvent(id: String, title: String) -> IPCEventEnvelope {
 
         fixture.controller.workspaceNavigationHandler.focusMonitorCyclic(previous: false)
 
-        let firstEvent = try await #require(connection.readEvent())
-        let secondEvent = try await #require(connection.readEvent())
-        let thirdEvent = try await #require(connection.readEvent())
+        let firstNextEvent = try await connection.readEvent()
+        let firstEvent = try #require(firstNextEvent)
+        let secondNextEvent = try await connection.readEvent()
+        let secondEvent = try #require(secondNextEvent)
+        let thirdNextEvent = try await connection.readEvent()
+        let thirdEvent = try #require(thirdNextEvent)
 
         #expect([firstEvent.channel, secondEvent.channel, thirdEvent.channel] == [
             .activeWorkspace,
@@ -1206,7 +1217,8 @@ private func makeTestFocusEvent(id: String, title: String) -> IPCEventEnvelope {
 
         let events = await connection.eventStream()
         var iterator = events.makeAsyncIterator()
-        let initialEvent = try await #require(iterator.next())
+        let initialNextEvent = try await iterator.next()
+        let initialEvent = try #require(initialNextEvent)
         #expect(initialEvent.channel == .workspaceBar)
 
         controller.requestWorkspaceBarRefresh()
@@ -1214,7 +1226,8 @@ private func makeTestFocusEvent(id: String, title: String) -> IPCEventEnvelope {
         controller.requestWorkspaceBarRefresh()
         await controller.waitForWorkspaceBarRefreshForTests()
 
-        let event = try await #require(iterator.next())
+        let nextEvent = try await iterator.next()
+        let event = try #require(nextEvent)
         #expect(event.channel == .workspaceBar)
         #expect(event.ok)
         #expect(event.status == .success)
@@ -1286,7 +1299,8 @@ private func makeTestFocusEvent(id: String, title: String) -> IPCEventEnvelope {
 
         let events = await connection.eventStream()
         var iterator = events.makeAsyncIterator()
-        let initialEvent = try await #require(iterator.next())
+        let initialNextEvent = try await iterator.next()
+        let initialEvent = try #require(initialNextEvent)
         #expect(initialEvent.channel == .workspaceBar)
 
         controller.requestWorkspaceBarRefresh()
@@ -1294,7 +1308,8 @@ private func makeTestFocusEvent(id: String, title: String) -> IPCEventEnvelope {
         controller.requestWorkspaceBarRefresh()
         await controller.waitForWorkspaceBarRefreshForTests()
 
-        let event = try await #require(iterator.next())
+        let nextEvent = try await iterator.next()
+        let event = try #require(nextEvent)
         #expect(event.channel == .workspaceBar)
         #expect(event.ok)
         #expect(event.status == .success)


### PR DESCRIPTION
## Summary

This PR fixes two small but user-visible maintenance issues and one test-suite compatibility problem with current Swift tooling:

- fix `AppCLIManager` home-directory detection so sibling paths are not treated as inside `HOME`
- refactor `CLICompletionGenerator.fishScript()` assembly to avoid Swift 6.2 type-check timeouts
- update async IPC tests to avoid wrapping mutating iterators and actor-isolated calls directly in `#require(...)`

## Details

### AppCLIManager

`AppCLIManager` previously used path-string prefix matching to decide whether a PATH entry belonged to the user's home directory. That can produce false positives for sibling paths with a shared prefix.

This change switches the check to normalized path component comparison and adds a regression test covering the prefix-collision case.

### CLI completion generator

`CLICompletionGenerator.fishScript()` previously built one very large concatenated expression. Under Swift 6.2 this could fail with:

`the compiler is unable to type-check this expression in reasonable time`

The implementation now builds the output incrementally with `append(contentsOf:)`, preserving behavior while avoiding the compiler timeout.

### IPC tests

Several tests used `#require(iterator.next())` or `#require(connection.readEvent())` directly.

That pattern breaks with current `swift-testing` macro expansion when the expression is:
- mutating, such as `AsyncIteratorProtocol.next()`
- actor-isolated and throwing, such as `connection.readEvent()`

The tests now first await the value and then pass the resulting optional into `#require(...)`, which matches the framework's expected usage and restores test-target compilation.

## Testing

- `swift build --target OmniWMCtl`
- `swift build --target OmniWM`
- `swift test --filter AppCLIManagerTests`
- `swift test --filter CLICompletionGeneratorTests`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved path comparison logic for CLI installation to use structured component matching instead of string prefix checks.
  * Refactored fish completion script generation for better code clarity.

* **Tests**
  * Added test coverage for CLI installation behavior with path directories sharing home prefix naming.
  * Enhanced test structure for event handling assertions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->