### PR TITLE
Fix: hasResolvedAttribute should strict-check AXUIElement to ignore AXValue error wrappers

### DIFF
--- a/Sources/OmniWM/Core/Ax/AXWindow.swift
+++ b/Sources/OmniWM/Core/Ax/AXWindow.swift
@@ -526,7 +526,20 @@ enum AXWindowService {
 
         func hasResolvedAttribute(_ value: Any?) -> Bool {
             guard let value else { return false }
-            return !(value is NSError)
+            if value is NSError { return false }
+            // Patch B: AXUIElementCopyMultipleAttributeValues with options=0
+            // returns *typed error wrappers* for missing attributes, not nil.
+            // Empirically observed for AXFullScreenButton on bilibili
+            // (com.bilibili.bilibiliPC): an `AXValue` containing
+            // `kAXValueAXErrorType` (error -25212 / kAXErrorNoValue), which
+            // is neither NSError nor CFError and slips past the original
+            // nil/NSError filter. The downstream code only ever calls this
+            // function on close/fullscreen/zoom/minimize button attributes —
+            // all of which must be AXUIElements when present — so accept
+            // ONLY genuine AXUIElement values. Anything else is treated as
+            // "attribute absent / unusable", which keeps
+            // attributeFetchSucceeded=true and lets bilibili tile.
+            return CFGetTypeID(value as CFTypeRef) == AXUIElementGetTypeID()
         }
 
         let fullscreenButtonElement = attributeValue(.fullScreenButton)


### PR DESCRIPTION
Fixes #291.

## Summary

`AXUIElementCopyMultipleAttributeValues` with `options=0` returns *typed error wrappers* (not nil) for missing attributes. Empirically observed for `AXFullScreenButton` on bilibili: an `AXValue` containing `kAXValueAXErrorType` (error -25212), which is neither `NSError` nor `CFError` and slips past the original `!(value is NSError)` filter. The wrapper is then misclassified as 'button present', which trips the AXUIElement type-check downstream and sets `attributeFetchSucceeded = false` on what is otherwise a perfectly normal window. The kernel sees `attributeFetchFailed` and returns `deferred / undecided` → window stays floating.

## Change

`hasResolvedAttribute` is only ever called on close / fullscreen / zoom / minimize button attributes — all of which must be `AXUIElement`s when present. Tighten the check to accept ONLY genuine `AXUIElement` values; treat anything else (AXValue error wrapper, CFError, etc.) as 'attribute absent / unusable'.

## Behaviour matrix

| Returned value type | Old | New | Correct? |
|---|---|---|---|
| `nil` | false | false | ✅ same |
| `NSError` | false | false | ✅ same |
| Real `AXUIElement` (button) | true | true | ✅ same |
| `AXValue` error wrapper | true (BUG) | false | ✅ fixed |
| `CFError` (theoretical) | true (BUG) | false | ✅ fixed |

## Verified

- bilibili: `attributeFetchSucceeded: True`, `admissionOutcome: tracked-floating` (was deferred) ✅
- Re-tested every previously-working app (Claude / Spotify / Cursor / Mail / Calendar / Ghostty / WeChat) — no disposition changes ✅

The remaining `floating` disposition for bilibili is now a legitimate heuristic decision (`missingFullscreenButton`) that users can override with a per-app rule.

See #291 for full reproducer and per-attribute type dump.

## Environment

- macOS 26.4.1 (Tahoe), Apple Silicon
- Swift 6.3.1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy of window button detection (close, fullscreen, zoom, minimize) through stricter validation of window attributes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->