### PR TITLE
Suppress input during screenshot selection

### DIFF
--- a/Sources/OmniWM/Core/Controller/LayoutRefreshController.swift
+++ b/Sources/OmniWM/Core/Controller/LayoutRefreshController.swift
@@ -790,7 +790,7 @@ import QuartzCore
 
         guard let controller else { return false }
 
-        if controller.isFrontmostAppLockScreen() || controller.isLockScreenActive {
+        if controller.isFrontmostAppLockScreen() || controller.isLockScreenActive || controller.isFrontmostAppScreenCapture() {
             return false
         }
 
@@ -819,7 +819,7 @@ import QuartzCore
 
         guard let controller else { return false }
 
-        if controller.isFrontmostAppLockScreen() || controller.isLockScreenActive {
+        if controller.isFrontmostAppLockScreen() || controller.isLockScreenActive || controller.isFrontmostAppScreenCapture() {
             return false
         }
 
@@ -863,7 +863,7 @@ import QuartzCore
         }
 
         guard let controller else { return false }
-        if controller.isFrontmostAppLockScreen() || controller.isLockScreenActive {
+        if controller.isFrontmostAppLockScreen() || controller.isLockScreenActive || controller.isFrontmostAppScreenCapture() {
             return false
         }
 
@@ -952,7 +952,7 @@ import QuartzCore
         guard let controller else { return false }
         controller.axEventHandler.resetManagedReplacementState()
 
-        if controller.isFrontmostAppLockScreen() || controller.isLockScreenActive {
+        if controller.isFrontmostAppLockScreen() || controller.isLockScreenActive || controller.isFrontmostAppScreenCapture() {
             return false
         }
 

--- a/Sources/OmniWM/Core/Controller/MouseEventHandler.swift
+++ b/Sources/OmniWM/Core/Controller/MouseEventHandler.swift
@@ -522,7 +522,9 @@ final class MouseEventHandler {
 
     private var isInputSuppressed: Bool {
         guard let controller else { return true }
-        return controller.isLockScreenActive || controller.isFrontmostAppLockScreen()
+        return controller.isLockScreenActive
+            || controller.isFrontmostAppLockScreen()
+            || controller.isFrontmostAppScreenCapture()
     }
 
     private func dropPendingTapEvents() {

--- a/Sources/OmniWM/Core/Controller/WMController.swift
+++ b/Sources/OmniWM/Core/Controller/WMController.swift
@@ -2717,6 +2717,18 @@ extension WMController {
         lockScreenObserver.isFrontmostAppLockScreen()
     }
 
+    private static let screenCaptureBundleIds: Set<String> = [
+        "com.apple.screencaptureui",
+        "com.apple.Screenshot",
+    ]
+
+    func isFrontmostAppScreenCapture() -> Bool {
+        guard let bundleId = NSWorkspace.shared.frontmostApplication?.bundleIdentifier else {
+            return false
+        }
+        return Self.screenCaptureBundleIds.contains(bundleId)
+    }
+
     func isPointInQuakeTerminal(_ point: CGPoint) -> Bool {
         guard settings.quakeTerminalEnabled,
               quakeTerminalController.visible,


### PR DESCRIPTION
## Summary

- Detect when macOS screenshot selection tool (Cmd+Shift+4) is the frontmost app and suppress OmniWM's mouse event handling and layout refreshes
- Follows the existing lock screen suppression pattern: `isInputSuppressed` in `MouseEventHandler` and lock screen guards in `LayoutRefreshController`
- Checks for `com.apple.screencaptureui` and `com.apple.Screenshot` bundle IDs

Fixes #254

## Details

When screenshot selection is active, OmniWM's session-level CGEventTap continues intercepting all mouse events. Dragging the selection rectangle near tiled window edges causes windows to shift or resize. By detecting the screencapture process as the frontmost app and suppressing input handling + layout refreshes (the same approach used for lock screen), the windows remain stable during screenshot capture.

## Test plan

- [ ] Press Cmd+Shift+4 and drag the selection rectangle near window edges — windows should remain stable
- [ ] Take a screenshot far from edges — still works as before
- [ ] Press Cmd+Shift+4 then Space (window capture mode) — still works
- [ ] Press Cmd+Shift+3 (full screenshot) — still works
- [ ] After screenshot completes, verify OmniWM resumes normal operation (move/resize windows, focus changes)
- [ ] Lock screen behavior unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Bug Fixes**
- Enhanced screen recording compatibility: the window manager now recognizes when the active application is actively screen-capturing and automatically pauses layout refresh operations, visibility updates, window removal, and input event handling during capture sessions to prevent interference with recording functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/BarutSRB/OmniWM/pull/385?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->