### PR TITLE
fix: preserve tiled mode during heuristic reevaluation

### DIFF
--- a/Sources/OmniWM/Core/Controller/WMController.swift
+++ b/Sources/OmniWM/Core/Controller/WMController.swift
@@ -1377,6 +1377,30 @@ final class WMController {
         return nil
     }
 
+    private func trackedModeForAutomaticReevaluation(
+        decision: WindowDecision,
+        existingEntry: WindowModel.Entry?,
+        context: WindowRuleReevaluationContext
+    ) -> TrackedWindowMode? {
+        guard let trackedMode = trackedModeForLifecycle(
+            decision: decision,
+            existingEntry: existingEntry
+        ) else {
+            return nil
+        }
+
+        guard context == .automatic,
+              let existingEntry,
+              existingEntry.mode == .tiling,
+              trackedMode == .floating,
+              decision.source == .heuristic
+        else {
+            return trackedMode
+        }
+
+        return .tiling
+    }
+
     func resolvedWorkspaceId(
         for evaluation: WindowDecisionEvaluation,
         axRef: AXWindowRef,
@@ -1607,9 +1631,10 @@ final class WMController {
             evaluatedAnyWindow = true
             let evaluation = evaluateWindowDisposition(axRef: axRef, pid: token.pid)
 
-            guard let trackedMode = trackedModeForLifecycle(
+            guard let effectiveTrackedMode = trackedModeForAutomaticReevaluation(
                 decision: evaluation.decision,
-                existingEntry: existingEntry
+                existingEntry: existingEntry,
+                context: context
             ) else {
                 if let existingEntry {
                     affectedWorkspaceIds.insert(existingEntry.workspaceId)
@@ -1635,17 +1660,17 @@ final class WMController {
                 pid: token.pid,
                 windowId: token.windowId,
                 to: workspaceId,
-                mode: oldMode ?? trackedMode,
+                mode: oldMode ?? effectiveTrackedMode,
                 ruleEffects: evaluation.decision.ruleEffects
             )
 
-            if let oldMode, oldMode != trackedMode {
+            if let oldMode, oldMode != effectiveTrackedMode {
                 _ = transitionWindowMode(
                     for: token,
-                    to: trackedMode,
+                    to: effectiveTrackedMode,
                     preferredMonitor: workspaceManager.monitor(for: workspaceId)
                 )
-            } else if trackedMode == .floating {
+            } else if effectiveTrackedMode == .floating {
                 seedFloatingGeometryIfNeeded(
                     for: token,
                     preferredMonitor: workspaceManager.monitor(for: workspaceId)
@@ -1672,7 +1697,7 @@ final class WMController {
             if existingEntry == nil
                 || oldEffects != evaluation.decision.ruleEffects
                 || oldWorkspaceId != workspaceId
-                || oldMode != trackedMode
+                || oldMode != effectiveTrackedMode
             {
                 if let oldWorkspaceId {
                     affectedWorkspaceIds.insert(oldWorkspaceId)

--- a/Tests/OmniWMTests/AXEventHandlerTests.swift
+++ b/Tests/OmniWMTests/AXEventHandlerTests.swift
@@ -5220,6 +5220,46 @@ private func waitUntilAXEventTest(
         #expect(relayoutReasons == [.windowRuleReevaluation])
     }
 
+    @Test @MainActor func automaticHeuristicReevaluationDoesNotFloatExistingTiledWindow() async {
+        let controller = makeAXEventTestController()
+        guard let workspaceId = controller.activeWorkspace()?.id else {
+            Issue.record("Missing active workspace")
+            return
+        }
+
+        let pid = getpid()
+        let token = controller.workspaceManager.addWindow(
+            AXWindowRef(element: AXUIElementCreateSystemWide(), windowId: 826),
+            pid: pid,
+            windowId: 826,
+            to: workspaceId,
+            mode: .tiling
+        )
+        controller.axEventHandler.axWindowRefProvider = { windowId, _ in
+            guard windowId == 826 else { return nil }
+            return AXWindowRef(element: AXUIElementCreateSystemWide(), windowId: Int(windowId))
+        }
+        controller.axEventHandler.windowFactsProvider = { _, _ in
+            makeAXEventWindowRuleFacts(
+                bundleId: "com.jetbrains.rustrover",
+                hasFullscreenButton: false
+            )
+        }
+        controller.layoutRefreshController.resetDebugState()
+        controller.layoutRefreshController.debugHooks.onRelayout = { reason, _ in
+            Issue.record("Unexpected relayout reason: \(reason)")
+            return true
+        }
+
+        let outcome = await controller.reevaluateWindowRules(for: [.window(token)])
+        await controller.layoutRefreshController.waitForRefreshWorkForTests()
+
+        #expect(outcome.resolvedAnyTarget)
+        #expect(outcome.evaluatedAnyWindow)
+        #expect(!outcome.relayoutNeeded)
+        #expect(controller.workspaceManager.entry(for: token)?.mode == .tiling)
+    }
+
     @Test @MainActor func appHideAndUnhideUseVisibilityRouteAndPreserveModelState() async {
         let controller = makeAXEventTestController()
         guard let workspaceId = controller.activeWorkspace()?.id else {


### PR DESCRIPTION
> [!NOTE]
> **AI Disclosure**: I asked the Codex agent to help investigating and fix the issue. I have reviewed the output and tested manually.

Closes #299 
Closes #303 

When the parent window opens a dialog, OmniVM detects it and marks the window as floating. However, the parent window is also marked as floating, causing the window to be detached from the Niri layout.

This pull request fixes the heuristic to change only the child dialog to floating, keeping the parent as tiling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed automatic window rule reevaluations incorrectly changing existing tiled windows to floating mode.

* **Tests**
  * Added test to verify tiled windows remain in tiling mode during automatic heuristic reevaluation.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/BarutSRB/OmniWM/pull/312)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->