### PR TITLE
perf: skip border work when borders are disabled

### DIFF
--- a/Sources/OmniWM/Core/Border/BorderManager.swift
+++ b/Sources/OmniWM/Core/Border/BorderManager.swift
@@ -27,6 +27,10 @@ final class BorderManager {
         self.borderWindowFactory = borderWindowFactory
     }
 
+    var isEnabled: Bool {
+        config.enabled
+    }
+
     func setEnabled(_ enabled: Bool) {
         config.enabled = enabled
         if !enabled {

--- a/Sources/OmniWM/Core/Controller/AXEventHandler.swift
+++ b/Sources/OmniWM/Core/Controller/AXEventHandler.swift
@@ -346,7 +346,9 @@ final class AXEventHandler: CGSEventDelegate {
 
     private func handleFrameChanged(windowId: UInt32) {
         guard let controller else { return }
-        _ = controller.borderCoordinator.reconcile(event: .cgsFrameChanged(windowId: windowId))
+        if controller.borderManager.isEnabled {
+            _ = controller.borderCoordinator.reconcile(event: .cgsFrameChanged(windowId: windowId))
+        }
         guard let token = resolveTrackedToken(windowId) else { return }
         guard let entry = controller.workspaceManager.entry(for: token) else { return }
 
@@ -2433,6 +2435,7 @@ final class AXEventHandler: CGSEventDelegate {
         entry: WindowModel.Entry
     ) {
         guard let controller else { return }
+        guard controller.borderManager.isEnabled else { return }
         guard controller.currentKeyboardFocusTargetForRendering()?.token == entry.token else { return }
 
         let registry = controller.workspaceManager.logicalWindowRegistry

--- a/Sources/OmniWM/Core/Controller/WMController.swift
+++ b/Sources/OmniWM/Core/Controller/WMController.swift
@@ -3610,7 +3610,8 @@ extension WMController {
         policy: KeyboardFocusBorderRenderPolicy = .coordinated,
         source: BorderReconcileSource = .manualRender
     ) -> Bool {
-        borderCoordinator.renderBorder(
+        guard borderManager.isEnabled else { return false }
+        return borderCoordinator.renderBorder(
             for: target ?? currentKeyboardFocusTargetForRendering(),
             preferredFrame: preferredFrame,
             policy: policy,
@@ -3626,6 +3627,7 @@ extension WMController {
         matchingPid: pid_t? = nil,
         matchingWindowId: Int? = nil
     ) -> Bool {
+        guard borderManager.isEnabled else { return false }
         return borderCoordinator.hideBorder(
             source: source,
             reason: reason,

--- a/Tests/OmniWMTests/BorderCoordinatorTests.swift
+++ b/Tests/OmniWMTests/BorderCoordinatorTests.swift
@@ -1334,4 +1334,177 @@ struct BorderCoordinatorTests {
         #expect(unsubscriptions == [[913]])
     }
 
+    @Test @MainActor func renderRequestShortCircuitsWhenBordersDisabled() {
+        let controller = makeLayoutPlanTestController()
+        let target = makeBorderCoordinatorFallbackTarget(windowId: 920)
+        let frame = CGRect(x: 24, y: 36, width: 480, height: 320)
+
+        controller.setBordersEnabled(false)
+        controller.focusBridge.setFocusedTarget(target)
+        controller.borderCoordinator.observedFrameProviderForTests = { _ in frame }
+
+        var infoProviderCalls = 0
+        controller.axEventHandler.windowInfoProvider = { windowId in
+            infoProviderCalls += 1
+            return makeBorderCoordinatorWindowInfo(id: windowId, frame: frame)
+        }
+        var factsProviderCalls = 0
+        controller.axEventHandler.windowFactsProvider = { axRef, _ in
+            factsProviderCalls += 1
+            return makeBorderCoordinatorWindowFacts(
+                title: "disabled-window",
+                windowServer: makeBorderCoordinatorWindowInfo(
+                    id: UInt32(axRef.windowId),
+                    frame: frame,
+                    title: "disabled-window"
+                )
+            )
+        }
+
+        let rendered = controller.renderKeyboardFocusBorder(
+            for: target,
+            preferredFrame: nil,
+            policy: .direct,
+            source: .manualRender
+        )
+        #expect(rendered == false)
+        #expect(controller.borderManager.isEnabled == false)
+        #expect(controller.borderCoordinator.ownerStateSnapshotForTests().owner == .none)
+        #expect(lastAppliedBorderWindowIdForLayoutPlanTests(on: controller) == nil)
+        #expect(infoProviderCalls == 0)
+        #expect(factsProviderCalls == 0)
+    }
+
+    @Test @MainActor func cgsFrameChangedSkippedWhenBordersDisabled() {
+        let controller = makeLayoutPlanTestController()
+        let target = makeBorderCoordinatorFallbackTarget(windowId: 921)
+        let frame = CGRect(x: 12, y: 18, width: 320, height: 240)
+
+        controller.setBordersEnabled(true)
+        controller.focusBridge.setFocusedTarget(target)
+        controller.borderCoordinator.observedFrameProviderForTests = { _ in frame }
+        controller.axEventHandler.windowInfoProvider = { windowId in
+            guard windowId == 921 else { return nil }
+            return makeBorderCoordinatorWindowInfo(id: windowId, frame: frame)
+        }
+        controller.axEventHandler.windowFactsProvider = { axRef, _ in
+            makeBorderCoordinatorWindowFacts(
+                title: "disabled-frame",
+                windowServer: makeBorderCoordinatorWindowInfo(
+                    id: UInt32(axRef.windowId),
+                    frame: frame,
+                    title: "disabled-frame"
+                )
+            )
+        }
+
+        #expect(
+            controller.borderCoordinator.reconcile(
+                event: .renderRequested(
+                    source: .manualRender,
+                    target: target,
+                    preferredFrame: nil,
+                    policy: .direct
+                )
+            )
+        )
+        #expect(controller.borderCoordinator.ownerStateSnapshotForTests().owner != .none)
+
+        controller.setBordersEnabled(false)
+        #expect(controller.borderCoordinator.ownerStateSnapshotForTests().owner == .none)
+
+        var observedFrameCalls = 0
+        controller.borderCoordinator.observedFrameProviderForTests = { _ in
+            observedFrameCalls += 1
+            return frame
+        }
+
+        controller.axEventHandler.cgsEventObserver(
+            CGSEventObserver.shared,
+            didReceive: .frameChanged(windowId: 921)
+        )
+
+        #expect(controller.borderCoordinator.ownerStateSnapshotForTests().owner == .none)
+        #expect(lastAppliedBorderWindowIdForLayoutPlanTests(on: controller) == nil)
+        #expect(observedFrameCalls == 0)
+    }
+
+    @Test @MainActor func disableAfterRenderClearsOwnerAndReEnableRenders() {
+        let controller = makeLayoutPlanTestController()
+        let target = makeBorderCoordinatorFallbackTarget(windowId: 922)
+        let frame = CGRect(x: 50, y: 70, width: 600, height: 400)
+
+        controller.setBordersEnabled(true)
+        controller.focusBridge.setFocusedTarget(target)
+        controller.borderCoordinator.observedFrameProviderForTests = { _ in frame }
+        controller.axEventHandler.windowInfoProvider = { windowId in
+            guard windowId == 922 else { return nil }
+            return makeBorderCoordinatorWindowInfo(id: windowId, frame: frame)
+        }
+        controller.axEventHandler.windowFactsProvider = { axRef, _ in
+            makeBorderCoordinatorWindowFacts(
+                title: "reenable-window",
+                windowServer: makeBorderCoordinatorWindowInfo(
+                    id: UInt32(axRef.windowId),
+                    frame: frame,
+                    title: "reenable-window"
+                )
+            )
+        }
+
+        #expect(
+            controller.renderKeyboardFocusBorder(
+                for: target,
+                preferredFrame: nil,
+                policy: .direct,
+                source: .manualRender
+            )
+        )
+        #expect(lastAppliedBorderWindowIdForLayoutPlanTests(on: controller) == 922)
+        #expect(controller.borderCoordinator.ownerStateSnapshotForTests().owner != .none)
+
+        controller.setBordersEnabled(false)
+        #expect(controller.borderManager.isEnabled == false)
+        #expect(controller.borderCoordinator.ownerStateSnapshotForTests().owner == .none)
+        #expect(lastAppliedBorderWindowIdForLayoutPlanTests(on: controller) == nil)
+
+        #expect(
+            controller.renderKeyboardFocusBorder(
+                for: target,
+                preferredFrame: nil,
+                policy: .direct,
+                source: .manualRender
+            ) == false
+        )
+        #expect(controller.borderCoordinator.ownerStateSnapshotForTests().owner == .none)
+
+        controller.setBordersEnabled(true)
+        #expect(controller.borderManager.isEnabled == true)
+        #expect(
+            controller.renderKeyboardFocusBorder(
+                for: target,
+                preferredFrame: nil,
+                policy: .direct,
+                source: .manualRender
+            )
+        )
+        #expect(lastAppliedBorderWindowIdForLayoutPlanTests(on: controller) == 922)
+    }
+
+    @Test @MainActor func cgsClosedDestroyedStillReconcileWhenBordersDisabled() {
+        let controller = makeLayoutPlanTestController()
+        controller.setBordersEnabled(false)
+
+        controller.axEventHandler.cgsEventObserver(
+            CGSEventObserver.shared,
+            didReceive: .closed(windowId: 923)
+        )
+        controller.axEventHandler.cgsEventObserver(
+            CGSEventObserver.shared,
+            didReceive: .destroyed(windowId: 923, spaceId: 0)
+        )
+
+        #expect(controller.borderCoordinator.ownerStateSnapshotForTests().owner == .none)
+        #expect(controller.borderManager.isEnabled == false)
+    }
 }


### PR DESCRIPTION
## Summary

When `borders.enabled = false`, OmniWM should avoid border rendering work, not only avoid drawing the border window.

This change short-circuits the hot border paths before they enter `BorderCoordinator` when borders are disabled.

## Changes

- Add a narrow `BorderManager.isEnabled` read accessor.
- Return early from `renderKeyboardFocusBorder(...)` when borders are disabled.
- Skip CGS `.frameChanged` border reconciliation when borders are disabled.
- Skip managed-rekey border refresh when borders are disabled.
- Keep `.cgsClosed` / `.cgsDestroyed` reconciliation intact so corner-radius cache invalidation remains correct.
- Add tests covering disabled render, frame-change skip, disable/re-enable behavior, and lifecycle safety.

## Performance

The tests verify the perf gate structurally: disabled-border paths do not call the window-info, window-facts, or observed-frame providers used by `BorderCoordinator`'s heavier render decision path.

## Notes

This does not add new UI for external border renderers. Users running tools such as JankyBorders can continue using the existing `borders.enabled = false` setting.

This also does not change unmanaged-window border tracking or add AX-frame-observed reconciliation.

## Testing

- `swift test --filter BorderCoordinatorTests`
- `./Scripts/package-app.sh debug false`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed border rendering operations to properly respect the disabled state across all window events.
  * Ensured borders remain disabled during state transitions and do not unexpectedly re-enable.

* **Tests**
  * Added comprehensive test coverage for border behavior when disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->