### PR TITLE
Preserve window width ratio on cross-workspace move

### DIFF
--- a/Sources/OmniWM/Core/Layout/Niri/NiriLayoutEngine+WorkspaceOps.swift
+++ b/Sources/OmniWM/Core/Layout/Niri/NiriLayoutEngine+WorkspaceOps.swift
@@ -33,11 +33,11 @@ extension NiriLayoutEngine {
 
         let targetColumn: NiriContainer
         if let existingColumn = claimEmptyColumnIfWorkspaceEmpty(in: targetRoot) {
-            initializeNewColumnWidth(existingColumn, in: targetWorkspaceId)
+            copyColumnWidthState(from: sourceColumn, to: existingColumn)
             targetColumn = existingColumn
         } else {
             let newColumn = NiriContainer()
-            initializeNewColumnWidth(newColumn, in: targetWorkspaceId)
+            copyColumnWidthState(from: sourceColumn, to: newColumn)
             targetRoot.appendChild(newColumn)
             targetColumn = newColumn
         }


### PR DESCRIPTION
## Summary

- Replaces `initializeNewColumnWidth()` with `copyColumnWidthState()` in `moveWindowToWorkspace()` 
- Preserves the source column's width proportions, preset index, full-width state, and manual override flag when moving a window to a different workspace

## Details

When moving a single window to another workspace (including cross-monitor moves), `moveWindowToWorkspace()` was calling `initializeNewColumnWidth()` which resets the target column to the workspace's default width. This discards any manual resizing the user had done.

The fix uses the existing `copyColumnWidthState()` helper (already used for same-workspace column moves in `moveColumnTo*` operations) to carry over the source column's width state. Note that `moveColumnToWorkspace()` already preserves width correctly since it transfers the entire column without re-initializing.

## Test plan

- [ ] Resize a column to a custom width, then move it to a workspace on a different monitor — width ratio should be preserved
- [ ] Move a full-width column across workspaces — full-width state should be preserved
- [ ] Move a window from a preset-width column — preset index should transfer
- [ ] Existing layout engine tests continue to pass

Fixes #295

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved window column width state handling when moving windows between workspaces for more consistent sizing behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/BarutSRB/OmniWM/pull/365?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->