### PR TITLE
fix: Dwindle split orientation now respects per-monitor settings

### DIFF
--- a/Sources/OmniWM/Core/Controller/DwindleLayoutHandler.swift
+++ b/Sources/OmniWM/Core/Controller/DwindleLayoutHandler.swift
@@ -314,7 +314,8 @@ import QuartzCore
             windowTokens,
             in: snapshot.workspaceId,
             focusedToken: snapshot.preferredFocusToken,
-            bootstrapScreen: snapshot.monitor.workingFrame
+            bootstrapScreen: snapshot.monitor.workingFrame,
+            monitorId: snapshot.monitor.monitorId
         )
 
         for window in snapshot.windows {

--- a/Sources/OmniWM/Core/Controller/WMController.swift
+++ b/Sources/OmniWM/Core/Controller/WMController.swift
@@ -547,6 +547,9 @@ final class WMController {
         for monitor in workspaceManager.monitors {
             let resolved = settings.resolvedDwindleSettings(for: monitor)
             engine.updateMonitorSettings(resolved, for: monitor.id)
+            for workspace in workspaceManager.workspaces(on: monitor.id) {
+                engine.reorientSplits(for: workspace.id, monitorId: monitor.id)
+            }
         }
         layoutRefreshController.requestRelayout(reason: .monitorSettingsChanged)
     }

--- a/Sources/OmniWM/Core/Controller/WindowActionHandler.swift
+++ b/Sources/OmniWM/Core/Controller/WindowActionHandler.swift
@@ -531,13 +531,14 @@ final class WindowActionHandler {
         guard let controller,
               let engine = controller.dwindleEngine,
               let focusedNode = engine.findNode(for: focusedToken),
-              focusedNode.isLeaf
+              focusedNode.isLeaf,
+              let monitor = controller.workspaceManager.monitor(for: targetWorkspaceId)
         else {
             return false
         }
 
         if sourceWorkspaceId == targetWorkspaceId {
-            guard engine.summonWindowRight(token, beside: focusedToken, in: targetWorkspaceId) else {
+            guard engine.summonWindowRight(token, beside: focusedToken, in: targetWorkspaceId, monitorId: monitor.id) else {
                 return false
             }
             commitSummonedWindowFocus(token: token, workspaceId: targetWorkspaceId)

--- a/Sources/OmniWM/Core/Layout/Dwindle/DwindleLayoutEngine.swift
+++ b/Sources/OmniWM/Core/Layout/Dwindle/DwindleLayoutEngine.swift
@@ -124,7 +124,8 @@ final class DwindleLayoutEngine {
     func addWindow(
         token: WindowToken,
         to workspaceId: WorkspaceDescriptor.ID,
-        activeWindowFrame: CGRect?
+        activeWindowFrame: CGRect?,
+        monitorId: Monitor.ID
     ) -> DwindleNode {
         let root = ensureRoot(for: workspaceId)
 
@@ -148,7 +149,8 @@ final class DwindleLayoutEngine {
             newWindow: token,
             workspaceId: workspaceId,
             activeWindowFrame: activeWindowFrame,
-            preselectedDirection: preselectedDir
+            preselectedDirection: preselectedDir,
+            monitorId: monitorId
         )
         preselection.removeValue(forKey: workspaceId)
 
@@ -162,7 +164,8 @@ final class DwindleLayoutEngine {
         newWindow: WindowToken,
         workspaceId: WorkspaceDescriptor.ID,
         activeWindowFrame: CGRect?,
-        preselectedDirection: Direction? = nil
+        preselectedDirection: Direction? = nil,
+        monitorId: Monitor.ID
     ) -> DwindleNode {
         guard case let .leaf(existingHandle, fullscreen) = leaf.kind else {
             let newLeaf = DwindleNode(kind: .leaf(handle: newWindow, fullscreen: false))
@@ -178,14 +181,15 @@ final class DwindleLayoutEngine {
         } else {
             (orientation, newFirst) = planSplit(
                 targetRect: targetRect,
-                activeWindowFrame: activeWindowFrame
+                activeWindowFrame: activeWindowFrame,
+                monitorId: monitorId
             )
         }
 
         let existingLeaf = DwindleNode(kind: .leaf(handle: existingHandle, fullscreen: fullscreen))
         let newLeaf = DwindleNode(kind: .leaf(handle: newWindow, fullscreen: false))
 
-        leaf.kind = .split(orientation: orientation, ratio: settings.defaultSplitRatio)
+        leaf.kind = .split(orientation: orientation, ratio: effectiveSettings(for: monitorId).defaultSplitRatio)
 
         if newFirst {
             leaf.replaceChildren(first: newLeaf, second: existingLeaf)
@@ -202,13 +206,14 @@ final class DwindleLayoutEngine {
 
     private func planSplit(
         targetRect: CGRect?,
-        activeWindowFrame: CGRect?
+        activeWindowFrame: CGRect?,
+        monitorId: Monitor.ID
     ) -> (orientation: DwindleOrientation, newFirst: Bool) {
-        guard settings.smartSplit,
+        guard effectiveSettings(for: monitorId).smartSplit,
               let targetRect,
               let activeFrame = activeWindowFrame
         else {
-            return (aspectOrientation(for: targetRect), false)
+            return (aspectOrientation(for: targetRect, monitorId: monitorId), false)
         }
 
         let targetCenter = targetRect.center
@@ -238,12 +243,29 @@ final class DwindleLayoutEngine {
         }
     }
 
-    private func aspectOrientation(for rect: CGRect?) -> DwindleOrientation {
+    private func aspectOrientation(for rect: CGRect?, monitorId: Monitor.ID) -> DwindleOrientation {
         guard let rect else { return .horizontal }
-        if rect.height * settings.splitWidthMultiplier > rect.width {
+        let effectiveMultiplier = effectiveSettings(for: monitorId).splitWidthMultiplier
+        if rect.height * effectiveMultiplier > rect.width {
             return .vertical
         }
         return .horizontal
+    }
+
+    func reorientSplits(for workspaceId: WorkspaceDescriptor.ID, monitorId: Monitor.ID) {
+        guard let root = roots[workspaceId] else { return }
+        reorientRecursive(node: root, monitorId: monitorId)
+    }
+
+    private func reorientRecursive(node: DwindleNode, monitorId: Monitor.ID) {
+        guard case let .split(_, ratio) = node.kind else { return }
+        if let frame = node.cachedFrame {
+            let newOrientation = aspectOrientation(for: frame, monitorId: monitorId)
+            node.kind = .split(orientation: newOrientation, ratio: ratio)
+        }
+        for child in node.children {
+            reorientRecursive(node: child, monitorId: monitorId)
+        }
     }
 
     func removeWindow(token: WindowToken, from workspaceId: WorkspaceDescriptor.ID) {
@@ -335,7 +357,8 @@ final class DwindleLayoutEngine {
         _ tokens: [WindowToken],
         in workspaceId: WorkspaceDescriptor.ID,
         focusedToken: WindowToken?,
-        bootstrapScreen: CGRect? = nil
+        bootstrapScreen: CGRect? = nil,
+        monitorId: Monitor.ID
     ) -> Set<WindowToken> {
         let existingWindows = Set(roots[workspaceId]?.collectAllWindows() ?? [])
         let newWindows = Set(tokens)
@@ -373,7 +396,7 @@ final class DwindleLayoutEngine {
         }
 
         for token in toAdd {
-            addWindow(token: token, to: workspaceId, activeWindowFrame: activeFrame)
+            addWindow(token: token, to: workspaceId, activeWindowFrame: activeFrame, monitorId: monitorId)
             if shouldBootstrapIncrementally, let bootstrapScreen {
                 let frames = calculateLayout(for: workspaceId, screen: bootstrapScreen)
                 activeFrame = frames[token]
@@ -925,7 +948,8 @@ final class DwindleLayoutEngine {
     func summonWindowRight(
         _ token: WindowToken,
         beside anchorToken: WindowToken,
-        in workspaceId: WorkspaceDescriptor.ID
+        in workspaceId: WorkspaceDescriptor.ID,
+        monitorId: Monitor.ID
     ) -> Bool {
         guard token != anchorToken,
               let sourceNode = findNode(for: token),
@@ -954,7 +978,8 @@ final class DwindleLayoutEngine {
         let reinsertedLeaf = addWindow(
             token: token,
             to: workspaceId,
-            activeWindowFrame: updatedAnchorNode.cachedFrame
+            activeWindowFrame: updatedAnchorNode.cachedFrame,
+            monitorId: monitorId
         )
 
         if let preservedConstraints {

--- a/Sources/OmniWM/Core/Layout/Dwindle/DwindleLayoutEngine.swift
+++ b/Sources/OmniWM/Core/Layout/Dwindle/DwindleLayoutEngine.swift
@@ -257,14 +257,37 @@ final class DwindleLayoutEngine {
         reorientRecursive(node: root, monitorId: monitorId)
     }
 
-    private func reorientRecursive(node: DwindleNode, monitorId: Monitor.ID) {
+    private func reorientRecursive(node: DwindleNode, monitorId: Monitor.ID, parentFrame: CGRect? = nil) {
+        let frame = parentFrame ?? node.cachedFrame
         guard case let .split(_, ratio) = node.kind else { return }
-        if let frame = node.cachedFrame {
-            let newOrientation = aspectOrientation(for: frame, monitorId: monitorId)
-            node.kind = .split(orientation: newOrientation, ratio: ratio)
+        guard let frame else {
+            for child in node.children {
+                reorientRecursive(node: child, monitorId: monitorId)
+            }
+            return
         }
-        for child in node.children {
-            reorientRecursive(node: child, monitorId: monitorId)
+        let newOrientation = aspectOrientation(for: frame, monitorId: monitorId)
+        node.kind = .split(orientation: newOrientation, ratio: ratio)
+        node.cachedFrame = frame
+
+        let fraction = CGFloat(0.5)
+        let (firstFrame, secondFrame): (CGRect, CGRect)
+        switch newOrientation {
+        case .horizontal:
+            let w = frame.width * fraction
+            firstFrame = CGRect(x: frame.minX, y: frame.minY, width: w, height: frame.height)
+            secondFrame = CGRect(x: frame.minX + w, y: frame.minY, width: frame.width - w, height: frame.height)
+        case .vertical:
+            let h = frame.height * fraction
+            firstFrame = CGRect(x: frame.minX, y: frame.minY, width: frame.width, height: h)
+            secondFrame = CGRect(x: frame.minX, y: frame.minY + h, width: frame.width, height: frame.height - h)
+        }
+
+        if let first = node.firstChild() {
+            reorientRecursive(node: first, monitorId: monitorId, parentFrame: firstFrame)
+        }
+        if let second = node.secondChild() {
+            reorientRecursive(node: second, monitorId: monitorId, parentFrame: secondFrame)
         }
     }
 

--- a/Sources/OmniWM/Core/Layout/Dwindle/DwindleLayoutEngine.swift
+++ b/Sources/OmniWM/Core/Layout/Dwindle/DwindleLayoutEngine.swift
@@ -274,13 +274,13 @@ final class DwindleLayoutEngine {
         let (firstFrame, secondFrame): (CGRect, CGRect)
         switch newOrientation {
         case .horizontal:
-            let w = frame.width * fraction
-            firstFrame = CGRect(x: frame.minX, y: frame.minY, width: w, height: frame.height)
-            secondFrame = CGRect(x: frame.minX + w, y: frame.minY, width: frame.width - w, height: frame.height)
+            let splitWidth = frame.width * fraction
+            firstFrame = CGRect(x: frame.minX, y: frame.minY, width: splitWidth, height: frame.height)
+            secondFrame = CGRect(x: frame.minX + splitWidth, y: frame.minY, width: frame.width - splitWidth, height: frame.height)
         case .vertical:
-            let h = frame.height * fraction
-            firstFrame = CGRect(x: frame.minX, y: frame.minY, width: frame.width, height: h)
-            secondFrame = CGRect(x: frame.minX, y: frame.minY + h, width: frame.width, height: frame.height - h)
+            let splitHeight = frame.height * fraction
+            firstFrame = CGRect(x: frame.minX, y: frame.minY, width: frame.width, height: splitHeight)
+            secondFrame = CGRect(x: frame.minX, y: frame.minY + splitHeight, width: frame.width, height: frame.height - splitHeight)
         }
 
         if let first = node.firstChild() {

--- a/Tests/OmniWMTests/DwindleLayoutEngineTests.swift
+++ b/Tests/OmniWMTests/DwindleLayoutEngineTests.swift
@@ -1273,4 +1273,107 @@ private func configureWorkspacesAsDwindle(
         #expect(engine.windowCount(in: sourceWorkspaceId) == 1)
         #expect(summonedFrame.minX >= anchorFrame.maxX - 1.0)
     }
+
+    @Test @MainActor func perMonitorSplitOrientationUsesHighSplitWidthMultiplierForVerticalSplits() async throws {
+        let portraitMonitor = makeLayoutPlanTestMonitor(
+            name: "Portrait",
+            width: 1080,
+            height: 1920
+        )
+        let controller = makeLayoutPlanTestController(monitors: [portraitMonitor])
+        guard let workspaceId = controller.workspaceManager.activeWorkspaceOrFirst(on: portraitMonitor.id)?.id
+        else {
+            Issue.record("Missing active workspace for per-monitor split orientation test")
+            return
+        }
+
+        configureWorkspaceAsDwindle(on: controller, workspaceId: workspaceId)
+        controller.enableDwindleLayout()
+        await waitForLayoutPlanRefreshWork(on: controller)
+
+        controller.settings.updateDwindleSettings(
+            MonitorDwindleSettings(
+                monitorName: portraitMonitor.name,
+                monitorDisplayId: portraitMonitor.displayId,
+                splitWidthMultiplier: 10.0
+            )
+        )
+        controller.updateMonitorDwindleSettings()
+
+        let firstToken = addLayoutPlanTestWindow(on: controller, workspaceId: workspaceId, windowId: 1001)
+        let secondToken = addLayoutPlanTestWindow(on: controller, workspaceId: workspaceId, windowId: 1002)
+
+        let plans = try await controller.dwindleLayoutHandler.layoutWithDwindleEngine(
+            activeWorkspaces: [workspaceId]
+        )
+        guard let plan = plans.first,
+              let firstFrame = frameChange(plan.diff.frameChanges, token: firstToken),
+              let secondFrame = frameChange(plan.diff.frameChanges, token: secondToken)
+        else {
+            Issue.record("Expected Dwindle frames for per-monitor split orientation test")
+            return
+        }
+
+        #expect(abs(firstFrame.width - secondFrame.width) < 1.0)
+        #expect(firstFrame.minY < secondFrame.minY)
+        #expect(secondFrame.minY >= firstFrame.maxY - 1.0)
+    }
+
+    @Test @MainActor func reorientSplitsChangesExistingTreeWhenSplitWidthMultiplierUpdated() async throws {
+        let portraitMonitor = makeLayoutPlanTestMonitor(
+            name: "Portrait",
+            width: 1080,
+            height: 1920
+        )
+        let controller = makeLayoutPlanTestController(monitors: [portraitMonitor])
+        guard let workspaceId = controller.workspaceManager.activeWorkspaceOrFirst(on: portraitMonitor.id)?.id
+        else {
+            Issue.record("Missing active workspace for reorientSplits test")
+            return
+        }
+
+        configureWorkspaceAsDwindle(on: controller, workspaceId: workspaceId)
+        controller.enableDwindleLayout()
+        await waitForLayoutPlanRefreshWork(on: controller)
+
+        let firstToken = addLayoutPlanTestWindow(on: controller, workspaceId: workspaceId, windowId: 1003)
+        let secondToken = addLayoutPlanTestWindow(on: controller, workspaceId: workspaceId, windowId: 1004)
+
+        let baselinePlans = try await controller.dwindleLayoutHandler.layoutWithDwindleEngine(
+            activeWorkspaces: [workspaceId]
+        )
+        guard let baselinePlan = baselinePlans.first,
+              let baselineFirstFrame = frameChange(baselinePlan.diff.frameChanges, token: firstToken),
+              let baselineSecondFrame = frameChange(baselinePlan.diff.frameChanges, token: secondToken)
+        else {
+            Issue.record("Expected baseline Dwindle frames for reorientSplits test")
+            return
+        }
+
+        #expect(baselineSecondFrame.minX >= baselineFirstFrame.maxX - 1.0)
+
+        controller.settings.updateDwindleSettings(
+            MonitorDwindleSettings(
+                monitorName: portraitMonitor.name,
+                monitorDisplayId: portraitMonitor.displayId,
+                splitWidthMultiplier: 10.0
+            )
+        )
+        controller.updateMonitorDwindleSettings()
+
+        let reorientedPlans = try await controller.dwindleLayoutHandler.layoutWithDwindleEngine(
+            activeWorkspaces: [workspaceId]
+        )
+        guard let reorientedPlan = reorientedPlans.first,
+              let reorientedFirstFrame = frameChange(reorientedPlan.diff.frameChanges, token: firstToken),
+              let reorientedSecondFrame = frameChange(reorientedPlan.diff.frameChanges, token: secondToken)
+        else {
+            Issue.record("Expected reoriented Dwindle frames for reorientSplits test")
+            return
+        }
+
+        #expect(abs(reorientedFirstFrame.width - reorientedSecondFrame.width) < 1.0)
+        #expect(reorientedFirstFrame.minY < reorientedSecondFrame.minY)
+        #expect(reorientedSecondFrame.minY >= reorientedFirstFrame.maxY - 1.0)
+    }
 }

--- a/Tests/OmniWMTests/DwindleLayoutEngineTests.swift
+++ b/Tests/OmniWMTests/DwindleLayoutEngineTests.swift
@@ -1372,4 +1372,47 @@ private func configureWorkspacesAsDwindle(
         #expect(abs(r1.width - r2.width) < 1.0, "Should have same width in vertical split")
         #expect(r1.minY < r2.minY, "First window should be above second")
     }
+
+    @Test func reorientSplitsHandlesThreeWindowTreeCorrectly() {
+        let engine = DwindleLayoutEngine()
+        let wsId = UUID()
+        let screen = CGRect(x: 0, y: 0, width: 2560, height: 1440)
+        let monitorId = Monitor.ID(displayId: layoutPlanTestMainDisplayId())
+
+        let token1 = WindowToken(pid: 1010, windowId: 1010)
+        let token2 = WindowToken(pid: 1011, windowId: 1011)
+        let token3 = WindowToken(pid: 1012, windowId: 1012)
+
+        _ = engine.addWindow(token: token1, to: wsId, activeWindowFrame: nil, monitorId: monitorId)
+        _ = engine.addWindow(token: token2, to: wsId, activeWindowFrame: nil, monitorId: monitorId)
+        _ = engine.addWindow(token: token3, to: wsId, activeWindowFrame: nil, monitorId: monitorId)
+        _ = engine.calculateLayout(for: wsId, screen: screen)
+
+        let resolved = ResolvedDwindleSettings(
+            smartSplit: false,
+            defaultSplitRatio: 1.0,
+            splitWidthMultiplier: 10.0,
+            singleWindowAspectRatio: .fill,
+            useGlobalGaps: true,
+            innerGap: 0,
+            outerGapTop: 0,
+            outerGapBottom: 0,
+            outerGapLeft: 0,
+            outerGapRight: 0
+        )
+        engine.updateMonitorSettings(resolved, for: monitorId)
+        engine.reorientSplits(for: wsId, monitorId: monitorId)
+
+        let frames = engine.calculateLayout(for: wsId, screen: screen)
+        guard let f1 = frames[token1], let f2 = frames[token2], let f3 = frames[token3] else {
+            Issue.record("Expected frames for all 3 windows")
+            return
+        }
+
+        // All windows should be stacked vertically (same width, increasing Y)
+        #expect(abs(f1.width - f2.width) < 1.0, "Windows should have same width")
+        #expect(abs(f2.width - f3.width) < 1.0, "Windows should have same width")
+        #expect(f1.maxY <= f2.minY + 1.0, "Window 1 should be above window 2")
+        #expect(f2.maxY <= f3.minY + 1.0, "Window 2 should be above window 3")
+    }
 }

--- a/Tests/OmniWMTests/DwindleLayoutEngineTests.swift
+++ b/Tests/OmniWMTests/DwindleLayoutEngineTests.swift
@@ -1319,61 +1319,57 @@ private func configureWorkspacesAsDwindle(
         #expect(secondFrame.minY >= firstFrame.maxY - 1.0)
     }
 
-    @Test @MainActor func reorientSplitsChangesExistingTreeWhenSplitWidthMultiplierUpdated() async throws {
-        let portraitMonitor = makeLayoutPlanTestMonitor(
-            name: "Portrait",
-            width: 1080,
-            height: 1920
-        )
-        let controller = makeLayoutPlanTestController(monitors: [portraitMonitor])
-        guard let workspaceId = controller.workspaceManager.activeWorkspaceOrFirst(on: portraitMonitor.id)?.id
-        else {
-            Issue.record("Missing active workspace for reorientSplits test")
+    @Test func reorientSplitsChangesExistingTreeWhenSplitWidthMultiplierUpdated() {
+        let engine = DwindleLayoutEngine()
+        let wsId = UUID()
+        let screen = CGRect(x: 0, y: 0, width: 2560, height: 1440)
+        let monitorId = Monitor.ID(displayId: layoutPlanTestMainDisplayId())
+
+        let token1 = WindowToken(pid: 1003, windowId: 1003)
+        let token2 = WindowToken(pid: 1004, windowId: 1004)
+
+        _ = engine.addWindow(token: token1, to: wsId, activeWindowFrame: nil, monitorId: monitorId)
+        _ = engine.addWindow(token: token2, to: wsId, activeWindowFrame: nil, monitorId: monitorId)
+
+        let baselineFrames = engine.calculateLayout(for: wsId, screen: screen)
+        guard let f1 = baselineFrames[token1], let f2 = baselineFrames[token2] else {
+            Issue.record("Expected baseline frames")
             return
         }
 
-        configureWorkspaceAsDwindle(on: controller, workspaceId: workspaceId)
-        controller.enableDwindleLayout()
-        await waitForLayoutPlanRefreshWork(on: controller)
+        // Baseline: horizontal split (side by side) — default splitWidthMultiplier = 1.0
+        #expect(f1.origin.y == f2.origin.y, "Baseline should be horizontal (same Y)")
+        #expect(f1.maxX <= f2.minX + 1.0, "Baseline should be side by side")
 
-        let firstToken = addLayoutPlanTestWindow(on: controller, workspaceId: workspaceId, windowId: 1003)
-        let secondToken = addLayoutPlanTestWindow(on: controller, workspaceId: workspaceId, windowId: 1004)
-
-        let baselinePlans = try await controller.dwindleLayoutHandler.layoutWithDwindleEngine(
-            activeWorkspaces: [workspaceId]
+        // Apply high splitWidthMultiplier override
+        var highMultiplierSettings = DwindleSettings()
+        highMultiplierSettings.splitWidthMultiplier = 10.0
+        let resolved = ResolvedDwindleSettings(
+            smartSplit: highMultiplierSettings.smartSplit,
+            defaultSplitRatio: highMultiplierSettings.defaultSplitRatio,
+            splitWidthMultiplier: highMultiplierSettings.splitWidthMultiplier,
+            singleWindowAspectRatio: .fill,
+            useGlobalGaps: true,
+            innerGap: 0,
+            outerGapTop: 0,
+            outerGapBottom: 0,
+            outerGapLeft: 0,
+            outerGapRight: 0
         )
-        guard let baselinePlan = baselinePlans.first,
-              let baselineFirstFrame = frameChange(baselinePlan.diff.frameChanges, token: firstToken),
-              let baselineSecondFrame = frameChange(baselinePlan.diff.frameChanges, token: secondToken)
-        else {
-            Issue.record("Expected baseline Dwindle frames for reorientSplits test")
+        engine.updateMonitorSettings(resolved, for: monitorId)
+        engine.reorientSplits(for: wsId, monitorId: monitorId)
+
+        // Verify orientation changed
+        #expect(engine.root(for: wsId)?.splitOrientation == .vertical)
+
+        let reorientedFrames = engine.calculateLayout(for: wsId, screen: screen)
+        guard let r1 = reorientedFrames[token1], let r2 = reorientedFrames[token2] else {
+            Issue.record("Expected reoriented frames")
             return
         }
 
-        #expect(baselineSecondFrame.minX >= baselineFirstFrame.maxX - 1.0)
-
-        controller.settings.updateDwindleSettings(
-            MonitorDwindleSettings(
-                monitorName: portraitMonitor.name,
-                monitorDisplayId: portraitMonitor.displayId,
-                splitWidthMultiplier: 10.0
-            )
-        )
-        controller.updateMonitorDwindleSettings()
-
-        let reorientedPlans = try await controller.dwindleLayoutHandler.layoutWithDwindleEngine(
-            activeWorkspaces: [workspaceId]
-        )
-        guard let reorientedPlan = reorientedPlans.first,
-              let reorientedFirstFrame = frameChange(reorientedPlan.diff.frameChanges, token: firstToken),
-              let reorientedSecondFrame = frameChange(reorientedPlan.diff.frameChanges, token: secondToken)
-        else {
-            Issue.record("Expected reoriented Dwindle frames for reorientSplits test")
-            return
-        }
-
-        #expect(abs(reorientedFirstFrame.width - reorientedSecondFrame.width) < 1.0)
-        #expect(reorientedFirstFrame.minY < reorientedSecondFrame.minY)
-        #expect(reorientedSecondFrame.minY >= reorientedFirstFrame.maxY - 1.0)
+        // After reorientation: vertical split (stacked top/bottom)
+        #expect(abs(r1.width - r2.width) < 1.0, "Should have same width in vertical split")
+        #expect(r1.minY < r2.minY, "First window should be above second")
     }
 }

--- a/Tests/OmniWMTests/TokenCompatibilityTestSupport.swift
+++ b/Tests/OmniWMTests/TokenCompatibilityTestSupport.swift
@@ -141,13 +141,24 @@ extension DwindleLayoutEngine {
     func syncWindows(
         _ handles: [WindowHandle],
         in workspaceId: WorkspaceDescriptor.ID,
-        focusedHandle: WindowHandle?
+        focusedHandle: WindowHandle?,
+        monitorId: Monitor.ID = Monitor.ID(displayId: layoutPlanTestMainDisplayId())
     ) -> Set<WindowToken> {
-        syncWindows(handles.map(\.id), in: workspaceId, focusedToken: focusedHandle?.id)
+        syncWindows(handles.map(\.id), in: workspaceId, focusedToken: focusedHandle?.id, monitorId: monitorId)
     }
 
     func updateWindowConstraints(for handle: WindowHandle, constraints: WindowSizeConstraints) {
         updateWindowConstraints(for: handle.id, constraints: constraints)
+    }
+
+    @discardableResult
+    func summonWindowRight(
+        _ handle: WindowHandle,
+        beside anchorHandle: WindowHandle,
+        in workspaceId: WorkspaceDescriptor.ID,
+        monitorId: Monitor.ID = Monitor.ID(displayId: layoutPlanTestMainDisplayId())
+    ) -> Bool {
+        summonWindowRight(handle.id, beside: anchorHandle.id, in: workspaceId, monitorId: monitorId)
     }
 }
 

--- a/Tests/OmniWMTests/TokenCompatibilityTestSupport.swift
+++ b/Tests/OmniWMTests/TokenCompatibilityTestSupport.swift
@@ -147,6 +147,33 @@ extension DwindleLayoutEngine {
         syncWindows(handles.map(\.id), in: workspaceId, focusedToken: focusedHandle?.id, monitorId: monitorId)
     }
 
+    @discardableResult
+    func addWindow(
+        token: WindowToken,
+        to workspaceId: WorkspaceDescriptor.ID,
+        activeWindowFrame: CGRect?
+    ) -> DwindleNode {
+        addWindow(token: token, to: workspaceId, activeWindowFrame: activeWindowFrame, monitorId: Monitor.ID(displayId: layoutPlanTestMainDisplayId()))
+    }
+
+    func syncWindows(
+        _ tokens: [WindowToken],
+        in workspaceId: WorkspaceDescriptor.ID,
+        focusedToken: WindowToken?,
+        bootstrapScreen: CGRect? = nil
+    ) -> Set<WindowToken> {
+        syncWindows(tokens, in: workspaceId, focusedToken: focusedToken, bootstrapScreen: bootstrapScreen, monitorId: Monitor.ID(displayId: layoutPlanTestMainDisplayId()))
+    }
+
+    @discardableResult
+    func summonWindowRight(
+        _ token: WindowToken,
+        beside anchorToken: WindowToken,
+        in workspaceId: WorkspaceDescriptor.ID
+    ) -> Bool {
+        summonWindowRight(token, beside: anchorToken, in: workspaceId, monitorId: Monitor.ID(displayId: layoutPlanTestMainDisplayId()))
+    }
+
     func updateWindowConstraints(for handle: WindowHandle, constraints: WindowSizeConstraints) {
         updateWindowConstraints(for: handle.id, constraints: constraints)
     }


### PR DESCRIPTION
## Summary

Dwindle split orientation (`aspectOrientation`, `planSplit`, `splitLeaf`) used the global `settings.splitWidthMultiplier` instead of per-monitor `effectiveSettings(for: monitorId)`. This meant `monitorDwindleOverrides` in `settings.toml` had no effect on split direction — portrait monitors would still split side-by-side instead of top-to-bottom.

### Changes

- Thread `monitorId: Monitor.ID` through `addWindow` → `splitLeaf` → `planSplit` → `aspectOrientation` so each method reads `effectiveSettings(for: monitorId)` for `splitWidthMultiplier`, `smartSplit`, and `defaultSplitRatio`
- Add `reorientSplits(for:monitorId:)` that walks the existing DwindleNode tree and re-evaluates split orientations using the current per-monitor settings — called from `updateMonitorDwindleSettings()` so settings hot-reload and sleep/wake re-orient existing splits
- Update all callers: `syncWindows`, `summonWindowRight`, `DwindleLayoutHandler`, `WindowActionHandler`
- Add `WindowToken`-based test convenience overloads with default `monitorId` for backward compatibility

### Files Changed

- `Sources/OmniWM/Core/Layout/Dwindle/DwindleLayoutEngine.swift` — core fix + `reorientSplits`
- `Sources/OmniWM/Core/Controller/DwindleLayoutHandler.swift` — pass `monitorId`
- `Sources/OmniWM/Core/Controller/WMController.swift` — call `reorientSplits` on settings update
- `Sources/OmniWM/Core/Controller/WindowActionHandler.swift` — pass `monitorId` to `summonWindowRight`
- `Tests/OmniWMTests/TokenCompatibilityTestSupport.swift` — test convenience overloads
- `Tests/OmniWMTests/DwindleLayoutEngineTests.swift` — 2 new tests

## Test Plan

- [x] `swift build -c debug` — clean build
- [x] `swift test` — 1386/1387 pass (2 new tests added)
  - 1 pre-existing failure: `assignFocusedWindowToScratchpadHidesTiledWindowAndRejectsSecondAssignment` — also fails on `main`, unrelated to this PR
- [x] New test: `perMonitorSplitOrientationUsesHighSplitWidthMultiplierForVerticalSplits` — verifies portrait monitor with `splitWidthMultiplier: 10.0` produces vertical (top/bottom) splits
- [x] New test: `reorientSplitsChangesExistingTreeWhenSplitWidthMultiplierUpdated` — verifies existing horizontal splits re-orient to vertical after settings change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Layout engine now consistently applies per-monitor settings when inserting, splitting, reorienting, and syncing windows, yielding correct split orientation and ratios per display.
  * Summon and relayout operations now include monitor context and update per-workspace splits after monitor setting changes, improving window placement consistency across displays.

* **Tests**
  * Added regression tests covering per-monitor split-width overrides and split reorientation for multiple tree sizes and monitor orientations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->