### PR TITLE
build: bundle Zig compiler-rt for x86_64 cross-compile

### DIFF
--- a/Zig/omniwm_kernels/build.zig
+++ b/Zig/omniwm_kernels/build.zig
@@ -19,6 +19,7 @@ pub fn build(b: *std.Build) void {
         .linkage = .static,
         .root_module = module,
     });
+    lib.bundle_compiler_rt = true;
     b.installArtifact(lib);
 
     const tests = b.addTest(.{


### PR DESCRIPTION
## Problem

`./Scripts/package-app.sh debug false` fails on the x86_64 link step with:

```
Undefined symbols for architecture x86_64:
  "___zig_probe_stack", referenced from:
      _debug.printLineFromFile in libomniwm_kernels.a[x86_64][2](libomniwm_kernels_zcu.o)
      _debug.panicExtra__anon_4904 in ...
      ...
ld: symbol(s) not found for architecture x86_64
```

`nm` confirms `___zig_probe_stack` is referenced (`U`) but not defined (`T`) in the x86_64 archive of `libomniwm_kernels.a`. The arm64 slice has no such reference at all (arm64 macOS uses guard-page-based stack overflow detection rather than runtime stack probing).

The arm64-only build (`make build`) works fine because the symbol only appears on x86_64. The breakage surfaces only when the universal pipeline tries to link the x86_64 slice.

## Root cause

Since Zig 0.16.0, static libraries no longer bundle `compiler_rt` symbols by default. The Zig kernel module emits `__zig_probe_stack` calls on x86_64 (debug builds, for stack overflow checks), but the corresponding implementation lives in `compiler_rt/stack_probe.zig` which isn't included in the static archive unless explicitly requested.

## Fix

Set `bundle_compiler_rt = true` on the library in `Zig/omniwm_kernels/build.zig`. This causes Zig to include `compiler_rt` symbols in the static archive, resolving `__zig_probe_stack` (and any other compiler-rt helpers) at link time.

Verified post-fix:
```
$ nm .../debug/x86_64/lib/libomniwm_kernels.a | grep probe_stack
                 U ___zig_probe_stack
0000000000001080 T ___zig_probe_stack
0000000000001080 t _compiler_rt.stack_probe.zig_probe_stack
```

The symbol now has both undefined references (`U`) and a definition (`T`), so the linker is happy.

## Verification

- `make build` (arm64-only) passes
- `./Scripts/package-app.sh debug false` produces a universal `.app` (verified `lipo -info`: `x86_64 arm64`)
- Packaged debug build runs for several hours of normal use including Niri layout, workspace switches, Quake terminal, and `omniwmctl` IPC commands without runtime issues attributable to the change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated library build configuration to bundle runtime dependencies into the final artifact, ensuring better portability and self-contained distribution of the library.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->