### PR TITLE
Fix two SwiftLint warnings

### DIFF
--- a/Sources/OmniWM/Core/Controller/AXEventHandler.swift
+++ b/Sources/OmniWM/Core/Controller/AXEventHandler.swift
@@ -2116,7 +2116,7 @@ final class AXEventHandler: CGSEventDelegate {
     }
 
     private func shouldDelayManagedReplacementCreate(_ candidate: PreparedCreate) -> Bool {
-        guard let _ = managedReplacementCorrelationPolicy(for: candidate.replacementMetadata) else {
+        guard managedReplacementCorrelationPolicy(for: candidate.replacementMetadata) != nil else {
             return false
         }
 

--- a/Sources/OmniWM/Core/Controller/WMController.swift
+++ b/Sources/OmniWM/Core/Controller/WMController.swift
@@ -429,7 +429,11 @@ final class WMController {
             && hasStartedServices
             && !serviceLifecycleManager.isSecureInputActive
         hotkeysEnabled = shouldEnableHotkeys
-        shouldEnableHotkeys ? hotkeys.start() : hotkeys.stop()
+        if shouldEnableHotkeys {
+            hotkeys.start()
+        } else {
+            hotkeys.stop()
+        }
     }
 
     func setGapSize(_ size: Double) {


### PR DESCRIPTION
Two trivial SwiftLint warnings, both flagged on the current `main`:

## `unused_optional_binding` in `AXEventHandler.swift:2119`

```swift
guard let _ = managedReplacementCorrelationPolicy(for: candidate.replacementMetadata) else {
    return false
}
```

→

```swift
guard managedReplacementCorrelationPolicy(for: candidate.replacementMetadata) != nil else {
    return false
}
```

SwiftLint message: `Prefer != nil over let _ =`.

## `void_function_in_ternary` in `WMController.swift:432`

```swift
shouldEnableHotkeys ? hotkeys.start() : hotkeys.stop()
```

→

```swift
if shouldEnableHotkeys {
    hotkeys.start()
} else {
    hotkeys.stop()
}
```

SwiftLint message: `Using ternary to call Void functions should be avoided`.

Both changes are pure semantic refactors — no behavior change. After this PR, `make lint` reports 979 violations (down from 981), with the remaining ones all structural (file length, complexity, line length).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved code clarity by replacing optional-binding patterns with explicit checks and converting ternary expressions to if/else statements for better readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->