### PR TITLE
Clear stale focus border for unmanaged windows

### DIFF
--- a/Sources/OmniWM/Core/Border/FocusBorderController.swift
+++ b/Sources/OmniWM/Core/Border/FocusBorderController.swift
@@ -258,6 +258,12 @@ final class FocusBorderController {
             return .hide
         }
 
+        if !target.isManaged {
+            guard observedFrame(for: target.axRef) != nil else {
+                return .clear
+            }
+        }
+
         return .update
     }
 


### PR DESCRIPTION
## Summary

- Unmanaged windows (e.g. Raycast) can hide without generating a destroy event, leaving a stale border rendered
- The `renderEligibility` check now verifies the window is still on-screen via AX frame query before rendering, returning `.clear` if the frame is gone

Scoped down per maintainer feedback — the parent-layout guards for #361/#306 have been handled more comprehensively in 434e14c.

Fixes #351

## Test plan

- Open Raycast (or another unmanaged floating app)
- Dismiss it — verify the focus border clears instead of lingering

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed focus border rendering to prevent unnecessary updates for certain window types when frame information is unavailable.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/BarutSRB/OmniWM/pull/363?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->