### PR TITLE
Fix: include CGWindowList in pidsWithWindows to catch Electron windows SLS misses

### DIFF
--- a/Sources/OmniWM/Core/Ax/AXManager.swift
+++ b/Sources/OmniWM/Core/Ax/AXManager.swift
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0-only
 import AppKit
 import ApplicationServices
+import CoreGraphics
 import Foundation
 
 private let perAppTimeout: TimeInterval = 0.5
@@ -286,7 +287,31 @@ final class AXManager {
         }
 
         let visibleWindows = SkyLight.shared.queryAllVisibleWindows()
-        let pidsWithWindows = Set(visibleWindows.map { $0.pid })
+        var pidsWithWindows = Set(visibleWindows.map { $0.pid })
+
+        // Patch: SLSWindowQueryWindows(cid, [], _) silently omits windows
+        // owned by certain Electron-based apps (notably WeChat —
+        // com.tencent.xinWeChat — verified empirically: its window is
+        // returned when queried by WID directly, but never appears in the
+        // empty-array enumeration regardless of the flags bitmap). Augment
+        // pidsWithWindows from the public CGWindowList API, which does see
+        // these apps. Filter to layer==0 (regular app windows) and
+        // alpha>0 (actually rendered) to avoid Dock / menubar / wallpaper.
+        // Additive only: apps already discovered via SLS are unaffected.
+        if let cgWindows = CGWindowListCopyWindowInfo(
+            [.optionOnScreenOnly, .excludeDesktopElements],
+            kCGNullWindowID
+        ) as? [[String: Any]] {
+            for window in cgWindows {
+                guard let pidNumber = window[kCGWindowOwnerPID as String] as? Int,
+                      let layer = window[kCGWindowLayer as String] as? Int,
+                      layer == 0,
+                      let alpha = window[kCGWindowAlpha as String] as? Double,
+                      alpha > 0
+                else { continue }
+                pidsWithWindows.insert(pid_t(pidNumber))
+            }
+        }
 
         let apps = NSWorkspace.shared.runningApplications.filter {
             shouldTrack($0) && pidsWithWindows.contains($0.processIdentifier)


### PR DESCRIPTION
Fixes #290.

## Summary

Some Electron-based apps (verified: WeChat, ChatGPT Atlas) are silently omitted by the private `SLSWindowQueryWindows(cid, [], _)` empty-array enumeration that `AXManager.fullRescanEnumerationSnapshot()` relies on. Their windows are returned when queried by WID directly but never appear in the full-tree enumeration regardless of the flags bitmap. The pid never makes it into `pidsWithWindows`, so the rest of OmniWM never sees these apps.

## Change

Augment `pidsWithWindows` from the public `CGWindowListCopyWindowInfo` API as a complement, restricted to `kCGWindowLayer == 0` (regular app windows) and `kCGWindowAlpha > 0` (actually rendered) to avoid Dock / menubar / wallpaper / tooltips. **Additive only** — apps already discovered via SLS are unaffected.

## Verified

- WeChat: `admissionOutcome: tracked-tiling`, `attributeFetchSucceeded: True`, `disposition: managed` ✅
- All previously-tracked apps (Claude / Spotify / Cursor / Mail / Calendar / Ghostty): unchanged ✅
- Persistent (no 'drops after 30s' regression) ✅

See #290 for full root-cause investigation, 13-flag test matrix, and reproducer scripts.

## Environment

- macOS 26.4.1 (Tahoe), Apple Silicon
- Swift 6.3.1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced the window detection system to more comprehensively identify applications with active windows, addressing cases where certain applications were not being properly tracked by the existing window enumeration mechanism.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->