### PR TITLE
Fix focus reverting on rapid next/prev key presses

### DIFF
--- a/Sources/OmniWM/Core/Controller/AXEventHandler.swift
+++ b/Sources/OmniWM/Core/Controller/AXEventHandler.swift
@@ -1198,7 +1198,8 @@ final class AXEventHandler: CGSEventDelegate {
             case let .conflictsWithPendingRequest(request):
                 if shouldHonorObservedFocusOverPendingRequest(
                     source: source,
-                    origin: origin
+                    origin: origin,
+                    pendingRequest: request
                 ) {
                     clearManagedFocusState(
                         matching: request.token,
@@ -1253,7 +1254,8 @@ final class AXEventHandler: CGSEventDelegate {
             case let .conflictsWithPendingRequest(request):
                 if shouldHonorObservedFocusOverPendingRequest(
                     source: source,
-                    origin: origin
+                    origin: origin,
+                    pendingRequest: request
                 ) {
                     clearManagedFocusState(
                         matching: request.token,
@@ -1292,7 +1294,8 @@ final class AXEventHandler: CGSEventDelegate {
              let .conflictsWithPendingRequest(request):
             if shouldHonorObservedFocusOverPendingRequest(
                 source: source,
-                origin: origin
+                origin: origin,
+                pendingRequest: request
             ) {
                 clearManagedFocusState(
                     matching: request.token,
@@ -2767,7 +2770,8 @@ final class AXEventHandler: CGSEventDelegate {
              let .conflictsWithPendingRequest(request):
             if shouldHonorObservedFocusOverPendingRequest(
                 source: source,
-                origin: origin
+                origin: origin,
+                pendingRequest: request
             ) {
                 clearManagedFocusState(
                     matching: request.token,
@@ -2844,11 +2848,15 @@ final class AXEventHandler: CGSEventDelegate {
         }
     }
 
+    private static let managedRequestGracePeriod: CFAbsoluteTime = 0.3
+
     private func shouldHonorObservedFocusOverPendingRequest(
         source: ActivationEventSource,
-        origin: ActivationCallOrigin
+        origin: ActivationCallOrigin,
+        pendingRequest: ManagedFocusRequest
     ) -> Bool {
-        source.isAuthoritative && origin == .external
+        guard source.isAuthoritative, origin == .external else { return false }
+        return pendingRequest.age > Self.managedRequestGracePeriod
     }
 
     func cleanupFocusStateForTerminatedApp(pid: pid_t) {

--- a/Sources/OmniWM/Core/Controller/KeyboardFocusLifecycleCoordinator.swift
+++ b/Sources/OmniWM/Core/Controller/KeyboardFocusLifecycleCoordinator.swift
@@ -30,11 +30,16 @@ struct ManagedFocusRequest: Equatable {
     }
 
     let requestId: UInt64
+    let createdAt: CFAbsoluteTime
     var token: WindowToken
     var workspaceId: WorkspaceDescriptor.ID
     var retryCount: Int = 0
     var lastActivationSource: ActivationEventSource?
     var status: Status = .pending
+
+    var age: CFAbsoluteTime {
+        CFAbsoluteTimeGetCurrent() - createdAt
+    }
 }
 
 @MainActor
@@ -59,6 +64,7 @@ final class FocusBridgeCoordinator {
 
         let request = ManagedFocusRequest(
             requestId: nextRequestId,
+            createdAt: CFAbsoluteTimeGetCurrent(),
             token: token,
             workspaceId: workspaceId
         )


### PR DESCRIPTION
## Summary

- Adds a creation timestamp to `ManagedFocusRequest` to detect stale AX focus notifications
- `shouldHonorObservedFocusOverPendingRequest()` now rejects conflicting AX notifications that arrive within 300ms of the pending managed request
- Prevents focus from reverting to an intermediate window during rapid focus navigation

## Root cause

When rapidly pressing focus-next/prev (e.g. 3 times on 4 windows), each command:
1. Updates `selectedNodeId` and creates a new `ManagedFocusRequest`
2. Triggers AX focus via `performWindowFronting()`

The AX notification from command N-1 can arrive *after* command N has already been issued. When this happens, `shouldHonorObservedFocusOverPendingRequest()` unconditionally returned `true` for authoritative external events, causing the stale notification to clear the current pending request and revert `selectedNodeId` to the intermediate window.

**Timeline of the race:**
| Event | selectedNodeId | Pending request |
|-------|---------------|-----------------|
| Command 1 (focus-next) | Window 2 | request(Window 2) |
| Command 2 (focus-next) | Window 3 | request(Window 3) |
| Command 3 (focus-next) | Window 4 | request(Window 4) ✓ |
| Stale AX notification from command 2 | Window 3 ✗ | cleared ✗ |

## Fix

Add `createdAt` timestamp to `ManagedFocusRequest`. When a conflicting AX notification arrives, check if the pending request is younger than 300ms. If so, the notification is likely stale — reject it and let `continueManagedFocusRequest` retry the current request instead.

After the grace period expires, external AX notifications (e.g. user clicking a different window) are honored normally.

## Changes

- `KeyboardFocusLifecycleCoordinator.swift`: Add `createdAt` and `age` to `ManagedFocusRequest`
- `AXEventHandler.swift`: Pass `pendingRequest` to `shouldHonorObservedFocusOverPendingRequest()`, add 300ms grace period check

## Test plan

- [ ] Open 4+ windows in a workspace, rapidly press focus-next 3+ times — focus should land on the expected window without reverting
- [ ] Click a different window while a focus request is pending (after 300ms) — external focus change should be honored
- [ ] Verify focus-prev works correctly with rapid presses
- [ ] Existing `AXEventHandlerTests` continue to pass

Fixes #317

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Refined window focus request handling by introducing request creation-time tracking and a grace period mechanism. Focus decisions now intelligently evaluate the age of pending requests, improving system reliability when managing concurrent focus operations and reducing conflicts from overlapping window activation attempts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/BarutSRB/OmniWM/pull/379?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->