### PR TITLE
fix(ax): admit windows on activation when CGS create event is missing

### DIFF
--- a/Sources/OmniWM/Core/Controller/AXEventHandler.swift
+++ b/Sources/OmniWM/Core/Controller/AXEventHandler.swift
@@ -925,6 +925,41 @@ final class AXEventHandler: CGSEventDelegate {
             )
             return
         }
+
+        // Some apps (e.g. WeChat) close windows via NSWindow.orderOut and reopen via
+        // orderFront, which produces no kCGSpaceWindowCreated event. Activation is then
+        // the only signal that a manageable window exists, so attempt admission here
+        // before falling back to the unmanaged path.
+        processCreatedWindow(windowId: UInt32(axRef.windowId))
+        if let admittedEntry = controller.workspaceManager.entry(for: token) {
+            if appFullscreen {
+                suspendManagedWindowForNativeFullscreen(admittedEntry)
+                return
+            }
+            _ = restoreManagedWindowFromNativeFullscreen(admittedEntry)
+            let wsId = admittedEntry.workspaceId
+            let targetMonitor = controller.workspaceManager.monitor(for: wsId)
+            let isWorkspaceActive = targetMonitor.map { monitor in
+                controller.workspaceManager.activeWorkspace(on: monitor.id)?.id == wsId
+            } ?? false
+            applyActivationObservation(
+                source: source,
+                origin: origin,
+                match: .managed(
+                    token: admittedEntry.token,
+                    workspaceId: wsId,
+                    monitorId: targetMonitor?.id,
+                    isWorkspaceActive: isWorkspaceActive,
+                    appFullscreen: appFullscreen,
+                    requiresNativeFullscreenRestoreRelayout: controller.workspaceManager
+                        .nativeFullscreenRestoreContext(for: admittedEntry.token) != nil
+                ),
+                observedAXRef: axRef,
+                managedEntry: admittedEntry
+            )
+            return
+        }
+
         applyActivationObservation(
             source: source,
             origin: origin,

--- a/Tests/OmniWMTests/AXEventHandlerTests.swift
+++ b/Tests/OmniWMTests/AXEventHandlerTests.swift
@@ -1134,6 +1134,111 @@ private func waitUntilAXEventTest(
         #expect(controller.workspaceManager.isNonManagedFocusActive == false)
     }
 
+    @Test @MainActor func activationAdmitsManageableWindowMissedByCreateEvent() async {
+        let controller = makeAXEventTestController(trackedBundleId: "com.example.orderfront")
+        controller.hasStartedServices = true
+        guard let workspaceId = controller.activeWorkspace()?.id,
+              let monitor = controller.workspaceManager.monitors.first
+        else {
+            Issue.record("Missing active workspace fixture")
+            return
+        }
+
+        let sourceToken = controller.workspaceManager.addWindow(
+            AXWindowRef(element: AXUIElementCreateSystemWide(), windowId: 901),
+            pid: 9_001,
+            windowId: 901,
+            to: workspaceId
+        )
+        _ = controller.workspaceManager.setManagedFocus(
+            sourceToken,
+            in: workspaceId,
+            onMonitor: monitor.id
+        )
+
+        let targetPid: pid_t = 9_902
+        let targetWindowId: UInt32 = 902
+        controller.axEventHandler.isFullscreenProvider = { _ in false }
+        controller.axEventHandler.focusedWindowRefProvider = { pid in
+            guard pid == targetPid else { return nil }
+            return AXWindowRef(element: AXUIElementCreateSystemWide(), windowId: Int(targetWindowId))
+        }
+        controller.axEventHandler.windowInfoProvider = { windowId in
+            guard windowId == targetWindowId else { return nil }
+            return WindowServerInfo(id: windowId, pid: targetPid, level: 0, frame: .zero)
+        }
+        controller.axEventHandler.axWindowRefProvider = { windowId, _ in
+            AXWindowRef(element: AXUIElementCreateSystemWide(), windowId: Int(windowId))
+        }
+        controller.axEventHandler.windowFactsProvider = { _, _ in
+            makeAXEventWindowRuleFacts(bundleId: "com.example.orderfront")
+        }
+
+        // Sanity: target has no entry yet — would be admitted only via the
+        // create-event path that orderOut/orderFront apps (e.g. WeChat) skip.
+        #expect(controller.workspaceManager.entry(forPid: targetPid, windowId: Int(targetWindowId)) == nil)
+
+        controller.axEventHandler.handleAppActivation(
+            pid: targetPid,
+            source: .workspaceDidActivateApplication
+        )
+        await controller.layoutRefreshController.waitForRefreshWorkForTests()
+
+        let admitted = controller.workspaceManager.entry(forPid: targetPid, windowId: Int(targetWindowId))
+        #expect(admitted?.mode == .tiling)
+        #expect(controller.workspaceManager.focusedToken == admitted?.token)
+        #expect(controller.workspaceManager.isNonManagedFocusActive == false)
+    }
+
+    @Test @MainActor func activationFallsBackToNonManagedWhenRecoveryAdmissionFails() async {
+        let controller = makeAXEventTestController(trackedBundleId: "com.example.orderfront")
+        controller.hasStartedServices = true
+        guard let workspaceId = controller.activeWorkspace()?.id,
+              let monitor = controller.workspaceManager.monitors.first
+        else {
+            Issue.record("Missing active workspace fixture")
+            return
+        }
+
+        let sourceToken = controller.workspaceManager.addWindow(
+            AXWindowRef(element: AXUIElementCreateSystemWide(), windowId: 911),
+            pid: 9_011,
+            windowId: 911,
+            to: workspaceId
+        )
+        _ = controller.workspaceManager.setManagedFocus(
+            sourceToken,
+            in: workspaceId,
+            onMonitor: monitor.id
+        )
+
+        let targetPid: pid_t = 9_912
+        let targetWindowId: UInt32 = 912
+        controller.axEventHandler.isFullscreenProvider = { _ in false }
+        controller.axEventHandler.focusedWindowRefProvider = { pid in
+            guard pid == targetPid else { return nil }
+            return AXWindowRef(element: AXUIElementCreateSystemWide(), windowId: Int(targetWindowId))
+        }
+        // Omit windowInfoProvider so prepareCreateCandidate cannot build a token
+        // and admission inside handleAppActivation's recovery branch must bail
+        // out, exercising the fall-through to the original .unmanaged path.
+        controller.axEventHandler.axWindowRefProvider = { windowId, _ in
+            AXWindowRef(element: AXUIElementCreateSystemWide(), windowId: Int(windowId))
+        }
+        controller.axEventHandler.windowFactsProvider = { _, _ in
+            makeAXEventWindowRuleFacts(bundleId: "com.example.orderfront")
+        }
+
+        controller.axEventHandler.handleAppActivation(
+            pid: targetPid,
+            source: .workspaceDidActivateApplication
+        )
+        await controller.layoutRefreshController.waitForRefreshWorkForTests()
+
+        #expect(controller.workspaceManager.entry(forPid: targetPid, windowId: Int(targetWindowId)) == nil)
+        #expect(controller.workspaceManager.isNonManagedFocusActive == true)
+    }
+
     @Test @MainActor func frontingProbeRetriesUntilFocusedWindowMatchesPendingRequest() async {
         var focusedWindows: [(pid_t, UInt32)] = []
         let operations = WindowFocusOperations(


### PR DESCRIPTION
> **Disclosure:** This PR was prepared with the help of an AI coding agent (Claude). I (the submitter) verified the fix manually on my own machine — see the Verification section below. If anything in the diagnosis, the patch, or the tests looks off, please feel free to close this PR without ceremony; I won't take it personally.

## Problem

Some apps — most reliably WeChat (`com.tencent.xinWeChat`), but also Finder and System Settings in some lifecycles — never become managed by OmniWM. Their borders render correctly (the eligibility path independently resolves their AX ref), but they don't appear in `omniwmctl query windows` and the workspace manager has no entry for them.

Diagnosed live with the existing IPC tooling:

- `omniwmctl query focused-window-decision` on the focused WeChat window returned `disposition=managed`, `admissionOutcome=tracked-tiling`, `attributeFetchSucceeded=true`, `axRole=AXWindow` / `axSubrole=AXStandardWindow`, `heuristicReasons=[]` — i.e. the rule engine, evaluated on demand, says "this should be managed".
- `omniwmctl query reconcile-debug` showed only `non_managed_focus_changed active=true` for that pid on every focus switch, and **no `window_admitted` event ever**.

So the rule engine is fine; the problem is that admission is never attempted. The trigger is that WeChat closes its windows via `NSWindow.orderOut` and reopens via `orderFront` (no new window object), which produces no `kCGSpaceWindowCreated`. The window's prior entry may also have been cleared earlier by a stray `kAXUIElementDestroyedNotification`. Once that happens, OmniWM's only window-discovery entry point (`handleCGSWindowCreated` → `processCreatedWindow`) never fires again for that window.

`AXEventHandler.handleAppActivation` does see the activation, resolves a valid `axRef`, finds no entry, and falls straight through to `applyActivationObservation(match: .unmanaged(...))` — describing the state without doing anything to fix it.

## Fix

Insert a recovery branch in `handleAppActivation` immediately before the `.unmanaged` fallback, mirroring the existing native-fullscreen restore branch pattern:

```swift
processCreatedWindow(windowId: UInt32(axRef.windowId))
if let admittedEntry = controller.workspaceManager.entry(for: token) {
    // ... route through the standard managed-activation branch
    return
}
// otherwise fall through to .unmanaged unchanged
```

Reusing `processCreatedWindow` (rather than open-coding admission) keeps owned-window checks, rule evaluation, retry scheduling, and managed-replacement burst handling in one place. The function is idempotent for already-tracked windows (early-out at `prepareCreateCandidate` when `workspaceManager.entry(for: token) != nil`), so calling it on every activation is safe and the existing `.unmanaged` fallback still runs unchanged when admission doesn't succeed (e.g. discovery in progress, no window info from CGS, owned window).

No throttling is added — `processCreatedWindow` only runs work when there's a candidate, and activations are user-driven so the rate is bounded.

## Tests

Two new cases in `Tests/OmniWMTests/AXEventHandlerTests.swift` directly exercise the new branch:

- `activationAdmitsManageableWindowMissedByCreateEvent` — pid has no entry, focused AX ref + window-server info + facts all indicate a manageable window. After activation, the window is admitted as tiling, becomes the focused token, and `isNonManagedFocusActive` is false. This is the WeChat-style scenario.
- `activationFallsBackToNonManagedWhenRecoveryAdmissionFails` — same setup but no `windowInfoProvider`, so `prepareCreateCandidate` returns nil and the recovery branch leaves the workspace manager untouched. The original `.unmanaged` fallback still runs and `isNonManagedFocusActive` flips to true. This guards the existing behavior.

Both new cases pass.

> **Note on the existing suite:** `swift test --filter AXEventHandlerTests` reports 3 pre-existing failures on my machine (`sameAppNewWindowCreateDefersAppActivationUntilAuthoritativeFocusConfirmation`, `frameChangedBurstCoalescesToSingleRelayout`, `interactiveGestureSuppresssFrameChangedRelayoutButKeepsBorderPath`) — they fail identically when this PR's diff is stashed, so they are unrelated to this change. Happy to investigate them in a separate PR if useful, but didn't want to entangle them here.

## Verification

Built locally and replaced the prod binary in a copy of `OmniWM.app` (separate bundle ID for TCC isolation). With WeChat launched and a window opened/closed/reopened:

- `omniwmctl query windows` now lists `com.tencent.xinWeChat pid=57745 windowId=1873 mode=tiling`
- `omniwmctl query reconcile-debug` shows `event=window_admitted token=WindowToken(pid: 57745, windowId: 1873) … phase=tiled` — i.e. admission is happening through the new path
- Side benefit: Finder and System Settings, which were also silently missed before, are now picked up

## Files changed

- `Sources/OmniWM/Core/Controller/AXEventHandler.swift` — only `handleAppActivation` is touched; the inserted block mirrors the native-fullscreen restore branch immediately above it
- `Tests/OmniWMTests/AXEventHandlerTests.swift` — two new `@Test` cases (positive + fallback)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Windows previously missed during creation are now automatically admitted for management when their applications are activated.
  * Improved handling of native fullscreen transitions for managed windows.

* **Tests**
  * Added test cases validating window admission behavior during app activation and fallback scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->