### PR TITLE
Respect window min size constraints in Niri column width

### DIFF
--- a/Sources/OmniWM/Core/Controller/LayoutRefreshController.swift
+++ b/Sources/OmniWM/Core/Controller/LayoutRefreshController.swift
@@ -560,16 +560,21 @@ import QuartzCore
                 mergedConstraints = mergedConstraints.normalized()
             }
 
+            let resizePlaceholderState = controller.workspaceManager.resizePlaceholderState(for: entry.token)
+            let layoutConstraints = resizePlaceholderState != nil
+                ? mergedConstraints.relaxedForResizePlaceholder()
+                : mergedConstraints
+
             snapshots.append(
                 LayoutWindowSnapshot(
                     token: entry.token,
                     constraints: mergedConstraints,
-                    layoutConstraints: mergedConstraints.relaxedForResizePlaceholder(),
+                    layoutConstraints: layoutConstraints,
                     hiddenState: controller.workspaceManager.hiddenState(for: entry.token),
                     layoutReason: layoutReason,
                     showsNativeFullscreenPlaceholder: controller.workspaceManager
                         .showsNativeFullscreenPlaceholder(for: entry.token),
-                    resizePlaceholderState: controller.workspaceManager.resizePlaceholderState(for: entry.token)
+                    resizePlaceholderState: resizePlaceholderState
                 )
             )
         }

--- a/Tests/OmniWMTests/NiriLayoutEngineTests.swift
+++ b/Tests/OmniWMTests/NiriLayoutEngineTests.swift
@@ -4060,7 +4060,44 @@ private func makeCenteredCrossMonitorFixture(
         #expect(!hasShowVisibilityChange(plan.diff.visibilityChanges, token: token))
     }
 
-    @Test @MainActor func tooSmallWindowEmitsResizePlaceholderInsteadOfFrameChangeInNiri() async throws {
+    @Test @MainActor func windowWithLargeMinSizeClampsColumnWidthInNiri() async throws {
+        let controller = makeLayoutPlanTestController()
+        guard let monitor = controller.workspaceManager.monitors.first,
+              let workspaceId = controller.workspaceManager.activeWorkspaceOrFirst(on: monitor.id)?.id
+        else {
+            Issue.record("Missing monitor or active workspace for Niri min size clamp test")
+            return
+        }
+
+        controller.enableNiriLayout()
+        await waitForLayoutPlanRefreshWork(on: controller)
+        controller.syncMonitorsToNiriEngine()
+
+        let token = addLayoutPlanTestWindow(on: controller, workspaceId: workspaceId, windowId: 3902)
+        _ = controller.workspaceManager.setManagedFocus(token, in: workspaceId, onMonitor: monitor.id)
+        let constraints = WindowSizeConstraints(
+            minSize: CGSize(width: 2500, height: 1200),
+            maxSize: CGSize(width: 5000, height: 5000),
+            isFixed: false
+        )
+        controller.workspaceManager.setCachedConstraints(constraints, for: token)
+
+        let plans = try await controller.niriLayoutHandler.layoutWithNiriEngine(
+            activeWorkspaces: [workspaceId]
+        )
+        guard let plan = plans.first else {
+            Issue.record("Expected a Niri layout plan for min size clamp test")
+            return
+        }
+
+        let frameChange = plan.diff.frameChanges.first { $0.token == token }
+        #expect(frameChange != nil)
+        #expect(frameChange!.frame.width >= constraints.minSize.width)
+        let placeholder = plan.diff.resizePlaceholders.first { $0.token == token }
+        #expect(placeholder == nil)
+    }
+
+    @Test @MainActor func existingResizePlaceholderKeepsRelaxedConstraintsInNiri() async throws {
         let controller = makeLayoutPlanTestController()
         guard let monitor = controller.workspaceManager.monitors.first,
               let workspaceId = controller.workspaceManager.activeWorkspaceOrFirst(on: monitor.id)?.id
@@ -4081,6 +4118,14 @@ private func makeCenteredCrossMonitorFixture(
             isFixed: false
         )
         controller.workspaceManager.setCachedConstraints(constraints, for: token)
+        controller.workspaceManager.setResizePlaceholderState(
+            ResizePlaceholderState(
+                workspaceId: workspaceId,
+                frame: CGRect(x: 0, y: 0, width: 960, height: 1080),
+                minimumSize: constraints.minSize
+            ),
+            for: token
+        )
 
         let plans = try await controller.niriLayoutHandler.layoutWithNiriEngine(
             activeWorkspaces: [workspaceId]

--- a/Tests/OmniWMTests/NiriLayoutEngineTests.swift
+++ b/Tests/OmniWMTests/NiriLayoutEngineTests.swift
@@ -4090,9 +4090,11 @@ private func makeCenteredCrossMonitorFixture(
             return
         }
 
-        let frameChange = plan.diff.frameChanges.first { $0.token == token }
-        #expect(frameChange != nil)
-        #expect(frameChange!.frame.width >= constraints.minSize.width)
+        guard let frameChange = plan.diff.frameChanges.first(where: { $0.token == token }) else {
+            Issue.record("Expected a frame change for min size clamp test")
+            return
+        }
+        #expect(frameChange.frame.width >= constraints.minSize.width)
         let placeholder = plan.diff.resizePlaceholders.first { $0.token == token }
         #expect(placeholder == nil)
     }


### PR DESCRIPTION
## Summary

- Apps with minimum size constraints (e.g., WhatsApp) triggered resize placeholders or got parked offscreen when the Niri column width preset was narrower than the app's minimum width
- Root cause: `layoutConstraints` were unconditionally relaxed via `relaxedForResizePlaceholder()`, dropping `minWidth`/`minHeight` to 1 for **all** windows — preventing the layout engine from clamping column widths to respect app minimum sizes
- Fix: only relax constraints for windows already in a resize placeholder state. For all other windows, full constraints propagate to the layout engine, allowing `resolveSpan()` to clamp column widths up to the app's minimum size
- Updated existing test to verify the new behavior and added a test for the resize placeholder persistence path

Fixes #383

## Test plan

- [ ] Open an app with known minimum width (e.g., WhatsApp) with a column preset of 50% or less
- [ ] Verify the column auto-expands to the app's minimum width instead of showing a resize placeholder
- [ ] Verify resize placeholders still work for windows already in that state (e.g., after AX frame apply fallback)
- [ ] Run existing test suite — `NiriLayoutEngineTests`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Column widths now correctly clamp to respect large minimum window sizes during layout.
  * Resize placeholder handling improved so window constraints are preserved during layout changes.

* **Tests**
  * Added/updated regression tests to validate clamped widths and correct resize-placeholder behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/BarutSRB/OmniWM/pull/384?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->