### PR TITLE
perf: avoid full CGSWindowList scan in Quake terminal screen detection

### DIFF
--- a/Sources/OmniWM/Core/Controller/WMController.swift
+++ b/Sources/OmniWM/Core/Controller/WMController.swift
@@ -108,6 +108,9 @@ final class WMController {
         },
         restoreFocusTarget: { [weak self] target in
             self?.restoreQuakeTerminalFocus(to: target)
+        },
+        focusedWindowScreenProvider: { [weak self] in
+            self?.focusedManagedWindowScreen()
         }
     )
     @ObservationIgnored
@@ -1206,6 +1209,17 @@ final class WMController {
         AXWindowService.framePreferFast(entry.axRef)
             ?? axManager.lastAppliedFrame(for: entry.windowId)
             ?? (try? AXWindowService.frame(entry.axRef))
+    }
+
+    func focusedManagedWindowScreen() -> NSScreen? {
+        guard let token = workspaceManager.focusedToken,
+              let entry = workspaceManager.entry(for: token),
+              let frame = liveFrame(for: entry),
+              let monitor = frame.center.monitorApproximation(in: workspaceManager.monitors)
+        else {
+            return nil
+        }
+        return NSScreen.screens.first(where: { $0.displayId == monitor.displayId })
     }
 
     private func floatingPlacementMonitor(

--- a/Sources/OmniWM/QuakeTerminal/QuakeTerminalController.swift
+++ b/Sources/OmniWM/QuakeTerminal/QuakeTerminalController.swift
@@ -45,6 +45,7 @@ final class QuakeTerminalController: NSObject, NSWindowDelegate, QuakeTerminalTa
     private let captureRestoreTarget: @MainActor () -> QuakeTerminalRestoreTarget?
     private let restoreFocusTarget: @MainActor (QuakeTerminalRestoreTarget) -> Void
     private let isWindowFocused: @MainActor (NSWindow) -> Bool
+    private let focusedWindowScreenProvider: @MainActor () -> NSScreen?
 
     private static var ghosttyInitialized = false
 
@@ -53,13 +54,15 @@ final class QuakeTerminalController: NSObject, NSWindowDelegate, QuakeTerminalTa
         motionPolicy: MotionPolicy,
         captureRestoreTarget: @escaping @MainActor () -> QuakeTerminalRestoreTarget? = { nil },
         restoreFocusTarget: @escaping @MainActor (QuakeTerminalRestoreTarget) -> Void = { _ in },
-        isWindowFocused: @escaping @MainActor (NSWindow) -> Bool = { $0.isKeyWindow }
+        isWindowFocused: @escaping @MainActor (NSWindow) -> Bool = { $0.isKeyWindow },
+        focusedWindowScreenProvider: @escaping @MainActor () -> NSScreen? = { nil }
     ) {
         self.settings = settings
         self.motionPolicy = motionPolicy
         self.captureRestoreTarget = captureRestoreTarget
         self.restoreFocusTarget = restoreFocusTarget
         self.isWindowFocused = isWindowFocused
+        self.focusedWindowScreenProvider = focusedWindowScreenProvider
         super.init()
     }
 
@@ -750,6 +753,9 @@ final class QuakeTerminalController: NSObject, NSWindowDelegate, QuakeTerminalTa
             }
 
         case .focusedWindow:
+            if let screen = focusedWindowScreenProvider() {
+                return screen
+            }
             if let screen = screenOfFocusedWindow(monitors: monitors) {
                 return screen
             }


### PR DESCRIPTION
## Problem

When `quakeTerminalMonitorMode == .focusedWindow`, every Quake terminal toggle calls `QuakeTerminalController.screenOfFocusedWindow`, which performs a full window-server snapshot:

```swift
guard let windowList = CGWindowListCopyWindowInfo(
    [.optionOnScreenOnly, .excludeDesktopElements],
    kCGNullWindowID  // all windows
) as? [[String: Any]] else { return nil }
```

`kCGNullWindowID` returns every on-screen window in the system — including app-private and inter-process layers — just to find which screen the topmost non-OmniWM window is on. The cost scales with system window count and is typically 5–20 ms per call (more with 50+ windows). Since toggling the Quake terminal is interactive, this contributes directly to perceived latency.

`WMController` already knows which window is focused (`workspaceManager.focusedToken`) and where it lives, so the snapshot is redundant for the common case.

## Fix

Inject a closure into `QuakeTerminalController` that resolves the focused window's screen directly from `WMController` state.

- `QuakeTerminalController` gains a `focusedWindowScreenProvider: @MainActor () -> NSScreen?` init parameter (defaults to `{ nil }` so existing call sites compile unchanged).
- In `targetScreen()` for `.focusedWindow` mode, the provider is consulted first; if it returns `nil` (e.g. focus is on an unmanaged window like a Finder dialog), the original `screenOfFocusedWindow` scan runs as a fallback. Behavior is preserved for that edge case.
- `WMController` wires the provider to a new helper `focusedManagedWindowScreen()` that walks `focusedToken → entry → liveFrame → monitorApproximation → NSScreen` — all O(1) lookups against existing in-memory state.

## Verification

- `make build` passes.
- `make test` passes (1997 / 1997, including all 27 Quake-related tests).
- Manually verified on a multi-monitor setup: focusing a managed window on monitor A then triggering Quake places the terminal on monitor A; switching focus to a window on monitor B and re-triggering places it on monitor B. Focusing an unmanaged window (Finder, System Settings) still falls back to the original scan and lands somewhere sensible.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy of screen detection when positioning the quake terminal on the currently focused window's screen, ensuring proper placement across multiple monitors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->