### PR TITLE
fix: correct Niri viewport origin for inset working areas

### DIFF
--- a/Sources/OmniWM/Core/Layout/Niri/ViewportState+Geometry.swift
+++ b/Sources/OmniWM/Core/Layout/Niri/ViewportState+Geometry.swift
@@ -114,21 +114,34 @@ extension ViewportState {
             CGRect(x: 0, y: 0, width: crossSpan, height: viewportSpan)
         }
         let parentFrame = viewFrame ?? workingArea ?? fallbackParentFrame
-        let parent = CGRect(origin: .zero, size: parentFrame.size)
 
         let localWorking: CGRect
         if let workingArea {
             localWorking = CGRect(
-                x: workingArea.minX - parentFrame.minX,
-                y: workingArea.minY - parentFrame.minY,
-                width: workingArea.width,
-                height: workingArea.height
+                origin: .zero,
+                size: workingArea.size
             )
         } else {
-            localWorking = parent
+            localWorking = CGRect(origin: .zero, size: parentFrame.size)
         }
 
-        let fallbackLocalFrame = CGRect(origin: .zero, size: fallbackParentFrame.size)
+        let parent: CGRect
+        if let workingArea {
+            parent = CGRect(
+                x: parentFrame.minX - workingArea.minX,
+                y: parentFrame.minY - workingArea.minY,
+                width: parentFrame.width,
+                height: parentFrame.height
+            )
+        } else {
+            parent = CGRect(
+                origin: .zero,
+                size: parentFrame.size
+            )
+        }
+
+        let fallbackLocalSize = workingArea?.size ?? fallbackParentFrame.size
+        let fallbackLocalFrame = CGRect(origin: .zero, size: fallbackLocalSize)
         let primarySpan: (CGRect) -> CGFloat = { rect in
             switch orientation {
             case .horizontal:

--- a/Tests/OmniWMTests/NiriLayoutEngineTests.swift
+++ b/Tests/OmniWMTests/NiriLayoutEngineTests.swift
@@ -2186,7 +2186,7 @@ private func makeCenteredCrossMonitorFixture(
         )
 
         #expect(changed)
-        #expect(abs(state.viewOffsetPixels.target() + 345) < 0.001)
+        #expect(abs(state.viewOffsetPixels.target() + 375) < 0.001)
     }
 
     @Test func centerVisibleColumnsNoOpsWhenFocusedColumnIsAlwaysCentered() {

--- a/Tests/OmniWMTests/ViewportGeometryTests.swift
+++ b/Tests/OmniWMTests/ViewportGeometryTests.swift
@@ -113,6 +113,57 @@ private func makeViewportGestureContainers(
         #expect(abs(fullscreenOffset) < 0.001)
     }
 
+    @Test func centeredOffsetUsesWorkingAreaRelativeCoordinatesForInsetDock() {
+        let state = ViewportState()
+        let workingArea = CGRect(x: 100, y: 0, width: 1_000, height: 800)
+        let parentArea = CGRect(x: 0, y: 0, width: 1_200, height: 800)
+        let gap: CGFloat = 10
+
+        let normal = makeViewportGestureContainers(widths: [600], modes: [.normal])
+        let maximized = makeViewportGestureContainers(widths: [600], modes: [.maximized])
+
+        let normalOffset = state.computeCenteredOffset(
+            containerIndex: 0,
+            containers: normal,
+            gap: gap,
+            viewportSpan: workingArea.width,
+            sizeKeyPath: \.cachedWidth,
+            workingArea: workingArea,
+            viewFrame: parentArea
+        )
+        let maximizedOffset = state.computeCenteredOffset(
+            containerIndex: 0,
+            containers: maximized,
+            gap: gap,
+            viewportSpan: workingArea.width,
+            sizeKeyPath: \.cachedWidth,
+            workingArea: workingArea,
+            viewFrame: parentArea
+        )
+
+        #expect(abs(normalOffset + 200) < 0.001)
+        #expect(abs(maximizedOffset + 200) < 0.001)
+    }
+
+    @Test func fullWidthNormalColumnDoesNotInheritLeftDockInset() {
+        let state = ViewportState()
+        let workingArea = CGRect(x: 100, y: 0, width: 1_000, height: 800)
+        let parentArea = CGRect(x: 0, y: 0, width: 1_200, height: 800)
+        let normal = makeViewportGestureContainers(widths: [1_000], modes: [.normal])
+
+        let offset = state.computeCenteredOffset(
+            containerIndex: 0,
+            containers: normal,
+            gap: 10,
+            viewportSpan: workingArea.width,
+            sizeKeyPath: \.cachedWidth,
+            workingArea: workingArea,
+            viewFrame: parentArea
+        )
+
+        #expect(abs(offset) < 0.001)
+    }
+
     @Test func updateGestureDoesNotClampOrAdvanceSelectionDuringSwipe() {
         var state = ViewportState()
         state.activeColumnIndex = 1
@@ -501,7 +552,7 @@ private func makeViewportGestureContainers(
         )
 
         #expect(state.activeColumnIndex == 1)
-        #expect(abs(Double(state.viewOffsetPixels.target()) + 190) < 0.001)
+        #expect(abs(Double(state.viewOffsetPixels.target()) + 90) < 0.001)
     }
 
     @Test func updateGestureReturnsNilForZeroWidthSingleColumn() {


### PR DESCRIPTION
> [!NOTE]
> AI Disclosure: I asked the Codex agent to help investigating and fix the issue. I have reviewed the output and tested manually.

Fixed that windows are layouted with extra gap when Dock is shown. This bug was introduced in a68c3511404e49669eaaaf2d775f664e5693a047 and not reproducible in the latest released version (0.4.8.1).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved viewport positioning calculations when working areas have insets (such as docked windows).
  * Fixed coordinate space handling to ensure windows are positioned correctly relative to available working space.

* **Tests**
  * Added test coverage for centered offset calculations with dock insets.
  * Updated tests to reflect corrected viewport positioning behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/BarutSRB/OmniWM/pull/313)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->