### PR TITLE
Admit focused untracked standard windows before non-managed fallback

### DIFF
--- a/Sources/OmniWM/Core/Controller/AXEventHandler.swift
+++ b/Sources/OmniWM/Core/Controller/AXEventHandler.swift
@@ -1369,6 +1369,29 @@ final class AXEventHandler: CGSEventDelegate {
             break
         }
 
+        if let windowId = UInt32(exactly: axRef.windowId),
+           let admittedEntry = admitFocusedUntrackedWindowIfNeeded(
+               token: token,
+               windowId: windowId
+           )
+        {
+            let wsId = admittedEntry.workspaceId
+            let targetMonitor = controller.workspaceManager.monitor(for: wsId)
+            let isWorkspaceActive = targetMonitor.map { monitor in
+                controller.workspaceManager.activeWorkspace(on: monitor.id)?.id == wsId
+            } ?? false
+
+            handleManagedAppActivation(
+                entry: admittedEntry,
+                isWorkspaceActive: isWorkspaceActive,
+                appFullscreen: appFullscreen,
+                source: source,
+                confirmRequest: true,
+                origin: origin
+            )
+            return
+        }
+
         let target = controller.keyboardFocusTarget(for: token, axRef: axRef)
         let fallbackFullscreen = appFullscreenForFallbackLifecyclePreservation(
             observedAppFullscreen: appFullscreen
@@ -1384,6 +1407,35 @@ final class AXEventHandler: CGSEventDelegate {
                 )
             )
         )
+    }
+
+    private func admitFocusedUntrackedWindowIfNeeded(
+        token: WindowToken,
+        windowId: UInt32
+    ) -> WindowModel.Entry? {
+        guard let controller else { return nil }
+        guard controller.workspaceManager.entry(for: token) == nil else {
+            return controller.workspaceManager.entry(for: token)
+        }
+
+        let windowInfo = resolveWindowInfo(windowId)
+        guard let candidate = prepareCreateCandidate(
+            windowId: windowId,
+            windowInfo: windowInfo,
+            createPlacementContext: createPlacementContextsByWindowId[windowId]
+        ),
+            candidate.token == token
+        else {
+            return nil
+        }
+
+        if shouldDelayManagedReplacementCreate(candidate) {
+            enqueueManagedReplacementCreate(candidate)
+            return nil
+        }
+
+        trackPreparedCreate(candidate)
+        return controller.workspaceManager.entry(for: token)
     }
 
     func handleManagedAppActivation(

--- a/Tests/OmniWMTests/AXEventHandlerTests.swift
+++ b/Tests/OmniWMTests/AXEventHandlerTests.swift
@@ -1727,6 +1727,81 @@ private func waitUntilAXEventTest(
         })
     }
 
+    @Test @MainActor func focusedUntrackedStandardWindowIsAdmittedBeforeNonManagedFallback() async {
+        let controller = makeAXEventTestController(trackedBundleId: "com.google.Chrome")
+        guard let monitor = controller.workspaceManager.monitors.first,
+              let workspaceId = controller.workspaceManager.activeWorkspaceOrFirst(on: monitor.id)?.id
+        else {
+            Issue.record("Missing focused-window admission fixture")
+            return
+        }
+
+        controller.hasStartedServices = true
+
+        let observedWindowId: UInt32 = 981
+        let observedToken = WindowToken(pid: getpid(), windowId: Int(observedWindowId))
+        let observedAXRef = AXWindowRef(
+            element: AXUIElementCreateSystemWide(),
+            windowId: observedToken.windowId
+        )
+        var subscriptions: [[UInt32]] = []
+        var relayoutReasons: [RefreshReason] = []
+
+        controller.axEventHandler.focusedWindowRefProvider = { pid in
+            guard pid == getpid() else { return nil }
+            return observedAXRef
+        }
+        controller.axEventHandler.windowInfoProvider = { windowId in
+            guard windowId == observedWindowId else { return nil }
+            return WindowServerInfo(
+                id: windowId,
+                pid: getpid(),
+                level: 0,
+                frame: CGRect(x: 120, y: 160, width: 900, height: 700)
+            )
+        }
+        controller.axEventHandler.axWindowRefProvider = { windowId, pid in
+            guard windowId == observedWindowId, pid == getpid() else { return nil }
+            return observedAXRef
+        }
+        controller.axEventHandler.windowFactsProvider = { _, _ in
+            makeAXEventWindowRuleFacts(
+                bundleId: "com.google.Chrome",
+                appName: "Google Chrome",
+                title: "Detached Tab - Google Chrome"
+            )
+        }
+        controller.axEventHandler.windowSubscriptionHandler = { windowIds in
+            subscriptions.append(windowIds)
+        }
+        controller.layoutRefreshController.resetDebugState()
+        controller.layoutRefreshController.debugHooks.onRelayout = { reason, _ in
+            relayoutReasons.append(reason)
+            return true
+        }
+
+        controller.axEventHandler.handleAppActivation(
+            pid: getpid(),
+            source: .focusedWindowChanged
+        )
+        await controller.layoutRefreshController.waitForRefreshWorkForTests()
+
+        guard let entry = controller.workspaceManager.entry(for: observedToken) else {
+            Issue.record("Expected focused untracked Chrome window to be admitted")
+            return
+        }
+
+        #expect(entry.workspaceId == workspaceId)
+        #expect(entry.mode == .tiling)
+        #expect(controller.workspaceManager.focusedToken == observedToken)
+        #expect(controller.workspaceManager.pendingFocusedToken == nil)
+        #expect(!controller.workspaceManager.isNonManagedFocusActive)
+        #expect(controller.focusBridge.focusedTarget?.token == observedToken)
+        #expect(controller.focusBridge.focusedTarget?.isManaged == true)
+        #expect(subscriptions == [[observedWindowId]])
+        #expect(relayoutReasons.contains(.axWindowCreated))
+    }
+
     @Test @MainActor func activationRetryExhaustionClearsPendingFocusAndRestoresConfirmedBorder() async throws {
         let controller = makeAXEventTestController()
         guard let monitor = controller.workspaceManager.monitors.first,

--- a/Tests/OmniWMTests/AXEventHandlerTests.swift
+++ b/Tests/OmniWMTests/AXEventHandlerTests.swift
@@ -1786,6 +1786,14 @@ private func waitUntilAXEventTest(
         )
         await controller.layoutRefreshController.waitForRefreshWorkForTests()
 
+        let trace = createFocusTraceEvents(on: controller)
+        #expect(!trace.contains { event in
+            if case let .nonManagedFallbackEntered(pid, source) = event.kind {
+                return pid == getpid() && source == .focusedWindowChanged
+            }
+            return false
+        })
+
         guard let entry = controller.workspaceManager.entry(for: observedToken) else {
             Issue.record("Expected focused untracked Chrome window to be admitted")
             return


### PR DESCRIPTION
## Summary

- Fixes a race condition where a focused standard window can be treated as non-managed if the app activation event arrives before OmniWM has tracked the window in `WorkspaceManager`
- Adds `admitFocusedUntrackedWindowIfNeeded` to the activation path — checks if the focused AX window is a valid managed candidate and admits it before falling through to the non-managed focus fallback
- Respects the existing managed-replacement delay path (`shouldDelayManagedReplacementCreate`)

Fixes #387

## Test plan

- [x] Added regression test `focusedUntrackedStandardWindowIsAdmittedBeforeNonManagedFallback` that verifies:
  - Untracked Chrome window is admitted as tiling
  - Window becomes the focused managed target
  - AX window subscriptions are created
  - `.axWindowCreated` relayout is triggered
  - Non-managed focus is NOT entered

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling so focused, previously untracked windows are admitted into managed tiling state instead of falling back to non-managed focus.
* **Tests**
  * Added a test verifying focused untracked windows are admitted, become the managed focus target, and trigger expected layout and subscription behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/BarutSRB/OmniWM/pull/388?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->