### PR TITLE
fix: restore floating panel classification and bar filtering

### DIFF
--- a/Sources/OmniWM/Core/Ax/AXWindow.swift
+++ b/Sources/OmniWM/Core/Ax/AXWindow.swift
@@ -303,6 +303,10 @@ enum AXWindowService {
         window.windowId
     }
 
+    static func shouldTreatAsTopLevelWindow(role: String?, subrole: String?) -> Bool {
+        role == kAXWindowRole as String || subrole == kAXStandardWindowSubrole as String
+    }
+
     static func frame(_ window: AXWindowRef) throws(AXErrorWrapper) -> CGRect {
         let attributes = [
             kAXPositionAttribute as CFString,
@@ -624,6 +628,14 @@ enum AXWindowService {
             )
         }
 
+        if let subrole = facts.subrole,
+           subrole != (kAXStandardWindowSubrole as String)
+        {
+            return AXWindowHeuristicDisposition(
+                disposition: .floating,
+                reasons: [.nonStandardSubrole]
+            )
+        }
 
         if !facts.hasFullscreenButton {
             return AXWindowHeuristicDisposition(

--- a/Sources/OmniWM/Core/Ax/AXWindow.swift
+++ b/Sources/OmniWM/Core/Ax/AXWindow.swift
@@ -299,10 +299,6 @@ enum AXWindowService {
         }
     }
 
-    static func shouldTreatAsTopLevelWindow(role: String?, subrole: String?) -> Bool {
-        role == kAXWindowRole as String || subrole == kAXStandardWindowSubrole as String
-    }
-
     static func windowId(_ window: AXWindowRef) -> Int {
         window.windowId
     }
@@ -628,14 +624,6 @@ enum AXWindowService {
             )
         }
 
-        if let subrole = facts.subrole,
-           subrole != (kAXStandardWindowSubrole as String)
-        {
-            return AXWindowHeuristicDisposition(
-                disposition: .floating,
-                reasons: [.nonStandardSubrole]
-            )
-        }
 
         if !facts.hasFullscreenButton {
             return AXWindowHeuristicDisposition(

--- a/Sources/OmniWM/Core/Ax/AppAXContext.swift
+++ b/Sources/OmniWM/Core/Ax/AppAXContext.swift
@@ -324,9 +324,26 @@ final class AppAXContext {
                     }
                 }
 
-                guard AXWindowService.shouldTreatAsTopLevelWindow(role: role, subrole: subrole) else {
+                var title: String?
+                var titleValue: CFTypeRef?
+                let titleResult = AXUIElementCopyAttributeValue(
+                    element,
+                    kAXTitleAttribute as CFString,
+                    &titleValue
+                )
+                if titleResult == .success {
+                    title = titleValue as? String
+                }
+
+                let isWindow = role == kAXWindowRole as String
+                let isDialog = role == "AXDialog"
+                let isPanel = role == "AXPanel"
+                
+                // Allow Windows, or Dialogs/Panels with titles (to avoid tooltips)
+                guard isWindow || ((isDialog || isPanel) && title != nil) else {
                     continue
                 }
+
 
                 let axRef = AXWindowRef(element: element, windowId: windowId)
                 newWindows[windowId] = element

--- a/Sources/OmniWM/Core/Ax/AppAXContext.swift
+++ b/Sources/OmniWM/Core/Ax/AppAXContext.swift
@@ -335,15 +335,14 @@ final class AppAXContext {
                     title = titleValue as? String
                 }
 
-                let isWindow = role == kAXWindowRole as String
+                let isWindow = AXWindowService.shouldTreatAsTopLevelWindow(role: role, subrole: subrole)
                 let isDialog = role == "AXDialog"
                 let isPanel = role == "AXPanel"
-                
-                // Allow Windows, or Dialogs/Panels with titles (to avoid tooltips)
+
+                // Allow windows, or titled dialogs/panels (to avoid tooltips).
                 guard isWindow || ((isDialog || isPanel) && title != nil) else {
                     continue
                 }
-
 
                 let axRef = AXWindowRef(element: element, windowId: windowId)
                 newWindows[windowId] = element

--- a/Sources/OmniWM/Core/Controller/WMController.swift
+++ b/Sources/OmniWM/Core/Controller/WMController.swift
@@ -1738,6 +1738,8 @@ final class WMController {
                         title: evaluation.facts.ax.title ?? updatedEntry.managedReplacementMetadata?.title,
                         windowLevel: evaluation.facts.windowServer?.level ?? updatedEntry.managedReplacementMetadata?
                             .windowLevel,
+                        parentWindowId: evaluation.facts.windowServer?.parentId ?? updatedEntry
+                            .managedReplacementMetadata?.parentWindowId,
                         frame: evaluation.facts.windowServer?.frame ?? updatedEntry.managedReplacementMetadata?.frame
                     ),
                     for: token

--- a/Sources/OmniWM/Core/Controller/WMController.swift
+++ b/Sources/OmniWM/Core/Controller/WMController.swift
@@ -1738,8 +1738,6 @@ final class WMController {
                         title: evaluation.facts.ax.title ?? updatedEntry.managedReplacementMetadata?.title,
                         windowLevel: evaluation.facts.windowServer?.level ?? updatedEntry.managedReplacementMetadata?
                             .windowLevel,
-                        parentWindowId: evaluation.facts.windowServer?.parentId ?? updatedEntry
-                            .managedReplacementMetadata?.parentWindowId,
                         frame: evaluation.facts.windowServer?.frame ?? updatedEntry.managedReplacementMetadata?.frame
                     ),
                     for: token

--- a/Sources/OmniWM/Core/Controller/WMController.swift
+++ b/Sources/OmniWM/Core/Controller/WMController.swift
@@ -390,7 +390,7 @@ final class WMController {
         } else {
             hiddenWorkspaceBarMonitorIds.insert(monitor.id)
         }
-
+ 
         cancelPendingWorkspaceBarRefresh()
         workspaceBarManager.setup(controller: self, settings: settings)
         layoutRefreshController.requestRelayout(reason: .monitorSettingsChanged)
@@ -1427,7 +1427,7 @@ final class WMController {
         return nil
     }
 
-    private func trackedModeForAutomaticReevaluation(
+    internal func trackedModeForAutomaticReevaluation(
         decision: WindowDecision,
         existingEntry: WindowModel.Entry?,
         context: WindowRuleReevaluationContext
@@ -1443,7 +1443,7 @@ final class WMController {
               let existingEntry,
               existingEntry.mode == .tiling,
               trackedMode == .floating,
-              decision.source == .heuristic
+              (decision.source == .heuristic || decision.layoutDecisionKind == .fallbackLayout)
         else {
             return trackedMode
         }
@@ -1529,9 +1529,7 @@ final class WMController {
             return preferredWindowInfo
         }
 
-        guard bundleId == WindowRuleEngine.cleanShotBundleId,
-              let windowId = UInt32(exactly: token.windowId)
-        else {
+        guard let windowId = UInt32(exactly: token.windowId) else {
             return nil
         }
 

--- a/Sources/OmniWM/Core/Rules/WindowRuleEngine.swift
+++ b/Sources/OmniWM/Core/Rules/WindowRuleEngine.swift
@@ -344,6 +344,18 @@ final class WindowRuleEngine {
             return cleanShotDecision
         }
 
+        if let parentId = facts.windowServer?.parentId, parentId != 0 {
+            return WindowDecision(
+                disposition: .floating,
+                source: .builtInRule("childWindowStructuralAnchor"),
+                layoutDecisionKind: .explicitLayout,
+                workspaceName: workspaceName,
+                ruleEffects: effects,
+                heuristicReasons: [],
+                deferredReason: nil
+            )
+        }
+
         if facts.ax.title == nil,
            requiresTitle(for: facts.ax.bundleId)
         {

--- a/Sources/OmniWM/Core/Rules/WindowRuleEngine.swift
+++ b/Sources/OmniWM/Core/Rules/WindowRuleEngine.swift
@@ -344,18 +344,6 @@ final class WindowRuleEngine {
             return cleanShotDecision
         }
 
-        if let parentId = facts.windowServer?.parentId, parentId != 0 {
-            return WindowDecision(
-                disposition: .floating,
-                source: .builtInRule("childWindowStructuralAnchor"),
-                layoutDecisionKind: .explicitLayout,
-                workspaceName: workspaceName,
-                ruleEffects: effects,
-                heuristicReasons: [],
-                deferredReason: nil
-            )
-        }
-
         if facts.ax.title == nil,
            requiresTitle(for: facts.ax.bundleId)
         {

--- a/Sources/OmniWM/Core/Workspace/WindowModel.swift
+++ b/Sources/OmniWM/Core/Workspace/WindowModel.swift
@@ -514,7 +514,6 @@ final class WindowModel {
     func allEntries() -> [Entry] {
         Array(entries.values)
     }
-
     func allEntries(mode: TrackedWindowMode) -> [Entry] {
         tokensByWorkspaceMode
             .filter { $0.key.mode == mode }

--- a/Sources/OmniWM/Core/Workspace/WorkspaceManager.swift
+++ b/Sources/OmniWM/Core/Workspace/WorkspaceManager.swift
@@ -2025,7 +2025,10 @@ final class WorkspaceManager {
     }
 
     private func barVisibleFloatingEntries(in workspace: WorkspaceDescriptor.ID) -> [WindowModel.Entry] {
-        floatingEntries(in: workspace).filter { hiddenState(for: $0.token)?.isScratchpad != true }
+        floatingEntries(in: workspace).filter {
+            hiddenState(for: $0.token)?.isScratchpad != true
+                && layoutReason(for: $0.token) == .standard
+        }
     }
 
     func handle(for token: WindowToken) -> WindowHandle? {

--- a/Tests/OmniWMTests/WMControllerReevaluationRegressionTests.swift
+++ b/Tests/OmniWMTests/WMControllerReevaluationRegressionTests.swift
@@ -1,0 +1,123 @@
+import AppKit
+import ApplicationServices
+import CoreGraphics
+import Foundation
+@testable import OmniWM
+import Testing
+
+@Suite(.serialized) @MainActor struct WMControllerReevaluationRegressionTests {
+    @Test func automaticReevaluationPreservesTilingForHeuristicFallback() {
+        // This test verifies the fix for Issue #306 where popups would cause 
+        // tiled windows to float during automatic reevaluation due to heuristic fallbacks.
+        
+        resetSharedControllerStateForTests()
+        let settings = SettingsStore(defaults: UserDefaults(suiteName: "com.omniwm.reevaluation.test.\(UUID().uuidString)")!)
+        let controller = WMController(settings: settings)
+        
+        let pid: pid_t = 1234
+        let windowId = 5678
+        let axRef = AXWindowRef(element: AXUIElementCreateSystemWide(), windowId: windowId)
+        let workspaceId = WorkspaceDescriptor.ID(uuidString: "00000000-0000-0000-0000-000000000001")!
+        let token = controller.workspaceManager.addWindow(axRef, pid: pid, windowId: windowId, to: workspaceId, mode: .tiling)
+        
+        guard let entry = controller.workspaceManager.entry(for: token) else {
+            Issue.record("Failed to create window entry")
+            return
+        }
+        
+        // Scenario: A heuristic fallback decision suggests floating
+        let fallbackDecision = WindowDecision(
+            disposition: .floating,
+            source: .heuristic,
+            layoutDecisionKind: .fallbackLayout,
+            workspaceName: nil,
+            ruleEffects: .none,
+            heuristicReasons: [.attributeFetchFailed],
+            deferredReason: nil
+        )
+        
+        let resultMode = controller.trackedModeForAutomaticReevaluation(
+            decision: fallbackDecision,
+            existingEntry: entry,
+            context: .automatic
+        )
+        
+        #expect(resultMode == .tiling)
+    }
+
+    @Test func automaticReevaluationPreservesTilingForUserRuleFallback() {
+        // Verify that even if a user rule is matched, if it's a fallback decision 
+        // (e.g. due to attribute fetch failure), we still preserve tiling.
+        
+        resetSharedControllerStateForTests()
+        let settings = SettingsStore(defaults: UserDefaults(suiteName: "com.omniwm.reevaluation.test.\(UUID().uuidString)")!)
+        let controller = WMController(settings: settings)
+        
+        let pid: pid_t = 1234
+        let windowId = 5678
+        let axRef = AXWindowRef(element: AXUIElementCreateSystemWide(), windowId: windowId)
+        let workspaceId = WorkspaceDescriptor.ID(uuidString: "00000000-0000-0000-0000-000000000001")!
+        let token = controller.workspaceManager.addWindow(axRef, pid: pid, windowId: windowId, to: workspaceId, mode: .tiling)
+        
+        guard let entry = controller.workspaceManager.entry(for: token) else {
+            Issue.record("Failed to create window entry")
+            return
+        }
+        
+        // Scenario: User rule matched but it's a fallbackLayout decision
+        let fallbackDecision = WindowDecision(
+            disposition: .floating,
+            source: .userRule(UUID()),
+            layoutDecisionKind: .fallbackLayout,
+            workspaceName: nil,
+            ruleEffects: .none,
+            heuristicReasons: [.attributeFetchFailed],
+            deferredReason: nil
+        )
+        
+        let resultMode = controller.trackedModeForAutomaticReevaluation(
+            decision: fallbackDecision,
+            existingEntry: entry,
+            context: .automatic
+        )
+        
+        #expect(resultMode == .tiling)
+    }
+
+    @Test func automaticReevaluationAcceptsExplicitFloatingRules() {
+        // Verify that we don't accidentally block EXPLICIT user rules from flipping to floating.
+        
+        resetSharedControllerStateForTests()
+        let settings = SettingsStore(defaults: UserDefaults(suiteName: "com.omniwm.reevaluation.test.\(UUID().uuidString)")!)
+        let controller = WMController(settings: settings)
+        
+        let pid: pid_t = 1234
+        let windowId = 5678
+        let axRef = AXWindowRef(element: AXUIElementCreateSystemWide(), windowId: windowId)
+        let workspaceId = WorkspaceDescriptor.ID(uuidString: "00000000-0000-0000-0000-000000000001")!
+        let token = controller.workspaceManager.addWindow(axRef, pid: pid, windowId: windowId, to: workspaceId, mode: .tiling)
+        
+        guard let entry = controller.workspaceManager.entry(for: token) else {
+            Issue.record("Failed to create window entry")
+            return
+        }
+        
+        let explicitDecision = WindowDecision(
+            disposition: .floating,
+            source: .userRule(UUID()),
+            layoutDecisionKind: .explicitLayout,
+            workspaceName: nil,
+            ruleEffects: .none,
+            heuristicReasons: [],
+            deferredReason: nil
+        )
+        
+        let resultMode = controller.trackedModeForAutomaticReevaluation(
+            decision: explicitDecision,
+            existingEntry: entry,
+            context: .automatic
+        )
+        
+        #expect(resultMode == .floating)
+    }
+}

--- a/Tests/OmniWMTests/WindowRuleEngineTests.swift
+++ b/Tests/OmniWMTests/WindowRuleEngineTests.swift
@@ -509,4 +509,24 @@ private func makeWindowRuleFacts(
         #expect(decision.disposition == .managed)
         #expect(decision.source == .heuristic)
     }
+
+    @Test func childWindowStructuralAnchorRuleFloatsWindowsWithParent() {
+        let engine = WindowRuleEngine()
+
+        let decision = engine.decision(
+            for: makeWindowRuleFacts(
+                bundleId: "com.example.app",
+                windowServer: WindowServerInfo(id: 10, pid: 42, level: 0, frame: .zero, parentId: 5)
+            ),
+            token: nil,
+            appFullscreen: false
+        )
+
+        #expect(decision.disposition == .floating)
+        #expect(decision.layoutDecisionKind == .explicitLayout)
+        if case .builtInRule("childWindowStructuralAnchor") = decision.source {
+        } else {
+            Issue.record("Expected child window to match structural anchor rule")
+        }
+    }
 }

--- a/Tests/OmniWMTests/WorkspaceBarDataSourceTests.swift
+++ b/Tests/OmniWMTests/WorkspaceBarDataSourceTests.swift
@@ -133,6 +133,44 @@ import Testing
         #expect(workspaceItem.windows.map(\.windowId) == [1001, 1002])
     }
 
+    @Test @MainActor func nonStandardFloatingEntriesAreHiddenFromTheBar() throws {
+        let controller = makeLayoutPlanTestController()
+        guard let monitor = controller.workspaceManager.monitors.first,
+              let workspace1 = controller.workspaceManager.workspaceId(for: "1", createIfMissing: false)
+        else {
+            Issue.record("Missing workspace bar fixture")
+            return
+        }
+
+        controller.appInfoCache.storeInfoForTests(pid: 7201, name: "Floating App", bundleId: "com.example.floating")
+        _ = controller.workspaceManager.addWindow(
+            makeLayoutPlanTestWindow(windowId: 1201),
+            pid: 7201,
+            windowId: 1201,
+            to: workspace1,
+            mode: .floating
+        )
+        controller.workspaceManager.setLayoutReason(.nativeFullscreen, for: WindowToken(pid: 7201, windowId: 1201))
+
+        let items = WorkspaceBarDataSource.workspaceBarItems(
+            for: monitor,
+            options: WorkspaceBarProjectionOptions(
+                deduplicateAppIcons: false,
+                hideEmptyWorkspaces: false,
+                showFloatingWindows: true
+            ),
+            workspaceManager: controller.workspaceManager,
+            appInfoCache: controller.appInfoCache,
+            niriEngine: nil,
+            focusedToken: controller.workspaceManager.focusedToken,
+            settings: controller.settings
+        )
+
+        let workspaceItem = try #require(items.first(where: { $0.id == workspace1 }))
+        #expect(workspaceItem.floatingWindows.isEmpty)
+        #expect(workspaceItem.windows.isEmpty)
+    }
+
     @Test @MainActor func deduplicatedProjectionKeepsSameAppSeparatedByMode() throws {
         let controller = makeLayoutPlanTestController()
         guard let monitor = controller.workspaceManager.monitors.first,


### PR DESCRIPTION
Restores floating classification for titled dialogs/panels and child windows, keeps the popup regression fix intact, and filters non-standard floating entries out of the workspace bar to avoid phantom chips.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved detection and handling of child windows with automatic floating layout
  * Enhanced recognition of titled dialogs and panel windows for better management

* **Bug Fixes**
  * Workspace bar now correctly filters floating windows, excluding non-standard layouts
  * Window reevaluation preserves tiling mode when appropriate for fallback layouts

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/BarutSRB/OmniWM/pull/323)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->