### PR TITLE
Fix border corner radius to match actual window corner radius

### DIFF
--- a/Sources/OmniWM/Core/Border/BorderWindow.swift
+++ b/Sources/OmniWM/Core/Border/BorderWindow.swift
@@ -15,6 +15,7 @@ final class BorderWindow {
         var transactionMoveAndOrder: @MainActor (UInt32, CGPoint, Int32, UInt32, SkyLightWindowOrder) -> Void
         var transactionHide: @MainActor (UInt32) -> Void
         var backingScaleForFrame: @MainActor (CGRect) -> CGFloat
+        var cornerRadiusForWindow: @MainActor (UInt32) -> CGFloat?
 
         static let live = Self(
             createBorderWindow: { SkyLight.shared.createBorderWindow(frame: $0) },
@@ -34,6 +35,9 @@ final class BorderWindow {
                     $0.frame.contains(targetFrame.center)
                 }) ?? NSScreen.main ?? NSScreen.screens.first
                 return targetScreen?.backingScaleFactor ?? 2.0
+            },
+            cornerRadiusForWindow: { wid in
+                SkyLight.shared.cornerRadius(forWindowId: Int(wid))
             }
         )
     }
@@ -53,8 +57,9 @@ final class BorderWindow {
     private var lastConfiguredScale: CGFloat = 0
 
     private let padding: CGFloat = 8.0
-    private let cornerRadius: CGFloat = 9.0
+    private let defaultCornerRadius: CGFloat = 10.0
     private let orderingLevel: Int32 = 3
+    private var resolvedCornerRadius: CGFloat = 10.0
 
     init(config: BorderConfig, operations: Operations = .live) {
         self.config = config
@@ -80,6 +85,13 @@ final class BorderWindow {
     ) -> Bool {
         let borderWidth = config.width
         let scale = operations.backingScaleForFrame(targetFrame)
+
+        let queriedRadius = operations.cornerRadiusForWindow(targetWid)
+        let newCornerRadius = queriedRadius ?? defaultCornerRadius
+        if newCornerRadius != resolvedCornerRadius {
+            resolvedCornerRadius = newCornerRadius
+            needsRedraw = true
+        }
 
         let borderOffset = -borderWidth - padding
         var frame = targetFrame.insetBy(dx: borderOffset, dy: borderOffset)
@@ -152,7 +164,7 @@ final class BorderWindow {
         needsRedraw = false
 
         let borderWidth = config.width
-        let outerRadius = cornerRadius + borderWidth
+        let outerRadius = resolvedCornerRadius + borderWidth
 
         context.saveGState()
         context.clear(frame)
@@ -160,8 +172,8 @@ final class BorderWindow {
         let innerRect = drawingBounds.insetBy(dx: borderWidth, dy: borderWidth)
         let innerPath = CGPath(
             roundedRect: innerRect,
-            cornerWidth: cornerRadius,
-            cornerHeight: cornerRadius,
+            cornerWidth: resolvedCornerRadius,
+            cornerHeight: resolvedCornerRadius,
             transform: nil
         )
 

--- a/Tests/OmniWMTests/BorderWindowTests.swift
+++ b/Tests/OmniWMTests/BorderWindowTests.swift
@@ -34,7 +34,8 @@ private func makeBorderTestContext() -> CGContext? {
             transactionMove: { _, origin in moveOnlyOrigins.append(origin) },
             transactionMoveAndOrder: { _, _, _, targetWid, _ in orderedTargets.append(targetWid) },
             transactionHide: { _ in },
-            backingScaleForFrame: { _ in 2.0 }
+            backingScaleForFrame: { _ in 2.0 },
+            cornerRadiusForWindow: { _ in nil }
         )
         let borderWindow = BorderWindow(
             config: BorderConfig(enabled: true, width: 4, color: .systemBlue),
@@ -84,7 +85,8 @@ private func makeBorderTestContext() -> CGContext? {
             transactionMove: { _, _ in moveOnlyCount += 1 },
             transactionMoveAndOrder: { _, _, _, targetWid, _ in orderedTargets.append(targetWid) },
             transactionHide: { _ in },
-            backingScaleForFrame: { _ in 2.0 }
+            backingScaleForFrame: { _ in 2.0 },
+            cornerRadiusForWindow: { _ in nil }
         )
         let borderWindow = BorderWindow(
             config: BorderConfig(enabled: true, width: 4, color: .systemBlue),
@@ -121,7 +123,8 @@ private func makeBorderTestContext() -> CGContext? {
             backingScaleForFrame: { _ in
                 backingScaleLookups += 1
                 return 2.0
-            }
+            },
+            cornerRadiusForWindow: { _ in nil }
         )
         let manager = BorderManager(
             config: BorderConfig(enabled: true, width: 4, color: .systemBlue),
@@ -160,7 +163,8 @@ private func makeBorderTestContext() -> CGContext? {
             backingScaleForFrame: { _ in
                 backingScaleLookups += 1
                 return 2.0
-            }
+            },
+            cornerRadiusForWindow: { _ in nil }
         )
         let manager = BorderManager(
             config: BorderConfig(enabled: true, width: 4, color: .systemBlue),
@@ -204,7 +208,8 @@ private func makeBorderTestContext() -> CGContext? {
             backingScaleForFrame: { _ in
                 backingScaleLookups += 1
                 return 2.0
-            }
+            },
+            cornerRadiusForWindow: { _ in nil }
         )
         let manager = BorderManager(
             config: BorderConfig(enabled: true, width: 4, color: .systemBlue),
@@ -250,7 +255,8 @@ private func makeBorderTestContext() -> CGContext? {
             transactionMove: { _, _ in moveOnlyCount += 1 },
             transactionMoveAndOrder: { _, _, _, targetWid, _ in orderedTargets.append(targetWid) },
             transactionHide: { _ in hideCount += 1 },
-            backingScaleForFrame: { _ in 2.0 }
+            backingScaleForFrame: { _ in 2.0 },
+            cornerRadiusForWindow: { _ in nil }
         )
         let borderWindow = BorderWindow(
             config: BorderConfig(enabled: true, width: 4, color: .systemBlue),
@@ -287,7 +293,8 @@ private func makeBorderTestContext() -> CGContext? {
             transactionHide: { _ in },
             backingScaleForFrame: { frame in
                 frame.midX < 1_000 ? 1.0 : 2.0
-            }
+            },
+            cornerRadiusForWindow: { _ in nil }
         )
         let borderWindow = BorderWindow(
             config: BorderConfig(enabled: true, width: 4, color: .systemBlue),


### PR DESCRIPTION
## Summary

- Query the target window's real corner radius via the existing `SkyLight.cornerRadius(forWindowId:)` API instead of using a hardcoded `9.0`
- Falls back to `10.0` (macOS default since Big Sur) when the API returns nil
- Wired through the `BorderWindow.Operations` dependency injection pattern so tests remain injectable
- Updated all existing `BorderWindowTests` to include the new operation

## Problem

The border corner radius was hardcoded to `9.0` but macOS windows use `10.0` corner radius (since Big Sur), causing a visible mismatch at the corners — especially noticeable with wider border widths.

The `SkyLight.cornerRadius(forWindowId:)` method already existed in the codebase (lines 287-318 of `SkyLight.swift`) but was never called.

## Test plan

- [x] All existing `BorderWindowTests` updated with the new `cornerRadiusForWindow` operation
- [ ] Visual verification: borders should align flush with window corners on macOS 11+ 
- [ ] Verify fallback: windows where SkyLight returns nil should use `10.0` default

Fixes #341

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Window borders now dynamically resolve and match the corner radius settings of each individual window instead of using a fixed radius.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/BarutSRB/OmniWM/pull/362?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->