### PR TITLE
Fix windows overlapping across monitors

### DIFF
--- a/Sources/OmniWM/Core/Layout/Niri/NiriLayoutEngine+Animation.swift
+++ b/Sources/OmniWM/Core/Layout/Niri/NiriLayoutEngine+Animation.swift
@@ -262,6 +262,8 @@ extension NiriLayoutEngine {
             hiddenPlacementMonitors: hiddenPlacementMonitors
         )
 
+        clampVisibleFramesToMonitorBounds(monitor.frame)
+
         return (framePool, hiddenPool)
     }
 
@@ -462,5 +464,16 @@ extension NiriLayoutEngine {
     func tilesOrigin(column: NiriContainer) -> CGPoint {
         let xOffset = column.isTabbed ? renderStyle.tabIndicatorWidth : 0
         return CGPoint(x: xOffset, y: 0)
+    }
+
+    private func clampVisibleFramesToMonitorBounds(_ monitorBounds: CGRect) {
+        for (token, frame) in framePool where hiddenPool[token] == nil {
+            let clamped = frame.intersection(monitorBounds)
+            if clamped.isNull {
+                framePool.removeValue(forKey: token)
+            } else if clamped != frame {
+                framePool[token] = clamped
+            }
+        }
     }
 }

--- a/Sources/OmniWM/Core/Layout/Niri/NiriLayoutEngine+Animation.swift
+++ b/Sources/OmniWM/Core/Layout/Niri/NiriLayoutEngine+Animation.swift
@@ -467,13 +467,23 @@ extension NiriLayoutEngine {
     }
 
     private func clampVisibleFramesToMonitorBounds(_ monitorBounds: CGRect) {
+        var toRemove: [WindowToken] = []
+        var toUpdate: [(WindowToken, CGRect)] = []
+
         for (token, frame) in framePool where hiddenPool[token] == nil {
             let clamped = frame.intersection(monitorBounds)
             if clamped.isNull {
-                framePool.removeValue(forKey: token)
+                toRemove.append(token)
             } else if clamped != frame {
-                framePool[token] = clamped
+                toUpdate.append((token, clamped))
             }
+        }
+
+        for token in toRemove {
+            framePool.removeValue(forKey: token)
+        }
+        for (token, rect) in toUpdate {
+            framePool[token] = rect
         }
     }
 }


### PR DESCRIPTION
## Summary

- Clamps visible window frames to monitor bounds after layout calculation in `calculateCombinedLayoutUsingPools()`
- Prevents tiled window frames from bleeding into adjacent monitors' screen space
- Hidden windows (already tracked in `hiddenPool`) are excluded from clamping since their positioning is handled separately by `HiddenWindowPlacementResolver`

## Details

The Niri layout engine's `calculateLayoutInto()` produces window frames based on container positions and scroll offsets without enforcing monitor boundary constraints. When a visible container partially extends beyond the monitor's frame rect, individual window frames within it can bleed into neighboring monitor space.

The fix adds a post-layout clamping pass that intersects each visible window's frame with `monitor.frame`, removing frames that fall entirely outside the monitor bounds.

## Test plan

- [ ] Open windows across two monitors — no window frame should extend beyond its assigned monitor
- [ ] Scroll through columns near monitor edges — partial columns should be clipped at the boundary
- [ ] Verify hidden windows still animate/position correctly (not affected by clamping)
- [ ] Existing `centeredColumnsDoNotEmit*WorkspaceFramesAcross*MonitorBoundary` tests continue to pass

Fixes #349

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a window layout issue where frames could extend beyond monitor boundaries. Visible windows are now clamped to their assigned monitor’s display area so they stay fully on-screen.
  * Removed or hidden any windows with no overlap after clamping, preventing orphaned off-screen entries and improving layout consistency across multi-monitor setups.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/BarutSRB/OmniWM/pull/364?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->