### PR TITLE
Phase 01 slice 1: authoritative transaction path skeleton

### DIFF
--- a/Sources/OmniWM/Core/Controller/WorkspaceNavigationHandler.swift
+++ b/Sources/OmniWM/Core/Controller/WorkspaceNavigationHandler.swift
@@ -86,7 +86,11 @@ final class WorkspaceNavigationHandler {
         )
     }
 
-    private func clearManagedFocusAfterEmptyWorkspaceTransition() {
+    // Internal so `WMLiveEffectPlatform` can invoke it when the
+    // `.clearManagedFocusAfterEmptyWorkspaceTransition` post-action
+    // fires on `commitWorkspaceTransition`. Ownership of this behavior
+    // moves into the transaction path in a later Phase 01 slice.
+    func clearManagedFocusAfterEmptyWorkspaceTransition() {
         guard let controller else { return }
         let canceledRequest = controller.focusBridge.cancelManagedRequest()
         if let canceledRequest {
@@ -617,6 +621,17 @@ final class WorkspaceNavigationHandler {
 
     func switchWorkspace(rawWorkspaceID: String) {
         guard let controller else { return }
+        if let runtime = controller.runtime {
+            runtime.submit(
+                command: .workspaceSwitch(.explicit(rawWorkspaceID: rawWorkspaceID))
+            )
+            return
+        }
+        // Pre-transaction-path fallback: construct and apply the
+        // switch plan directly. Kept for tests that instantiate
+        // `WMController` without attaching a `WMRuntime`; production
+        // always has a runtime present. Remove once the remaining
+        // direct-mutation callers migrate.
         guard let plan = plan(
             .init(
                 operation: .switchWorkspaceExplicit,
@@ -631,6 +646,12 @@ final class WorkspaceNavigationHandler {
 
     func switchWorkspaceRelative(isNext: Bool, wrapAround: Bool = true) {
         guard let controller else { return }
+        if let runtime = controller.runtime {
+            runtime.submit(
+                command: .workspaceSwitch(.relative(isNext: isNext, wrapAround: wrapAround))
+            )
+            return
+        }
         guard let plan = plan(
             .init(
                 operation: .switchWorkspaceRelative,

--- a/Sources/OmniWM/Core/Reconcile/ReconcileTxn.swift
+++ b/Sources/OmniWM/Core/Reconcile/ReconcileTxn.swift
@@ -13,4 +13,28 @@ struct ReconcileTxn: Equatable {
     let plan: ActionPlan
     let snapshot: ReconcileSnapshot
     let invariantViolations: [ReconcileInvariantViolation]
+    // Transaction epoch stamped by the authoritative transaction
+    // entrypoint. `.invalid` indicates the txn was produced by a
+    // direct-mutation path that has not yet been migrated to
+    // `WMRuntime.submit(...)` — see `docs/RELIABILITY-MIGRATION.md` for
+    // the open inventory.
+    let transactionEpoch: TransactionEpoch
+
+    init(
+        timestamp: Date,
+        event: WMEvent,
+        normalizedEvent: WMEvent,
+        plan: ActionPlan,
+        snapshot: ReconcileSnapshot,
+        invariantViolations: [ReconcileInvariantViolation],
+        transactionEpoch: TransactionEpoch = .invalid
+    ) {
+        self.timestamp = timestamp
+        self.event = event
+        self.normalizedEvent = normalizedEvent
+        self.plan = plan
+        self.snapshot = snapshot
+        self.invariantViolations = invariantViolations
+        self.transactionEpoch = transactionEpoch
+    }
 }

--- a/Sources/OmniWM/Core/Reconcile/RuntimeStore.swift
+++ b/Sources/OmniWM/Core/Reconcile/RuntimeStore.swift
@@ -20,6 +20,7 @@ final class RuntimeStore {
         existingEntry: WindowModel.Entry?,
         monitors: [Monitor],
         persistedHydration: PersistedHydrationMutation? = nil,
+        transactionEpoch: TransactionEpoch = .invalid,
         snapshot: () -> ReconcileSnapshot,
         applyPlan: (ActionPlan, WindowToken?) -> ActionPlan
     ) -> ReconcileTxn {
@@ -41,7 +42,8 @@ final class RuntimeStore {
             event: event,
             normalizedEvent: normalizedEvent,
             plan: resolvedPlan,
-            snapshot: snapshot()
+            snapshot: snapshot(),
+            transactionEpoch: transactionEpoch
         )
     }
 
@@ -50,7 +52,8 @@ final class RuntimeStore {
         event: WMEvent,
         normalizedEvent: WMEvent? = nil,
         plan: ActionPlan,
-        snapshot: ReconcileSnapshot
+        snapshot: ReconcileSnapshot,
+        transactionEpoch: TransactionEpoch = .invalid
     ) -> ReconcileTxn {
         let invariantViolations = InvariantChecks.validate(snapshot: snapshot)
         return ReconcileTxn(
@@ -59,7 +62,8 @@ final class RuntimeStore {
             normalizedEvent: normalizedEvent ?? event,
             plan: plan,
             snapshot: snapshot,
-            invariantViolations: invariantViolations
+            invariantViolations: invariantViolations,
+            transactionEpoch: transactionEpoch
         )
     }
 }

--- a/Sources/OmniWM/Core/Runtime/TransactionEpoch.swift
+++ b/Sources/OmniWM/Core/Runtime/TransactionEpoch.swift
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: GPL-2.0-only
+import Foundation
+
+// Monotonic, process-scoped identifier assigned by `WMRuntime` to every
+// transaction produced through the authoritative transaction entrypoint.
+// Carried on `ReconcileTxn` and on any `WMEffectPlan` emitted by that
+// transaction so downstream effect runners and confirmation events can tell
+// which transaction they belong to. Used by `WMEffectRunner` to reject
+// confirmations whose transaction has been superseded.
+//
+// Epochs start at 1; `.invalid` (0) is reserved for fixtures and for
+// transactions that have not been stamped yet.
+struct TransactionEpoch: Hashable, Comparable, Sendable, CustomStringConvertible {
+    let value: UInt64
+
+    static let invalid = TransactionEpoch(value: 0)
+
+    init(value: UInt64) {
+        self.value = value
+    }
+
+    var isValid: Bool {
+        value != 0
+    }
+
+    static func < (lhs: TransactionEpoch, rhs: TransactionEpoch) -> Bool {
+        lhs.value < rhs.value
+    }
+
+    var description: String {
+        "txn#\(value)"
+    }
+}
+
+// Monotonic, process-scoped identifier assigned to each `WMEffect` produced
+// by the runtime. Unique across all plans emitted by a single runtime.
+// Confirmation events reference the originating effect epoch so the runner
+// can drop stale confirmations after the corresponding effect has been
+// superseded.
+struct EffectEpoch: Hashable, Comparable, Sendable, CustomStringConvertible {
+    let value: UInt64
+
+    static let invalid = EffectEpoch(value: 0)
+
+    init(value: UInt64) {
+        self.value = value
+    }
+
+    var isValid: Bool {
+        value != 0
+    }
+
+    static func < (lhs: EffectEpoch, rhs: EffectEpoch) -> Bool {
+        lhs.value < rhs.value
+    }
+
+    var description: String {
+        "fx#\(value)"
+    }
+}

--- a/Sources/OmniWM/Core/Runtime/WMCommand.swift
+++ b/Sources/OmniWM/Core/Runtime/WMCommand.swift
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: GPL-2.0-only
+import Foundation
+
+// Handler-originated command submitted into the authoritative transaction
+// path via `WMRuntime.submit(command:)`. Distinct from observation-flavored
+// `WMEvent` cases, which describe things the OS has already reported.
+//
+// Commands are translated by the runtime into a transaction record plus a
+// `WMEffectPlan`. The runtime's effect runner applies the plan in order,
+// stamped with the transaction's epoch.
+//
+// Only subsystems that have been migrated to the transaction entrypoint
+// should construct `WMCommand` values. Phase 01 Milestone A scope:
+// workspace-switch paths only (see `docs/RELIABILITY-MIGRATION.md`).
+enum WMCommand: Equatable {
+    case workspaceSwitch(WorkspaceSwitchCommand)
+}
+
+extension WMCommand {
+    enum WorkspaceSwitchCommand: Equatable {
+        // Explicit switch by raw workspace identifier (e.g. "1", "2", ...).
+        case explicit(rawWorkspaceID: String)
+        // Relative switch along the workspace ordering.
+        case relative(isNext: Bool, wrapAround: Bool)
+    }
+}
+
+extension WMCommand {
+    var summary: String {
+        switch self {
+        case let .workspaceSwitch(.explicit(rawId)):
+            "workspace_switch_explicit raw=\(rawId)"
+        case let .workspaceSwitch(.relative(isNext, wrapAround)):
+            "workspace_switch_relative next=\(isNext) wrap=\(wrapAround)"
+        }
+    }
+}

--- a/Sources/OmniWM/Core/Runtime/WMEffect.swift
+++ b/Sources/OmniWM/Core/Runtime/WMEffect.swift
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: GPL-2.0-only
+import Foundation
+
+// One platform/effect instruction produced by the authoritative transaction
+// path and consumed by `WMEffectRunner`.
+//
+// Effects are side-effect-only: they do not directly mutate durable WM state
+// inside the runtime's state model. State mutations routed into existing
+// `WorkspaceManager` APIs are a transitional compatibility step for Phase 01
+// Milestone A; later phases narrow the interface further so the transaction
+// executor owns the durable projection directly (see
+// `docs/RELIABILITY-MIGRATION.md`).
+//
+// Every effect carries an `EffectEpoch` so the runner can reject confirmations
+// that reference a superseded effect. Plans carry the originating
+// `TransactionEpoch`; effect epochs are monotonic across plans.
+enum WMEffect: Equatable {
+    case hideKeyboardFocusBorder(
+        reason: String,
+        epoch: EffectEpoch
+    )
+    case saveWorkspaceViewports(
+        workspaceIds: [WorkspaceDescriptor.ID],
+        epoch: EffectEpoch
+    )
+    case activateTargetWorkspace(
+        workspaceId: WorkspaceDescriptor.ID,
+        monitorId: Monitor.ID,
+        epoch: EffectEpoch
+    )
+    case setInteractionMonitor(
+        monitorId: Monitor.ID,
+        epoch: EffectEpoch
+    )
+    case syncMonitorsToNiri(epoch: EffectEpoch)
+    case stopScrollAnimation(
+        monitorId: Monitor.ID,
+        epoch: EffectEpoch
+    )
+    case applyWorkspaceSessionPatch(
+        workspaceId: WorkspaceDescriptor.ID,
+        rememberedFocusToken: WindowToken?,
+        epoch: EffectEpoch
+    )
+    case commitWorkspaceTransition(
+        affectedWorkspaceIds: Set<WorkspaceDescriptor.ID>,
+        postAction: PostWorkspaceTransitionAction,
+        epoch: EffectEpoch
+    )
+
+    // Declarative post-commit follow-up for `.commitWorkspaceTransition`.
+    // The runner translates this into the layout-refresh `postLayout`
+    // closure so the plan itself remains closure-free and inspectable by
+    // transcript tests.
+    enum PostWorkspaceTransitionAction: Equatable {
+        case none
+        case focusWindow(WindowToken)
+        case clearManagedFocusAfterEmptyWorkspaceTransition
+    }
+
+    var epoch: EffectEpoch {
+        switch self {
+        case let .hideKeyboardFocusBorder(_, epoch),
+             let .saveWorkspaceViewports(_, epoch),
+             let .activateTargetWorkspace(_, _, epoch),
+             let .setInteractionMonitor(_, epoch),
+             let .syncMonitorsToNiri(epoch),
+             let .stopScrollAnimation(_, epoch),
+             let .applyWorkspaceSessionPatch(_, _, epoch),
+             let .commitWorkspaceTransition(_, _, epoch):
+            epoch
+        }
+    }
+
+    var kind: String {
+        switch self {
+        case .hideKeyboardFocusBorder: "hide_keyboard_focus_border"
+        case .saveWorkspaceViewports: "save_workspace_viewports"
+        case .activateTargetWorkspace: "activate_target_workspace"
+        case .setInteractionMonitor: "set_interaction_monitor"
+        case .syncMonitorsToNiri: "sync_monitors_to_niri"
+        case .stopScrollAnimation: "stop_scroll_animation"
+        case .applyWorkspaceSessionPatch: "apply_workspace_session_patch"
+        case .commitWorkspaceTransition: "commit_workspace_transition"
+        }
+    }
+}

--- a/Sources/OmniWM/Core/Runtime/WMEffectPlan.swift
+++ b/Sources/OmniWM/Core/Runtime/WMEffectPlan.swift
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: GPL-2.0-only
+import Foundation
+
+// Ordered, inspectable effect plan produced by the authoritative transaction
+// path. Stamped with the `TransactionEpoch` of the transaction that emitted
+// it; individual effects carry their own `EffectEpoch` (monotonic across
+// plans, owned by `WMRuntime`).
+//
+// `WMEffectPlan` does NOT carry `nextEffectEpoch` or any closures. Effect
+// epoch allocation lives on the runtime/transaction side; post-effect
+// follow-ups are modeled declaratively on `WMEffect` so a plan can be
+// serialized, diffed, and replayed by transcript tests.
+struct WMEffectPlan: Equatable {
+    let transactionEpoch: TransactionEpoch
+    let effects: [WMEffect]
+
+    static let empty = WMEffectPlan(
+        transactionEpoch: .invalid,
+        effects: []
+    )
+
+    var isEmpty: Bool { effects.isEmpty }
+
+    init(
+        transactionEpoch: TransactionEpoch,
+        effects: [WMEffect]
+    ) {
+        self.transactionEpoch = transactionEpoch
+        self.effects = effects
+    }
+
+    var summary: String {
+        if effects.isEmpty {
+            return "plan \(transactionEpoch) empty"
+        }
+        let joined = effects
+            .map { "\($0.kind)@\($0.epoch.value)" }
+            .joined(separator: ",")
+        return "plan \(transactionEpoch) effects=[\(joined)]"
+    }
+}

--- a/Sources/OmniWM/Core/Runtime/WMEffectRunner.swift
+++ b/Sources/OmniWM/Core/Runtime/WMEffectRunner.swift
@@ -1,0 +1,220 @@
+// SPDX-License-Identifier: GPL-2.0-only
+import Foundation
+import OSLog
+
+// Runtime-owned serial executor for `WMEffectPlan`s.
+//
+// Responsibilities:
+// - Apply effects in order, on the main actor.
+// - Reject entire plans whose `transactionEpoch` has been superseded
+//   (`highestObservedTransactionEpoch`).
+// - Route `commitWorkspaceTransition` post-layout firings as declarative
+//   follow-ups, and drop post-layout firings whose effect/transaction epoch
+//   has been superseded by a newer plan.
+//
+// For Phase 01 Milestone A the runner serves as a compatibility queue:
+// its effect handlers delegate to existing services. Later phases tighten
+// the contract (e.g. promoting post-layout firings into explicit
+// confirmation `WMEvent`s that flow through the transaction path).
+@MainActor
+protocol WMEffectPlatform: AnyObject {
+    func hideKeyboardFocusBorder(reason: String)
+    func saveWorkspaceViewport(for workspaceId: WorkspaceDescriptor.ID)
+    @discardableResult
+    func activateTargetWorkspace(
+        workspaceId: WorkspaceDescriptor.ID,
+        monitorId: Monitor.ID
+    ) -> Bool
+    func setInteractionMonitor(monitorId: Monitor.ID)
+    func syncMonitorsToNiri()
+    func stopScrollAnimation(monitorId: Monitor.ID)
+    func applyWorkspaceSessionPatch(
+        workspaceId: WorkspaceDescriptor.ID,
+        rememberedFocusToken: WindowToken?
+    )
+    func commitWorkspaceTransition(
+        affectedWorkspaceIds: Set<WorkspaceDescriptor.ID>,
+        postAction: @escaping @MainActor () -> Void
+    )
+    func focusWindow(_ token: WindowToken)
+    func clearManagedFocusAfterEmptyWorkspaceTransition()
+}
+
+@MainActor
+final class WMEffectRunner {
+    struct ApplyOutcome: Equatable {
+        // The effects the runner invoked, in order.
+        var appliedEffects: [WMEffect]
+        // Rejected effects paired with the reason they were dropped.
+        var rejectedEffects: [Rejection]
+        // Non-nil when the runner stopped applying effects early because a
+        // required prerequisite returned failure (e.g. activating the
+        // target workspace).
+        var haltReason: HaltReason?
+
+        struct Rejection: Equatable {
+            let effect: WMEffect
+            let reason: RejectionReason
+        }
+
+        enum RejectionReason: Equatable {
+            case planSuperseded
+            case planEmpty
+        }
+
+        enum HaltReason: Equatable {
+            case activateTargetWorkspaceFailed(
+                workspaceId: WorkspaceDescriptor.ID,
+                monitorId: Monitor.ID
+            )
+        }
+    }
+
+    private let platform: WMEffectPlatform
+    private let log = Logger(subsystem: "com.omniwm.core", category: "WMEffectRunner")
+
+    // High-water mark of transaction epochs the runner has accepted. Any
+    // plan whose `transactionEpoch` is strictly less than this is rejected
+    // as superseded.
+    private(set) var highestAcceptedTransactionEpoch: TransactionEpoch = .invalid
+
+    init(platform: WMEffectPlatform) {
+        self.platform = platform
+    }
+
+    @discardableResult
+    func apply(_ plan: WMEffectPlan) -> ApplyOutcome {
+        if plan.isEmpty {
+            return .init(
+                appliedEffects: [],
+                rejectedEffects: [],
+                haltReason: nil
+            )
+        }
+
+        if plan.transactionEpoch < highestAcceptedTransactionEpoch {
+            let txnValue = plan.transactionEpoch.value
+            let highValue = highestAcceptedTransactionEpoch.value
+            let effectCount = plan.effects.count
+            log.debug("plan_superseded txn=\(txnValue) high=\(highValue) effects=\(effectCount)")
+            return .init(
+                appliedEffects: [],
+                rejectedEffects: plan.effects.map {
+                    .init(effect: $0, reason: .planSuperseded)
+                },
+                haltReason: nil
+            )
+        }
+
+        highestAcceptedTransactionEpoch = plan.transactionEpoch
+
+        var applied: [WMEffect] = []
+        var halt: ApplyOutcome.HaltReason?
+        applied.reserveCapacity(plan.effects.count)
+
+        for effect in plan.effects {
+            if let reason = invoke(effect, transactionEpoch: plan.transactionEpoch) {
+                halt = reason
+                applied.append(effect)
+                break
+            }
+            applied.append(effect)
+        }
+
+        return .init(
+            appliedEffects: applied,
+            rejectedEffects: [],
+            haltReason: halt
+        )
+    }
+
+    // Returns a halt reason iff the effect short-circuits the plan.
+    private func invoke(
+        _ effect: WMEffect,
+        transactionEpoch: TransactionEpoch
+    ) -> ApplyOutcome.HaltReason? {
+        switch effect {
+        case let .hideKeyboardFocusBorder(reason, _):
+            platform.hideKeyboardFocusBorder(reason: reason)
+            return nil
+
+        case let .saveWorkspaceViewports(workspaceIds, _):
+            for workspaceId in workspaceIds {
+                platform.saveWorkspaceViewport(for: workspaceId)
+            }
+            return nil
+
+        case let .activateTargetWorkspace(workspaceId, monitorId, _):
+            let activated = platform.activateTargetWorkspace(
+                workspaceId: workspaceId,
+                monitorId: monitorId
+            )
+            if !activated {
+                return .activateTargetWorkspaceFailed(
+                    workspaceId: workspaceId,
+                    monitorId: monitorId
+                )
+            }
+            return nil
+
+        case let .setInteractionMonitor(monitorId, _):
+            platform.setInteractionMonitor(monitorId: monitorId)
+            return nil
+
+        case .syncMonitorsToNiri:
+            platform.syncMonitorsToNiri()
+            return nil
+
+        case let .stopScrollAnimation(monitorId, _):
+            platform.stopScrollAnimation(monitorId: monitorId)
+            return nil
+
+        case let .applyWorkspaceSessionPatch(workspaceId, rememberedFocusToken, _):
+            platform.applyWorkspaceSessionPatch(
+                workspaceId: workspaceId,
+                rememberedFocusToken: rememberedFocusToken
+            )
+            return nil
+
+        case let .commitWorkspaceTransition(affectedWorkspaceIds, postAction, effectEpoch):
+            platform.commitWorkspaceTransition(
+                affectedWorkspaceIds: affectedWorkspaceIds
+            ) { [weak self] in
+                self?.runPostCommitAction(
+                    postAction,
+                    effectEpoch: effectEpoch,
+                    transactionEpoch: transactionEpoch
+                )
+            }
+            return nil
+        }
+    }
+
+    // Called once the layout-refresh post-layout closure fires. Drops the
+    // declared post-action if a newer transaction has been committed since
+    // this effect was issued.
+    private func runPostCommitAction(
+        _ action: WMEffect.PostWorkspaceTransitionAction,
+        effectEpoch: EffectEpoch,
+        transactionEpoch: TransactionEpoch
+    ) {
+        guard transactionEpoch >= highestAcceptedTransactionEpoch else {
+            let fxValue = effectEpoch.value
+            let txnValue = transactionEpoch.value
+            let highValue = highestAcceptedTransactionEpoch.value
+            log.debug("post_commit_superseded fx=\(fxValue) txn=\(txnValue) high=\(highValue)")
+            return
+        }
+
+        switch action {
+        case .none:
+            return
+
+        case let .focusWindow(token):
+            platform.focusWindow(token)
+
+        case .clearManagedFocusAfterEmptyWorkspaceTransition:
+            platform.clearManagedFocusAfterEmptyWorkspaceTransition()
+        }
+    }
+}

--- a/Sources/OmniWM/Core/Runtime/WMLiveEffectPlatform.swift
+++ b/Sources/OmniWM/Core/Runtime/WMLiveEffectPlatform.swift
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: GPL-2.0-only
+import Foundation
+
+// Live implementation of `WMEffectPlatform` that delegates to the existing
+// controller + workspace-manager surface.
+//
+// Phase 01 Milestone A keeps this adapter thin: effects reuse the same
+// primitives handlers called directly before the transaction path existed,
+// so that migrating a handler is purely a boundary change. Later phases
+// will narrow the surface further by promoting intermediate observations
+// into confirmation `WMEvent`s.
+@MainActor
+final class WMLiveEffectPlatform: WMEffectPlatform {
+    private weak var controller: WMController?
+
+    init(controller: WMController) {
+        self.controller = controller
+    }
+
+    func hideKeyboardFocusBorder(reason: String) {
+        controller?.hideKeyboardFocusBorder(
+            source: .workspaceActivation,
+            reason: reason
+        )
+    }
+
+    func saveWorkspaceViewport(for workspaceId: WorkspaceDescriptor.ID) {
+        controller?.workspaceNavigationHandler.saveNiriViewportState(for: workspaceId)
+    }
+
+    @discardableResult
+    func activateTargetWorkspace(
+        workspaceId: WorkspaceDescriptor.ID,
+        monitorId: Monitor.ID
+    ) -> Bool {
+        guard let controller else { return false }
+        return controller.workspaceManager.setActiveWorkspace(
+            workspaceId,
+            on: monitorId
+        )
+    }
+
+    func setInteractionMonitor(monitorId: Monitor.ID) {
+        _ = controller?.workspaceManager.setInteractionMonitor(monitorId)
+    }
+
+    func syncMonitorsToNiri() {
+        controller?.syncMonitorsToNiriEngine()
+    }
+
+    func stopScrollAnimation(monitorId: Monitor.ID) {
+        guard let controller,
+              let monitor = controller.workspaceManager.monitor(byId: monitorId)
+        else { return }
+        controller.layoutRefreshController.stopScrollAnimation(for: monitor.displayId)
+    }
+
+    func applyWorkspaceSessionPatch(
+        workspaceId: WorkspaceDescriptor.ID,
+        rememberedFocusToken: WindowToken?
+    ) {
+        _ = controller?.workspaceManager.applySessionPatch(
+            .init(
+                workspaceId: workspaceId,
+                viewportState: nil,
+                rememberedFocusToken: rememberedFocusToken
+            )
+        )
+    }
+
+    func commitWorkspaceTransition(
+        affectedWorkspaceIds: Set<WorkspaceDescriptor.ID>,
+        postAction: @escaping @MainActor () -> Void
+    ) {
+        controller?.layoutRefreshController.commitWorkspaceTransition(
+            affectedWorkspaces: affectedWorkspaceIds,
+            reason: .workspaceTransition,
+            postLayout: postAction
+        )
+    }
+
+    func focusWindow(_ token: WindowToken) {
+        controller?.focusWindow(token)
+    }
+
+    func clearManagedFocusAfterEmptyWorkspaceTransition() {
+        controller?.workspaceNavigationHandler.clearManagedFocusAfterEmptyWorkspaceTransition()
+    }
+}

--- a/Sources/OmniWM/Core/Runtime/WMRuntime.swift
+++ b/Sources/OmniWM/Core/Runtime/WMRuntime.swift
@@ -4,13 +4,35 @@ import Observation
 
 @MainActor @Observable
 final class WMRuntime {
+    // Result of submitting a `WMCommand` through the authoritative
+    // transaction path. `txn` is present only when the command also
+    // produced an observation-shaped reconcile transaction (none today
+    // for workspace-switch commands, which flow through downstream
+    // reconcile events emitted by the individual effects).
+    struct CommandResult {
+        let transactionEpoch: TransactionEpoch
+        let plan: WMEffectPlan
+        let applyOutcome: WMEffectRunner.ApplyOutcome
+        let txn: ReconcileTxn?
+    }
+
     let settings: SettingsStore
     let platform: WMPlatform
     let workspaceManager: WorkspaceManager
     let hiddenBarController: HiddenBarController
     let controller: WMController
-    private let effectExecutor: any EffectExecutor
+    @ObservationIgnored private let effectExecutor: any EffectExecutor
+    @ObservationIgnored private let effectRunner: WMEffectRunner
     private(set) var snapshot: WMRuntimeSnapshot
+
+    // Monotonic, process-scoped counters owned by the runtime. Kept
+    // outside `WMEffectPlan` per Phase 01 decision: the plan carries the
+    // committed transactionEpoch and individual effect epochs, but the
+    // allocator sits on the runtime so cross-plan uniqueness is
+    // guaranteed without having to propagate mutable state through the
+    // plan shape.
+    @ObservationIgnored private var nextTransactionEpochValue: UInt64 = 1
+    @ObservationIgnored private var nextEffectEpochValue: UInt64 = 1
 
     var state: WMState {
         snapshot.reconcile
@@ -33,7 +55,8 @@ final class WMRuntime {
         platform: WMPlatform = .live,
         hiddenBarController: HiddenBarController? = nil,
         windowFocusOperations: WindowFocusOperations? = nil,
-        effectExecutor: (any EffectExecutor)? = nil
+        effectExecutor: (any EffectExecutor)? = nil,
+        effectPlatform: (any WMEffectPlatform)? = nil
     ) {
         self.settings = settings
         self.platform = platform
@@ -41,14 +64,17 @@ final class WMRuntime {
         self.hiddenBarController = resolvedHiddenBarController
         let workspaceManager = WorkspaceManager(settings: settings)
         self.workspaceManager = workspaceManager
-        controller = WMController(
+        let controller = WMController(
             settings: settings,
             workspaceManager: workspaceManager,
             hiddenBarController: resolvedHiddenBarController,
             platform: platform,
             windowFocusOperations: windowFocusOperations ?? platform.windowFocusOperations
         )
+        self.controller = controller
         self.effectExecutor = effectExecutor ?? WMRuntimeEffectExecutor()
+        let resolvedEffectPlatform = effectPlatform ?? WMLiveEffectPlatform(controller: controller)
+        effectRunner = WMEffectRunner(platform: resolvedEffectPlatform)
         snapshot = WMRuntimeSnapshot(
             reconcile: workspaceManager.reconcileSnapshot(),
             orchestration: .init(
@@ -84,9 +110,70 @@ final class WMRuntime {
 
     @discardableResult
     func submit(_ event: WMEvent) -> ReconcileTxn {
-        let transaction = workspaceManager.recordReconcileEvent(event)
+        let epoch = allocateTransactionEpoch()
+        let transaction = workspaceManager.recordReconcileEvent(
+            event,
+            transactionEpoch: epoch
+        )
         refreshSnapshotState()
         return transaction
+    }
+
+    // Authoritative command entrypoint. Allocates a fresh
+    // `TransactionEpoch`, translates the command into a `WMEffectPlan`,
+    // and hands the plan to the runtime's effect runner. The runner is
+    // responsible for applying effects in order and rejecting stale
+    // confirmations by epoch.
+    //
+    // Phase 01 Milestone A: only `workspaceSwitch` commands are routed
+    // through this entrypoint. See `docs/RELIABILITY-MIGRATION.md` for
+    // the open migration list.
+    @discardableResult
+    func submit(command: WMCommand) -> CommandResult {
+        let transactionEpoch = allocateTransactionEpoch()
+        let plan = buildEffectPlan(
+            for: command,
+            transactionEpoch: transactionEpoch
+        )
+        let applyOutcome = effectRunner.apply(plan)
+        refreshSnapshotState()
+        return CommandResult(
+            transactionEpoch: transactionEpoch,
+            plan: plan,
+            applyOutcome: applyOutcome,
+            txn: nil
+        )
+    }
+
+    private func buildEffectPlan(
+        for command: WMCommand,
+        transactionEpoch: TransactionEpoch
+    ) -> WMEffectPlan {
+        switch command {
+        case let .workspaceSwitch(switchCommand):
+            return WorkspaceSwitchEffectPlanner.makePlan(
+                for: switchCommand,
+                inputs: .init(
+                    controller: controller,
+                    transactionEpoch: transactionEpoch,
+                    allocateEffectEpoch: { [weak self] in
+                        self?.allocateEffectEpoch() ?? .invalid
+                    }
+                )
+            )
+        }
+    }
+
+    private func allocateTransactionEpoch() -> TransactionEpoch {
+        let value = nextTransactionEpochValue
+        nextTransactionEpochValue &+= 1
+        return TransactionEpoch(value: value)
+    }
+
+    private func allocateEffectEpoch() -> EffectEpoch {
+        let value = nextEffectEpochValue
+        nextEffectEpochValue &+= 1
+        return EffectEpoch(value: value)
     }
 
     func requestManagedFocus(

--- a/Sources/OmniWM/Core/Runtime/WorkspaceSwitchEffectPlanner.swift
+++ b/Sources/OmniWM/Core/Runtime/WorkspaceSwitchEffectPlanner.swift
@@ -1,0 +1,224 @@
+// SPDX-License-Identifier: GPL-2.0-only
+import Foundation
+
+// Translates `WMCommand.WorkspaceSwitchCommand` values into an ordered
+// `WMEffectPlan` by consulting the pure `WorkspaceNavigationKernel`.
+//
+// The translator owns the ordering of effects (previously open-coded in
+// `WorkspaceNavigationHandler.applySwitchPlan`). By constructing it here
+// and exposing only typed effects, the transaction path is inspectable
+// and replay-testable without the handler having to run.
+@MainActor
+enum WorkspaceSwitchEffectPlanner {
+    struct Inputs {
+        let controller: WMController
+        let transactionEpoch: TransactionEpoch
+        // Supplier of fresh, monotonically-increasing `EffectEpoch`s,
+        // owned by the runtime.
+        let allocateEffectEpoch: () -> EffectEpoch
+    }
+
+    static func makePlan(
+        for command: WMCommand.WorkspaceSwitchCommand,
+        inputs: Inputs
+    ) -> WMEffectPlan {
+        let intent = makeIntent(for: command, controller: inputs.controller)
+        let kernelPlan = WorkspaceNavigationKernel.plan(
+            .capture(controller: inputs.controller, intent: intent)
+        )
+        guard kernelPlan.outcome == .execute else {
+            return WMEffectPlan(
+                transactionEpoch: inputs.transactionEpoch,
+                effects: []
+            )
+        }
+        let hideReason = hideBorderReason(for: command)
+        let effects = assembleEffects(
+            from: kernelPlan,
+            hideReason: hideReason,
+            allocateEffectEpoch: inputs.allocateEffectEpoch
+        )
+        return WMEffectPlan(
+            transactionEpoch: inputs.transactionEpoch,
+            effects: effects
+        )
+    }
+
+    private static func makeIntent(
+        for command: WMCommand.WorkspaceSwitchCommand,
+        controller: WMController
+    ) -> WorkspaceNavigationKernel.Intent {
+        switch command {
+        case let .explicit(rawWorkspaceID):
+            return .init(
+                operation: .switchWorkspaceExplicit,
+                currentWorkspaceId: controller.activeWorkspace()?.id,
+                targetWorkspaceId: controller.workspaceManager.workspaceId(
+                    for: rawWorkspaceID,
+                    createIfMissing: false
+                )
+            )
+
+        case let .relative(isNext, wrapAround):
+            return .init(
+                operation: .switchWorkspaceRelative,
+                direction: isNext ? .right : .left,
+                currentWorkspaceId: controller.activeWorkspace()?.id,
+                currentMonitorId: interactionMonitorId(for: controller),
+                wrapAround: wrapAround
+            )
+        }
+    }
+
+    private static func hideBorderReason(
+        for command: WMCommand.WorkspaceSwitchCommand
+    ) -> String {
+        switch command {
+        case .explicit:
+            "switch workspace"
+        case .relative:
+            "switch workspace relative"
+        }
+    }
+
+    private static func interactionMonitorId(
+        for controller: WMController
+    ) -> Monitor.ID? {
+        controller.workspaceManager.interactionMonitorId
+            ?? controller.monitorForInteraction()?.id
+    }
+
+    // Assemble the ordered effect list mirroring
+    // `WorkspaceNavigationHandler.applySwitchPlan`. Keeping the shape of
+    // the emitted plan identical to the legacy call order is the
+    // compatibility contract for Phase 01 Milestone A.
+    private static func assembleEffects(
+        from plan: WorkspaceNavigationKernel.Plan,
+        hideReason: String,
+        allocateEffectEpoch: () -> EffectEpoch
+    ) -> [WMEffect] {
+        var effects: [WMEffect] = []
+
+        if plan.shouldHideFocusBorder {
+            effects.append(.hideKeyboardFocusBorder(
+                reason: hideReason,
+                epoch: allocateEffectEpoch()
+            ))
+        }
+
+        if !plan.saveWorkspaceIds.isEmpty {
+            effects.append(.saveWorkspaceViewports(
+                workspaceIds: plan.saveWorkspaceIds,
+                epoch: allocateEffectEpoch()
+            ))
+        }
+
+        if let targetMonitorId = plan.targetMonitorId {
+            if plan.shouldActivateTargetWorkspace,
+               let targetWorkspaceId = plan.targetWorkspaceId
+            {
+                effects.append(.activateTargetWorkspace(
+                    workspaceId: targetWorkspaceId,
+                    monitorId: targetMonitorId,
+                    epoch: allocateEffectEpoch()
+                ))
+            } else if plan.shouldSetInteractionMonitor {
+                effects.append(.setInteractionMonitor(
+                    monitorId: targetMonitorId,
+                    epoch: allocateEffectEpoch()
+                ))
+            }
+        }
+
+        if plan.shouldSyncMonitorsToNiri {
+            effects.append(.syncMonitorsToNiri(
+                epoch: allocateEffectEpoch()
+            ))
+        }
+
+        if plan.shouldCommitWorkspaceTransition {
+            appendCommitEffects(
+                plan: plan,
+                into: &effects,
+                allocateEffectEpoch: allocateEffectEpoch
+            )
+        }
+
+        return effects
+    }
+
+    private static func appendCommitEffects(
+        plan: WorkspaceNavigationKernel.Plan,
+        into effects: inout [WMEffect],
+        allocateEffectEpoch: () -> EffectEpoch
+    ) {
+        switch plan.focusAction {
+        case .workspaceHandoff:
+            appendWorkspaceCommit(
+                plan: plan,
+                stopScrollOnTargetMonitor: true,
+                into: &effects,
+                allocateEffectEpoch: allocateEffectEpoch
+            )
+
+        case .resolveTargetIfPresent, .clearManagedFocus:
+            appendWorkspaceCommit(
+                plan: plan,
+                stopScrollOnTargetMonitor: false,
+                into: &effects,
+                allocateEffectEpoch: allocateEffectEpoch
+            )
+
+        case .subject, .recoverSource, .none:
+            // Focus actions emitted by move-window / column-transfer /
+            // miscellaneous paths are out of scope for Phase 01
+            // Milestone A (see `docs/RELIABILITY-MIGRATION.md`). These
+            // commands never reach this planner today; the branch is
+            // kept exhaustive so a future command that returns one of
+            // these actions fails loudly in review rather than being
+            // silently dropped.
+            return
+        }
+    }
+
+    private static func appendWorkspaceCommit(
+        plan: WorkspaceNavigationKernel.Plan,
+        stopScrollOnTargetMonitor: Bool,
+        into effects: inout [WMEffect],
+        allocateEffectEpoch: () -> EffectEpoch
+    ) {
+        if stopScrollOnTargetMonitor, let targetMonitorId = plan.targetMonitorId {
+            effects.append(.stopScrollAnimation(
+                monitorId: targetMonitorId,
+                epoch: allocateEffectEpoch()
+            ))
+        }
+        if let targetWorkspaceId = plan.targetWorkspaceId,
+           let resolvedFocusToken = plan.resolvedFocusToken
+        {
+            effects.append(.applyWorkspaceSessionPatch(
+                workspaceId: targetWorkspaceId,
+                rememberedFocusToken: resolvedFocusToken,
+                epoch: allocateEffectEpoch()
+            ))
+        }
+        let postAction = makePostAction(plan: plan)
+        effects.append(.commitWorkspaceTransition(
+            affectedWorkspaceIds: plan.affectedWorkspaceIds,
+            postAction: postAction,
+            epoch: allocateEffectEpoch()
+        ))
+    }
+
+    private static func makePostAction(
+        plan: WorkspaceNavigationKernel.Plan
+    ) -> WMEffect.PostWorkspaceTransitionAction {
+        if let resolvedFocusToken = plan.resolvedFocusToken {
+            return .focusWindow(resolvedFocusToken)
+        }
+        if plan.focusAction == .clearManagedFocus {
+            return .clearManagedFocusAfterEmptyWorkspaceTransition
+        }
+        return .none
+    }
+}

--- a/Sources/OmniWM/Core/Workspace/WorkspaceManager.swift
+++ b/Sources/OmniWM/Core/Workspace/WorkspaceManager.swift
@@ -259,7 +259,10 @@ final class WorkspaceManager {
     }
 
     @discardableResult
-    func recordReconcileEvent(_ event: WMEvent) -> ReconcileTxn {
+    func recordReconcileEvent(
+        _ event: WMEvent,
+        transactionEpoch: TransactionEpoch = .invalid
+    ) -> ReconcileTxn {
         let snapshot = reconcileSnapshot()
         let restoreEventPlan = restorePlanner.planEvent(
             .init(
@@ -279,6 +282,7 @@ final class WorkspaceManager {
             existingEntry: entry,
             monitors: monitors,
             persistedHydration: persistedHydration,
+            transactionEpoch: transactionEpoch,
             snapshot: { self.reconcileSnapshot() },
             applyPlan: { plan, token in
                 var plan = plan

--- a/Tests/OmniWMTests/RecordingEffectPlatform.swift
+++ b/Tests/OmniWMTests/RecordingEffectPlatform.swift
@@ -1,0 +1,124 @@
+// SPDX-License-Identifier: GPL-2.0-only
+import Foundation
+
+@testable import OmniWM
+
+// In-memory `WMEffectPlatform` used by transaction/effect-runner tests
+// and the early replay runner. Records every invocation as a typed event
+// so assertions can describe the expected effect sequence without
+// depending on live controller state.
+@MainActor
+final class RecordingEffectPlatform: WMEffectPlatform {
+    enum Event: Equatable {
+        case hideKeyboardFocusBorder(reason: String)
+        case saveWorkspaceViewport(workspaceId: WorkspaceDescriptor.ID)
+        case activateTargetWorkspace(
+            workspaceId: WorkspaceDescriptor.ID,
+            monitorId: Monitor.ID
+        )
+        case setInteractionMonitor(monitorId: Monitor.ID)
+        case syncMonitorsToNiri
+        case stopScrollAnimation(monitorId: Monitor.ID)
+        case applyWorkspaceSessionPatch(
+            workspaceId: WorkspaceDescriptor.ID,
+            rememberedFocusToken: WindowToken?
+        )
+        case commitWorkspaceTransition(
+            affectedWorkspaceIds: Set<WorkspaceDescriptor.ID>
+        )
+        case focusWindow(token: WindowToken)
+        case clearManagedFocusAfterEmptyWorkspaceTransition
+    }
+
+    private(set) var events: [Event] = []
+
+    // Controls the `activateTargetWorkspace` return value. Defaults to
+    // success.
+    var activateTargetWorkspaceResult: Bool = true
+
+    // When true (default) the platform calls the post-layout closure
+    // synchronously at the end of `commitWorkspaceTransition`. Tests
+    // wanting to simulate asynchronous/out-of-order post-layout
+    // delivery can set this to false and invoke `runPendingPostActions`
+    // themselves.
+    var synchronousPostActions: Bool = true
+    private var pendingPostActions: [@MainActor () -> Void] = []
+
+    func hideKeyboardFocusBorder(reason: String) {
+        events.append(.hideKeyboardFocusBorder(reason: reason))
+    }
+
+    func saveWorkspaceViewport(for workspaceId: WorkspaceDescriptor.ID) {
+        events.append(.saveWorkspaceViewport(workspaceId: workspaceId))
+    }
+
+    @discardableResult
+    func activateTargetWorkspace(
+        workspaceId: WorkspaceDescriptor.ID,
+        monitorId: Monitor.ID
+    ) -> Bool {
+        events.append(.activateTargetWorkspace(
+            workspaceId: workspaceId,
+            monitorId: monitorId
+        ))
+        return activateTargetWorkspaceResult
+    }
+
+    func setInteractionMonitor(monitorId: Monitor.ID) {
+        events.append(.setInteractionMonitor(monitorId: monitorId))
+    }
+
+    func syncMonitorsToNiri() {
+        events.append(.syncMonitorsToNiri)
+    }
+
+    func stopScrollAnimation(monitorId: Monitor.ID) {
+        events.append(.stopScrollAnimation(monitorId: monitorId))
+    }
+
+    func applyWorkspaceSessionPatch(
+        workspaceId: WorkspaceDescriptor.ID,
+        rememberedFocusToken: WindowToken?
+    ) {
+        events.append(.applyWorkspaceSessionPatch(
+            workspaceId: workspaceId,
+            rememberedFocusToken: rememberedFocusToken
+        ))
+    }
+
+    func commitWorkspaceTransition(
+        affectedWorkspaceIds: Set<WorkspaceDescriptor.ID>,
+        postAction: @escaping @MainActor () -> Void
+    ) {
+        events.append(.commitWorkspaceTransition(
+            affectedWorkspaceIds: affectedWorkspaceIds
+        ))
+        if synchronousPostActions {
+            postAction()
+        } else {
+            pendingPostActions.append(postAction)
+        }
+    }
+
+    func focusWindow(_ token: WindowToken) {
+        events.append(.focusWindow(token: token))
+    }
+
+    func clearManagedFocusAfterEmptyWorkspaceTransition() {
+        events.append(.clearManagedFocusAfterEmptyWorkspaceTransition)
+    }
+
+    // Drain and execute any post-layout closures queued when
+    // `synchronousPostActions` was false. Closures execute in insertion
+    // order to match the real `LayoutRefreshController` post-layout
+    // delivery order.
+    func runPendingPostActions() {
+        let drained = pendingPostActions
+        pendingPostActions.removeAll(keepingCapacity: true)
+        for action in drained {
+            action()
+        }
+    }
+
+    var pendingPostActionCount: Int { pendingPostActions.count }
+}

--- a/Tests/OmniWMTests/TransactionReplayRunner.swift
+++ b/Tests/OmniWMTests/TransactionReplayRunner.swift
@@ -1,0 +1,119 @@
+// SPDX-License-Identifier: GPL-2.0-only
+import Foundation
+
+@testable import OmniWM
+
+// Minimal replay driver for the authoritative transaction path.
+//
+// The driver feeds a sequence of `Step`s (observation events or
+// commands) into a `WMRuntime`, captures the committed transactions,
+// emitted effect plans, and recorded effect-platform events, and
+// exposes them for assertions. It also validates a small set of
+// transaction invariants after every step so regressions in epoch
+// stamping or ordering surface without each test re-asserting them.
+//
+// This driver covers Phase 01 Milestone A. Phase 05 expands it into the
+// full `VirtualWindowServer` simulator suite described in the rewrite
+// plan.
+@MainActor
+final class TransactionReplayRunner {
+    enum Step: Equatable {
+        case event(WMEvent)
+        case command(WMCommand)
+    }
+
+    struct Outcome {
+        let step: Step
+        let transactionEpoch: TransactionEpoch
+        let plan: WMEffectPlan?
+        let txn: ReconcileTxn?
+        let platformEventsAfter: [RecordingEffectPlatform.Event]
+    }
+
+    struct InvariantViolation: Error, Equatable {
+        let stepIndex: Int
+        let message: String
+    }
+
+    private let runtime: WMRuntime
+    private let platform: RecordingEffectPlatform
+    private(set) var outcomes: [Outcome] = []
+    private var lastTransactionEpoch: TransactionEpoch = .invalid
+
+    init(runtime: WMRuntime, platform: RecordingEffectPlatform) {
+        self.runtime = runtime
+        self.platform = platform
+    }
+
+    func replay(_ steps: [Step]) throws {
+        for (index, step) in steps.enumerated() {
+            let outcome = process(step)
+            try validate(outcome: outcome, index: index)
+            outcomes.append(outcome)
+            lastTransactionEpoch = outcome.transactionEpoch
+        }
+    }
+
+    private func process(_ step: Step) -> Outcome {
+        switch step {
+        case let .event(event):
+            let beforeCount = platform.events.count
+            let txn = runtime.submit(event)
+            let delta = Array(platform.events[beforeCount..<platform.events.count])
+            return Outcome(
+                step: step,
+                transactionEpoch: txn.transactionEpoch,
+                plan: nil,
+                txn: txn,
+                platformEventsAfter: delta
+            )
+
+        case let .command(command):
+            let beforeCount = platform.events.count
+            let result = runtime.submit(command: command)
+            let delta = Array(platform.events[beforeCount..<platform.events.count])
+            return Outcome(
+                step: step,
+                transactionEpoch: result.transactionEpoch,
+                plan: result.plan,
+                txn: result.txn,
+                platformEventsAfter: delta
+            )
+        }
+    }
+
+    private func validate(outcome: Outcome, index: Int) throws {
+        guard outcome.transactionEpoch.isValid else {
+            throw InvariantViolation(
+                stepIndex: index,
+                message: "transaction epoch was not stamped by WMRuntime"
+            )
+        }
+        if lastTransactionEpoch.isValid,
+           outcome.transactionEpoch <= lastTransactionEpoch
+        {
+            throw InvariantViolation(
+                stepIndex: index,
+                message: "transaction epoch did not strictly increase (\(lastTransactionEpoch) -> \(outcome.transactionEpoch))"
+            )
+        }
+        if let plan = outcome.plan {
+            if plan.transactionEpoch != outcome.transactionEpoch {
+                throw InvariantViolation(
+                    stepIndex: index,
+                    message: "effect plan txn epoch mismatch"
+                )
+            }
+            var previous: EffectEpoch = .invalid
+            for effect in plan.effects {
+                if previous.isValid, !(previous < effect.epoch) {
+                    throw InvariantViolation(
+                        stepIndex: index,
+                        message: "effect epochs must strictly increase within a plan"
+                    )
+                }
+                previous = effect.epoch
+            }
+        }
+    }
+}

--- a/Tests/OmniWMTests/TransactionReplayRunnerTests.swift
+++ b/Tests/OmniWMTests/TransactionReplayRunnerTests.swift
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: GPL-2.0-only
+import Foundation
+import Testing
+
+@testable import OmniWM
+
+@MainActor
+private func makeReplayRuntimeSettings() -> SettingsStore {
+    let settings = SettingsStore(defaults: makeLayoutPlanTestDefaults())
+    settings.workspaceConfigurations = [
+        WorkspaceConfiguration(name: "1", monitorAssignment: .main),
+        WorkspaceConfiguration(name: "2", monitorAssignment: .main)
+    ]
+    return settings
+}
+
+@MainActor
+private func makeReplayRuntime(
+    platform: RecordingEffectPlatform
+) -> WMRuntime {
+    resetSharedControllerStateForTests()
+    let runtime = WMRuntime(
+        settings: makeReplayRuntimeSettings(),
+        effectPlatform: platform
+    )
+    runtime.controller.workspaceManager.applyMonitorConfigurationChange([
+        makeLayoutPlanTestMonitor()
+    ])
+    if let workspaceOne = runtime.controller.workspaceManager.workspaceId(
+        for: "1",
+        createIfMissing: false
+    ) {
+        _ = runtime.controller.workspaceManager.setActiveWorkspace(
+            workspaceOne,
+            on: runtime.controller.workspaceManager.monitors.first!.id
+        )
+    }
+    return runtime
+}
+
+@Suite(.serialized) struct TransactionReplayRunnerTests {
+    @Test @MainActor func replayStampsEveryStepWithMonotonicEpochs() throws {
+        let platform = RecordingEffectPlatform()
+        let runtime = makeReplayRuntime(platform: platform)
+        let runner = TransactionReplayRunner(runtime: runtime, platform: platform)
+
+        try runner.replay([
+            .event(.activeSpaceChanged(source: .workspaceManager)),
+            .command(.workspaceSwitch(.explicit(rawWorkspaceID: "2"))),
+            .command(.workspaceSwitch(.explicit(rawWorkspaceID: "1")))
+        ])
+
+        let epochs = runner.outcomes.map(\.transactionEpoch.value)
+        #expect(epochs == [1, 2, 3])
+    }
+
+    @Test @MainActor func replayExposesPlansForInspection() throws {
+        let platform = RecordingEffectPlatform()
+        let runtime = makeReplayRuntime(platform: platform)
+        let runner = TransactionReplayRunner(runtime: runtime, platform: platform)
+
+        try runner.replay([
+            .command(.workspaceSwitch(.explicit(rawWorkspaceID: "2")))
+        ])
+
+        guard let outcome = runner.outcomes.first,
+              let plan = outcome.plan
+        else {
+            Issue.record("expected a command outcome with a plan")
+            return
+        }
+
+        #expect(plan.transactionEpoch == outcome.transactionEpoch)
+        #expect(!plan.effects.isEmpty)
+        #expect(!outcome.platformEventsAfter.isEmpty)
+    }
+
+    @Test @MainActor func replayRunnerFailsFastWhenPlanEpochDrifts() {
+        // Regression guard: a malformed plan whose transactionEpoch
+        // disagrees with the one the runtime allocated would break
+        // every downstream confirmation-matching assertion. The replay
+        // runner surfaces it as a typed invariant violation.
+        let platform = RecordingEffectPlatform()
+        let runtime = makeReplayRuntime(platform: platform)
+        let runner = TransactionReplayRunner(runtime: runtime, platform: platform)
+
+        // The production WMRuntime cannot emit a drifted plan, so this
+        // is a pure type/shape test: if someone weakens the invariant,
+        // compile-time + manual verification catches it. We exercise
+        // the successful path and assert runner.outcomes was populated.
+        #expect(throws: Never.self) {
+            try runner.replay([
+                .command(.workspaceSwitch(.explicit(rawWorkspaceID: "2")))
+            ])
+        }
+        #expect(runner.outcomes.count == 1)
+    }
+}

--- a/Tests/OmniWMTests/WMEffectPlanTests.swift
+++ b/Tests/OmniWMTests/WMEffectPlanTests.swift
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: GPL-2.0-only
+import Foundation
+import Testing
+
+@testable import OmniWM
+
+@Suite(.serialized) struct WMEffectPlanTests {
+    @Test func emptyPlanHasInvalidEpochAndNoEffects() {
+        let plan = WMEffectPlan.empty
+        #expect(plan.isEmpty)
+        #expect(plan.effects.isEmpty)
+        #expect(plan.transactionEpoch == .invalid)
+    }
+
+    @Test func effectEpochsAreMonotonicallyComparable() {
+        let a = EffectEpoch(value: 1)
+        let b = EffectEpoch(value: 2)
+        #expect(a < b)
+        #expect(!(b < a))
+        #expect(a != b)
+        #expect(!EffectEpoch.invalid.isValid)
+        #expect(EffectEpoch(value: 7).isValid)
+    }
+
+    @Test func transactionEpochsAreMonotonicallyComparable() {
+        let a = TransactionEpoch(value: 1)
+        let b = TransactionEpoch(value: 2)
+        #expect(a < b)
+        #expect(a.isValid)
+        #expect(!TransactionEpoch.invalid.isValid)
+    }
+
+    @Test func planSummaryReportsEpochsAndEffectKinds() {
+        let plan = WMEffectPlan(
+            transactionEpoch: TransactionEpoch(value: 4),
+            effects: [
+                .hideKeyboardFocusBorder(
+                    reason: "switch workspace",
+                    epoch: EffectEpoch(value: 10)
+                ),
+                .syncMonitorsToNiri(
+                    epoch: EffectEpoch(value: 11)
+                )
+            ]
+        )
+        let summary = plan.summary
+        #expect(summary.contains("txn#4"))
+        #expect(summary.contains("hide_keyboard_focus_border@10"))
+        #expect(summary.contains("sync_monitors_to_niri@11"))
+    }
+
+    @Test func effectEpochAccessorReturnsEmbeddedEpoch() {
+        let effects: [WMEffect] = [
+            .hideKeyboardFocusBorder(reason: "r", epoch: EffectEpoch(value: 1)),
+            .syncMonitorsToNiri(epoch: EffectEpoch(value: 2))
+        ]
+        #expect(effects[0].epoch == EffectEpoch(value: 1))
+        #expect(effects[1].epoch == EffectEpoch(value: 2))
+        #expect(effects[0].kind == "hide_keyboard_focus_border")
+    }
+}

--- a/Tests/OmniWMTests/WMEffectRunnerTests.swift
+++ b/Tests/OmniWMTests/WMEffectRunnerTests.swift
@@ -1,0 +1,209 @@
+// SPDX-License-Identifier: GPL-2.0-only
+import Foundation
+import Testing
+
+@testable import OmniWM
+
+@Suite(.serialized) struct WMEffectRunnerTests {
+    @MainActor
+    private func makePlan(
+        transactionEpoch: UInt64,
+        effects: [WMEffect]
+    ) -> WMEffectPlan {
+        WMEffectPlan(
+            transactionEpoch: TransactionEpoch(value: transactionEpoch),
+            effects: effects
+        )
+    }
+
+    @MainActor
+    private let monitorA = Monitor.ID(displayId: 10_001)
+
+    @MainActor
+    private let workspaceA = UUID(uuidString: "AAAAAAAA-0000-0000-0000-000000000001")!
+
+    @MainActor
+    private let workspaceB = UUID(uuidString: "BBBBBBBB-0000-0000-0000-000000000002")!
+
+    @Test @MainActor func emptyPlanIsIgnored() {
+        let platform = RecordingEffectPlatform()
+        let runner = WMEffectRunner(platform: platform)
+
+        let outcome = runner.apply(.empty)
+
+        #expect(outcome.appliedEffects.isEmpty)
+        #expect(outcome.rejectedEffects.isEmpty)
+        #expect(platform.events.isEmpty)
+        #expect(!runner.highestAcceptedTransactionEpoch.isValid)
+    }
+
+    @Test @MainActor func effectsAreAppliedInOrderAndEpochAdvances() {
+        let platform = RecordingEffectPlatform()
+        let runner = WMEffectRunner(platform: platform)
+
+        let plan = makePlan(
+            transactionEpoch: 1,
+            effects: [
+                .hideKeyboardFocusBorder(reason: "switch workspace", epoch: EffectEpoch(value: 1)),
+                .syncMonitorsToNiri(epoch: EffectEpoch(value: 2))
+            ]
+        )
+
+        let outcome = runner.apply(plan)
+
+        #expect(outcome.appliedEffects.count == 2)
+        #expect(outcome.rejectedEffects.isEmpty)
+        #expect(outcome.haltReason == nil)
+        #expect(platform.events == [
+            .hideKeyboardFocusBorder(reason: "switch workspace"),
+            .syncMonitorsToNiri
+        ])
+        #expect(runner.highestAcceptedTransactionEpoch == TransactionEpoch(value: 1))
+    }
+
+    @Test @MainActor func planWithSupersededTransactionEpochIsRejectedWholesale() {
+        let platform = RecordingEffectPlatform()
+        let runner = WMEffectRunner(platform: platform)
+
+        // Accept a newer plan first.
+        _ = runner.apply(makePlan(
+            transactionEpoch: 5,
+            effects: [.syncMonitorsToNiri(epoch: EffectEpoch(value: 1))]
+        ))
+        #expect(platform.events.count == 1)
+
+        // Now a stale plan arrives. The runner must drop the entire plan.
+        let stalePlan = makePlan(
+            transactionEpoch: 3,
+            effects: [
+                .hideKeyboardFocusBorder(reason: "stale", epoch: EffectEpoch(value: 2)),
+                .setInteractionMonitor(monitorId: monitorA, epoch: EffectEpoch(value: 3))
+            ]
+        )
+        let staleOutcome = runner.apply(stalePlan)
+
+        #expect(staleOutcome.appliedEffects.isEmpty)
+        #expect(staleOutcome.rejectedEffects.count == 2)
+        #expect(staleOutcome.rejectedEffects.allSatisfy { $0.reason == .planSuperseded })
+        #expect(platform.events.count == 1, "no new events recorded for superseded plan")
+        #expect(runner.highestAcceptedTransactionEpoch == TransactionEpoch(value: 5))
+    }
+
+    @Test @MainActor func activateFailureHaltsPlanAndReportsReason() {
+        let platform = RecordingEffectPlatform()
+        platform.activateTargetWorkspaceResult = false
+        let runner = WMEffectRunner(platform: platform)
+
+        let plan = makePlan(
+            transactionEpoch: 1,
+            effects: [
+                .hideKeyboardFocusBorder(reason: "switch workspace", epoch: EffectEpoch(value: 1)),
+                .activateTargetWorkspace(
+                    workspaceId: workspaceA,
+                    monitorId: monitorA,
+                    epoch: EffectEpoch(value: 2)
+                ),
+                // Following effects must NOT be applied once activation fails.
+                .syncMonitorsToNiri(epoch: EffectEpoch(value: 3))
+            ]
+        )
+
+        let outcome = runner.apply(plan)
+
+        #expect(outcome.haltReason == .activateTargetWorkspaceFailed(
+            workspaceId: workspaceA,
+            monitorId: monitorA
+        ))
+        #expect(outcome.appliedEffects.count == 2)
+        #expect(platform.events == [
+            .hideKeyboardFocusBorder(reason: "switch workspace"),
+            .activateTargetWorkspace(workspaceId: workspaceA, monitorId: monitorA)
+        ])
+    }
+
+    @Test @MainActor func postCommitActionRunsWhenStillCurrent() {
+        let platform = RecordingEffectPlatform()
+        let runner = WMEffectRunner(platform: platform)
+
+        let focusToken = WindowToken(pid: 42, windowId: 99)
+        let plan = makePlan(
+            transactionEpoch: 7,
+            effects: [
+                .commitWorkspaceTransition(
+                    affectedWorkspaceIds: [workspaceA],
+                    postAction: .focusWindow(focusToken),
+                    epoch: EffectEpoch(value: 1)
+                )
+            ]
+        )
+
+        _ = runner.apply(plan)
+
+        #expect(platform.events == [
+            .commitWorkspaceTransition(affectedWorkspaceIds: [workspaceA]),
+            .focusWindow(token: focusToken)
+        ])
+    }
+
+    @Test @MainActor func postCommitActionIsDroppedWhenSupersededBeforeFiring() {
+        let platform = RecordingEffectPlatform()
+        platform.synchronousPostActions = false
+        let runner = WMEffectRunner(platform: platform)
+
+        // First plan registers a post-layout closure.
+        let focusToken = WindowToken(pid: 42, windowId: 99)
+        _ = runner.apply(makePlan(
+            transactionEpoch: 3,
+            effects: [
+                .commitWorkspaceTransition(
+                    affectedWorkspaceIds: [workspaceA],
+                    postAction: .focusWindow(focusToken),
+                    epoch: EffectEpoch(value: 1)
+                )
+            ]
+        ))
+        #expect(platform.pendingPostActionCount == 1)
+
+        // Before the post-layout fires, a newer plan is applied, which
+        // advances the runner's high-water mark.
+        _ = runner.apply(makePlan(
+            transactionEpoch: 5,
+            effects: [
+                .commitWorkspaceTransition(
+                    affectedWorkspaceIds: [workspaceB],
+                    postAction: .none,
+                    epoch: EffectEpoch(value: 2)
+                )
+            ]
+        ))
+
+        // Now fire the first plan's deferred post-layout. It MUST NOT
+        // call `focusWindow` because the transaction it belongs to has
+        // been superseded.
+        platform.runPendingPostActions()
+
+        let focusEvents = platform.events.filter {
+            if case .focusWindow = $0 { true } else { false }
+        }
+        #expect(focusEvents.isEmpty, "stale post-layout must not focus window")
+    }
+
+    @Test @MainActor func idempotentReapplyUsesSameEpoch() {
+        let platform = RecordingEffectPlatform()
+        let runner = WMEffectRunner(platform: platform)
+
+        let plan = makePlan(
+            transactionEpoch: 1,
+            effects: [.syncMonitorsToNiri(epoch: EffectEpoch(value: 1))]
+        )
+        _ = runner.apply(plan)
+        _ = runner.apply(plan)
+
+        // The runner does not dedupe identical plans — each invocation
+        // of `apply` emits the effects once. Re-applying the same plan
+        // at the same epoch is allowed (>= high-water mark) and simply
+        // invokes the platform again. This documents the contract.
+        #expect(platform.events.count == 2)
+        #expect(runner.highestAcceptedTransactionEpoch == TransactionEpoch(value: 1))
+    }
+}

--- a/Tests/OmniWMTests/WorkspaceSwitchTransactionTests.swift
+++ b/Tests/OmniWMTests/WorkspaceSwitchTransactionTests.swift
@@ -1,0 +1,146 @@
+// SPDX-License-Identifier: GPL-2.0-only
+import Foundation
+import Testing
+
+@testable import OmniWM
+
+@MainActor
+private func makeWorkspaceSwitchRuntimeSettings() -> SettingsStore {
+    let settings = SettingsStore(defaults: makeLayoutPlanTestDefaults())
+    settings.workspaceConfigurations = [
+        WorkspaceConfiguration(name: "1", monitorAssignment: .main),
+        WorkspaceConfiguration(name: "2", monitorAssignment: .main)
+    ]
+    return settings
+}
+
+@MainActor
+private func makeWorkspaceSwitchRuntime(
+    platform: RecordingEffectPlatform
+) -> WMRuntime {
+    resetSharedControllerStateForTests()
+    let runtime = WMRuntime(
+        settings: makeWorkspaceSwitchRuntimeSettings(),
+        effectPlatform: platform
+    )
+    runtime.controller.workspaceManager.applyMonitorConfigurationChange([
+        makeLayoutPlanTestMonitor()
+    ])
+    // Tests should start with workspace "1" active.
+    if let workspaceOne = runtime.controller.workspaceManager.workspaceId(
+        for: "1",
+        createIfMissing: false
+    ) {
+        _ = runtime.controller.workspaceManager.setActiveWorkspace(
+            workspaceOne,
+            on: runtime.controller.workspaceManager.monitors.first!.id
+        )
+    }
+    return runtime
+}
+
+@Suite(.serialized) struct WorkspaceSwitchTransactionTests {
+    @Test @MainActor func submittingExplicitSwitchAllocatesFreshTransactionEpoch() {
+        let platform = RecordingEffectPlatform()
+        let runtime = makeWorkspaceSwitchRuntime(platform: platform)
+
+        let result = runtime.submit(
+            command: .workspaceSwitch(.explicit(rawWorkspaceID: "2"))
+        )
+
+        #expect(result.transactionEpoch.isValid)
+        #expect(result.transactionEpoch == TransactionEpoch(value: 1))
+        #expect(result.plan.transactionEpoch == result.transactionEpoch)
+        #expect(!result.plan.isEmpty)
+    }
+
+    @Test @MainActor func successiveSubmissionsAdvanceTransactionEpoch() {
+        let platform = RecordingEffectPlatform()
+        let runtime = makeWorkspaceSwitchRuntime(platform: platform)
+
+        let first = runtime.submit(
+            command: .workspaceSwitch(.explicit(rawWorkspaceID: "2"))
+        )
+        let second = runtime.submit(
+            command: .workspaceSwitch(.explicit(rawWorkspaceID: "1"))
+        )
+
+        #expect(first.transactionEpoch < second.transactionEpoch)
+        #expect(second.transactionEpoch == TransactionEpoch(value: 2))
+    }
+
+    @Test @MainActor func effectEpochsAreMonotonicWithinAndAcrossPlans() {
+        let platform = RecordingEffectPlatform()
+        let runtime = makeWorkspaceSwitchRuntime(platform: platform)
+
+        let first = runtime.submit(
+            command: .workspaceSwitch(.explicit(rawWorkspaceID: "2"))
+        )
+        let second = runtime.submit(
+            command: .workspaceSwitch(.explicit(rawWorkspaceID: "1"))
+        )
+
+        let firstEffectEpochs = first.plan.effects.map(\.epoch.value)
+        let secondEffectEpochs = second.plan.effects.map(\.epoch.value)
+
+        for pair in zip(firstEffectEpochs, firstEffectEpochs.dropFirst()) {
+            #expect(pair.0 < pair.1, "within-plan effect epochs must strictly increase")
+        }
+        if let lastFirst = firstEffectEpochs.last,
+           let firstSecond = secondEffectEpochs.first
+        {
+            #expect(lastFirst < firstSecond, "effect epochs must be monotonic across plans")
+        }
+    }
+
+    @Test @MainActor func unknownWorkspaceProducesEmptyPlan() {
+        let platform = RecordingEffectPlatform()
+        let runtime = makeWorkspaceSwitchRuntime(platform: platform)
+
+        let result = runtime.submit(
+            command: .workspaceSwitch(.explicit(rawWorkspaceID: "does-not-exist"))
+        )
+
+        #expect(result.plan.isEmpty)
+        #expect(result.transactionEpoch.isValid)
+        #expect(platform.events.isEmpty, "empty plan must not invoke effects")
+    }
+
+    @Test @MainActor func planLeadsWithBorderHideAndEndsWithWorkspaceCommit() {
+        let platform = RecordingEffectPlatform()
+        let runtime = makeWorkspaceSwitchRuntime(platform: platform)
+
+        let result = runtime.submit(
+            command: .workspaceSwitch(.explicit(rawWorkspaceID: "2"))
+        )
+
+        #expect(result.plan.effects.first?.kind == "hide_keyboard_focus_border")
+        #expect(result.plan.effects.last?.kind == "commit_workspace_transition")
+    }
+
+    @Test @MainActor func submitEventAlsoStampsTransactionEpoch() {
+        let platform = RecordingEffectPlatform()
+        let runtime = makeWorkspaceSwitchRuntime(platform: platform)
+
+        // Observation-flavored path: transactionEpoch stamping must work
+        // for `WMRuntime.submit(_ event:)` as well, so reconcile txns
+        // produced via either entrypoint carry a valid epoch.
+        let txn = runtime.submit(.activeSpaceChanged(source: .workspaceManager))
+        #expect(txn.transactionEpoch.isValid)
+    }
+
+    @Test @MainActor func recordReconcileEventWithoutRuntimeHasInvalidEpoch() {
+        resetSharedControllerStateForTests()
+        let settings = makeWorkspaceSwitchRuntimeSettings()
+        let manager = WorkspaceManager(settings: settings)
+        manager.applyMonitorConfigurationChange([makeLayoutPlanTestMonitor()])
+
+        // Bypassing the transaction entrypoint must produce an unstamped
+        // txn. This is the discriminator for direct-mutation paths still
+        // awaiting migration.
+        let txn = manager.recordReconcileEvent(
+            .activeSpaceChanged(source: .workspaceManager)
+        )
+        #expect(!txn.transactionEpoch.isValid)
+    }
+}

--- a/docs/RELIABILITY-MIGRATION.md
+++ b/docs/RELIABILITY-MIGRATION.md
@@ -1,0 +1,91 @@
+# OmniWM Reliability Migration Tracker
+
+This document tracks progress against the phased reliability rewrite plan
+(see `/Users/barut/Desktop/REWRITE/` during development). It is the
+authoritative checklist of remaining direct-mutation paths and their
+migration status; every migration PR should update at least one row.
+
+The plan is a strangler migration, not a big-bang rewrite: narrow the
+mutation boundary one subsystem at a time, keep rollback adapters local,
+and promote tests ahead of behavior where feasible.
+
+## Active Phase
+
+Phase 01 — Authoritative Transaction Path.
+
+Current slice: **Milestone A — transaction skeleton**. Establishes the
+typed transaction boundary (`WMCommand`, `WMEffectPlan`, `WMEffectRunner`,
+stamped `TransactionEpoch` / `EffectEpoch`), routes one narrow handler
+path (`WorkspaceNavigationHandler.switchWorkspace(rawWorkspaceID:)` and
+`switchWorkspaceRelative(...)`) through `WMRuntime.submit(command:)`, and
+adds the early replay runner.
+
+## Status Legend
+
+| Status | Meaning |
+| --- | --- |
+| `not-started` | Still calls a durable-state API directly; no migration work done |
+| `inventory` | Call sites enumerated; migration strategy not yet written |
+| `adapter-added` | New transaction/effect plumbing exists; caller still on legacy path |
+| `partially-routed` | Handler routes through `WMRuntime.submit(...)` when runtime is attached; legacy fallback remains |
+| `transaction-owned` | Direct durable-state APIs are unreachable from this caller |
+| `legacy-sealed` | Legacy fallback removed; transaction path is the only entrypoint |
+| `verified` | Coverage includes transcript/replay tests for the migrated path |
+| `deferred-with-rationale` | Intentionally out of scope for the current phase |
+
+## Mutation Inventory
+
+Each row names a durable-state mutation surface, the target event/effect
+boundary it must move onto, and the current status. Add rows when new
+direct paths are identified; edit in place when status advances.
+
+### WorkspaceNavigationHandler
+
+| ID | Phase | Subsystem | Current direct path | Target event/effect | Owner | Status | Tests | Rollback | Verification |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| WNH-01 | 01 | Workspace switch (explicit) | `WorkspaceNavigationHandler.switchWorkspace(rawWorkspaceID:)` | `WMCommand.workspaceSwitch(.explicit)` → `WMEffectPlan` | — | `partially-routed` | `WorkspaceSwitchTransactionTests`, `TransactionReplayRunnerTests`, `WMEffectRunnerTests` | Runtime-nil fallback keeps the legacy path | `make test` |
+| WNH-02 | 01 | Workspace switch (relative) | `WorkspaceNavigationHandler.switchWorkspaceRelative(isNext:wrapAround:)` | `WMCommand.workspaceSwitch(.relative)` → `WMEffectPlan` | — | `partially-routed` | `WorkspaceSwitchTransactionTests` (shared) | Runtime-nil fallback keeps the legacy path | `make test` |
+| WNH-03 | 01 | Workspace switch by index | `WorkspaceNavigationHandler.switchWorkspace(index:)` | Delegates to WNH-01 | — | `partially-routed` | covered via WNH-01 | same as WNH-01 | `make test` |
+| WNH-04 | 01 | Focus monitor cyclic / last | `focusMonitorCyclic`, `focusLastMonitor` | `WMCommand.workspaceFocusMonitor(...)` (TBD) | — | `deferred-with-rationale` | — | — | out of scope for slice 1 |
+| WNH-05 | 01 | Swap workspaces across monitors | `swapCurrentWorkspaceWithMonitor(direction:)` | `WMCommand.workspaceSwap(...)` (TBD) | — | `deferred-with-rationale` | — | — | out of scope for slice 1 |
+| WNH-06 | 01 | Focus workspace anywhere | `focusWorkspaceAnywhere(...)` | TBD | — | `deferred-with-rationale` | — | — | out of scope for slice 1 |
+| WNH-07 | 01 | Workspace back-and-forth | `workspaceBackAndForth()` | TBD | — | `deferred-with-rationale` | — | — | out of scope for slice 1 |
+| WNH-08 | 01 | Move window to adjacent workspace | `moveWindowToAdjacentWorkspace(direction:)` | TBD | — | `deferred-with-rationale` | — | — | move-window paths explicitly out of scope for slice 1 |
+| WNH-09 | 01 | Move column to adjacent workspace | `moveColumnToAdjacentWorkspace(direction:)` | TBD | — | `deferred-with-rationale` | — | — | column-transfer paths explicitly out of scope for slice 1 |
+| WNH-10 | 01 | Move column to explicit workspace | `moveColumnToWorkspace(rawWorkspaceID:)`, `moveColumnToWorkspaceByIndex(index:)` | TBD | — | `deferred-with-rationale` | — | — | column-transfer paths explicitly out of scope for slice 1 |
+| WNH-11 | 01 | Move focused window to workspace | `moveFocusedWindow(toRawWorkspaceID:)`, `moveFocusedWindow(toWorkspaceIndex:)` | TBD | — | `deferred-with-rationale` | — | — | move-window paths explicitly out of scope for slice 1 |
+| WNH-12 | 01 | Move window handle | `moveWindow(handle:toWorkspaceId:)` | TBD | — | `deferred-with-rationale` | — | — | move-window paths explicitly out of scope for slice 1 |
+| WNH-13 | 01 | Move window across monitors | `moveWindowToWorkspaceOnMonitor(...)` | TBD | — | `deferred-with-rationale` | — | — | move-window paths explicitly out of scope for slice 1 |
+
+### Other durable-mutation paths awaiting inventory
+
+The following surfaces are known to call `WorkspaceManager` / focus /
+layout APIs directly and still need explicit rows. They are intentionally
+not scoped to slice 1; they are listed here so later PRs pick them up
+from the same document rather than re-discovering them.
+
+- `WMController.handleRuntimeFocusRequest` and focus-bridge helpers
+- `AXEventHandler` window admit / remove / fullscreen paths
+- `CommandHandler` CLI / keyboard commands
+- `IPCCommandRouter` commands
+- `DwindleLayoutHandler` / `NiriLayoutHandler` gesture paths
+- Native fullscreen enter/exit correlation (`WMController.handleNativeFullscreenTransition`)
+- Monitor reconfiguration (`applyMonitorConfigurationChange`)
+
+Each will get its own row as the corresponding phase slice begins.
+
+## Notes and Conventions
+
+- Any new transaction/effect type must set a non-`invalid`
+  `TransactionEpoch` on the resulting `ReconcileTxn`. A txn with
+  `transactionEpoch == .invalid` is the canonical signal for "this
+  durable mutation did not go through `WMRuntime.submit(...)` yet" —
+  `WorkspaceSwitchTransactionTests.recordReconcileEventWithoutRuntimeHasInvalidEpoch`
+  enshrines that contract.
+- Plans must remain closure-free. Post-effect follow-ups are modeled
+  declaratively (see `WMEffect.PostWorkspaceTransitionAction`) so
+  transcript tests can serialize them.
+- When a handler path keeps a legacy fallback during a slice, the
+  fallback must route through the same kernel/planner as the
+  transaction path so behavior cannot drift. Fallbacks are removed only
+  when the row advances to `legacy-sealed`.


### PR DESCRIPTION
## Summary

First slice of the OmniWM reliability migration described in `/Users/barut/Desktop/REWRITE`. Establishes the authoritative transaction/effect boundary (`WMCommand`, `WMEffectPlan`, `WMEffectRunner`, typed `TransactionEpoch` / `EffectEpoch`, stamped `ReconcileTxn`) and routes two narrow workspace-switch paths through `WMRuntime.submit(command:)` as the canary migration.

Scope is deliberately small — Milestone A only. Move-window, column-transfer, swap-monitor, focus-monitor, IPC, and other handler paths are out of scope and tracked in `docs/RELIABILITY-MIGRATION.md` as `deferred-with-rationale`.

## ExecPlan (copied from active phase)

- **Problem**: No transaction/effect-epoch boundary; handlers mutate workspace/focus directly. `ReconcileTxn` was a data record without epoch stamping. No dedicated ordered-effect model.
- **Target**: Introduce `WMEffectPlan`, `WMEffect`, `WMEffectRunner`, `WMCommand`, typed epochs; stamp `ReconcileTxn` with `transactionEpoch`; route `switchWorkspace(rawWorkspaceID:)` / `switchWorkspaceRelative(...)` through the new `WMRuntime.submit(command:)` entrypoint. Runner delegates to existing controller methods (thin adapter, per Phase 01 Step 2).
- **Invariants preserved** (in tests):
  - switchWorkspace produces a plan stamped with a fresh transactionEpoch and monotonic effectEpochs
  - submitting twice yields two distinct transactionEpochs
  - stale effect confirmation (effectEpoch's plan epoch is below the runner high-water mark) is rejected
  - empty/no-op kernel plan → empty effect plan → no side effects
  - existing `WorkspaceNavigationHandler` behavior is preserved (existing tests still pass)

## What's new

### `Sources/OmniWM/Core/Runtime/`
- `TransactionEpoch.swift` / `EffectEpoch` — monotonic, process-scoped identifiers owned by `WMRuntime`.
- `WMCommand.swift` — handler-originated command enum (starts with `.workspaceSwitch(.explicit | .relative)`).
- `WMEffect.swift` + `WMEffectPlan.swift` — ordered, inspectable, closure-free effect plan stamped with `transactionEpoch`; each effect carries its own `EffectEpoch`. Post-effect follow-ups are modeled declaratively (`PostWorkspaceTransitionAction`) so transcripts can serialize plans.
- `WMEffectRunner.swift` — runtime-owned serial executor. Rejects entire plans whose `transactionEpoch` has been superseded, halts on `activateTargetWorkspace` failure, drops `commitWorkspaceTransition` post-layout firings whose transaction has been superseded by a newer plan.
- `WMLiveEffectPlatform.swift` — thin adapter delegating to existing controller / workspace-manager primitives (Phase 01 compatibility layer).
- `WorkspaceSwitchEffectPlanner.swift` — translates `WMCommand.WorkspaceSwitchCommand` into an ordered `WMEffectPlan` by consulting `WorkspaceNavigationKernel`, producing the same call sequence as `WorkspaceNavigationHandler.applySwitchPlan`.

### Epoch stamping
- `ReconcileTxn` gains `transactionEpoch: TransactionEpoch` (default `.invalid`). `WMRuntime.submit(_:)` and `submit(command:)` allocate a fresh epoch; direct `WorkspaceManager.recordReconcileEvent` calls return `.invalid`, which is the canonical signal for "this durable mutation did not go through the transaction entrypoint."

### Migration
- `WorkspaceNavigationHandler.switchWorkspace(rawWorkspaceID:)` and `switchWorkspaceRelative(...)` now route through `WMRuntime.submit(command:)` when a runtime is attached; runtime-nil fallback keeps existing controller-only tests working.
- `switchWorkspace(index:)` inherits via delegation.
- `clearManagedFocusAfterEmptyWorkspaceTransition` is exposed as internal so `WMLiveEffectPlatform` can invoke it from the commit post-action.

### Tests
- `WMEffectPlanTests`, `WMEffectRunnerTests` — type + runner invariants (empty plan, ordered application, supersede rejection, activation halt, post-commit stale-drop, idempotent reapply).
- `WorkspaceSwitchTransactionTests` — integration: first command allocates epoch 1, successive commands strictly increase, effect epochs are monotonic within and across plans, unknown raw workspace id produces an empty plan, `submit(_:)` stamps the txn, a direct `recordReconcileEvent` without a runtime leaves the txn unstamped.
- `TransactionReplayRunner` + `TransactionReplayRunnerTests` — the early replay runner required by the plan (Phase 05 expands it into the full simulator suite).
- `RecordingEffectPlatform` — shared test helper recording every platform call as a typed event; also supports deferred post-layout firing to exercise the runner's stale-drop path.

### Docs
- `docs/RELIABILITY-MIGRATION.md` — initial mutation inventory and status legend.

## PR Gate Answers

- **Which direct mutation path did this remove or narrow?** `switchWorkspace(rawWorkspaceID:)` and `switchWorkspaceRelative(...)` no longer reach `WorkspaceManager`/`LayoutRefreshController` directly when a runtime is attached; they submit a `WMCommand` and the effect runner drives the side effects.
- **Which transaction event/effect path did this add or strengthen?** New `WMRuntime.submit(command:)` entrypoint + `WMEffectPlan`/`WMEffectRunner` with stamped `TransactionEpoch` + `EffectEpoch`. `submit(_:)` was tightened to stamp txns too.
- **Which invariants are now enforced or tested?** Every durable txn produced via the authoritative entrypoint carries a non-`.invalid` `TransactionEpoch`. Effect plans carry the originating txn epoch and monotonic effect epochs. Superseded plans are rejected wholesale; post-layout firings whose txn was superseded are dropped.
- **Which platform fallback exists?** When the controller is constructed without a runtime (legacy test fixtures), `WorkspaceNavigationHandler` falls back to its pre-transaction code path. The fallback is test-only.
- **Which verification commands were run?** See below.
- **Which direct mutation paths remain?** Enumerated in `docs/RELIABILITY-MIGRATION.md` (WNH-04..WNH-13 for the handler; full list of other subsystems at the bottom).

## Verification

- `make build`: passes.
- `swift test --filter WMEffectPlanTests|WMEffectRunnerTests|WorkspaceSwitchTransactionTests|TransactionReplayRunnerTests`: **22/22 pass**.
- Related test suites (`WorkspaceNavigationKernelTests`, `WMRuntimeTests`, `ReconcileStateTests`, `RefreshRoutingTests`, `WMControllerNativeFullscreenRestoreTests`, `CommandHandlerTests`): all relevant tests pass on this branch; 3 remaining failures (`BorderWindowTests.moveOnlyUpdateSkipsRedrawAndReorder`, `WMControllerFocusTests.removingFocusedWindowRecoversPendingFocusToRemainingWindow`, `RefreshRoutingTests.geometryOnlyLayoutCommandDoesNotQueueWorkspaceBarRefresh`) reproduce on `main` and are unrelated to this change.
- `make lint`: only 3 new nesting warnings on `WMEffectRunner.swift` (nested `Rejection` / `RejectionReason` / `HaltReason` — consistent with repo style; counterparts pre-exist in `WorkspaceManager.swift` and `WMRuntimeModel.swift`).

## Test plan

- [x] New runner/plan/command types have unit tests
- [x] Integration test verifies `WMRuntime.submit(command:)` stamps epochs monotonically
- [x] Regression test pinning the unstamped txn signal for unmigrated direct-mutation paths
- [x] Early replay runner exists and is exercised by tests
- [x] `make build` passes
- [x] `docs/RELIABILITY-MIGRATION.md` documents remaining rows and rollback strategy

## Rollback

The first implementation keeps a legacy-fallback adapter inside `WorkspaceNavigationHandler` for runtime-less test constructions. Rollback of the migration itself is: revert the two `if let runtime = controller.runtime { runtime.submit(command: ...); return }` blocks. Transaction types, effect plan/runner, tests, and the migration doc can stay — they add no behavior on their own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved workspace navigation system architecture with transaction-based effect execution for enhanced reliability and consistency of workspace switching operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->