### PR TITLE
feat: focus adjacent monitor when directional focus reaches a workspace edge

### DIFF
--- a/Sources/OmniWM/Core/Controller/DwindleLayoutHandler.swift
+++ b/Sources/OmniWM/Core/Controller/DwindleLayoutHandler.swift
@@ -153,8 +153,10 @@ import QuartzCore
 
     func focusNeighbor(direction: Direction) {
         guard let controller else { return }
+        var moved = false
         withDwindleContext { engine, wsId in
             if let token = engine.moveFocus(direction: direction, in: wsId) {
+                moved = true
                 _ = controller.workspaceManager.applySessionPatch(
                     .init(
                         workspaceId: wsId,
@@ -169,6 +171,9 @@ import QuartzCore
                     controller?.focusWindow(token)
                 }
             }
+        }
+        if !moved {
+            controller.workspaceNavigationHandler.focusMonitor(direction: direction)
         }
     }
 

--- a/Sources/OmniWM/Core/Controller/NiriLayoutHandler.swift
+++ b/Sources/OmniWM/Core/Controller/NiriLayoutHandler.swift
@@ -1232,6 +1232,8 @@ enum NiriWindowMoveResult {
                 )
             )
             requestSelectedWindowFocusAfterLayout(in: wsId)
+        } else {
+            controller.workspaceNavigationHandler.focusMonitor(direction: direction)
         }
     }
 

--- a/Sources/OmniWM/Core/Controller/WorkspaceNavigationHandler.swift
+++ b/Sources/OmniWM/Core/Controller/WorkspaceNavigationHandler.swift
@@ -155,6 +155,21 @@ final class WorkspaceNavigationHandler {
         switchToMonitor(previousId, fromMonitor: currentMonitorId)
     }
 
+    @discardableResult
+    func focusMonitor(direction: Direction) -> Bool {
+        guard let controller else { return false }
+        guard let currentMonitorId = interactionMonitorId(for: controller)
+        else { return false }
+
+        guard let target = controller.workspaceManager.adjacentMonitor(
+            from: currentMonitorId,
+            direction: direction
+        ) else { return false }
+
+        switchToMonitor(target.id, fromMonitor: currentMonitorId)
+        return true
+    }
+
     private func switchToMonitor(_ targetMonitorId: Monitor.ID, fromMonitor currentMonitorId: Monitor.ID) {
         guard let controller else { return }
 

--- a/Sources/OmniWM/Core/Controller/WorkspaceNavigationHandler.swift
+++ b/Sources/OmniWM/Core/Controller/WorkspaceNavigationHandler.swift
@@ -155,19 +155,17 @@ final class WorkspaceNavigationHandler {
         switchToMonitor(previousId, fromMonitor: currentMonitorId)
     }
 
-    @discardableResult
-    func focusMonitor(direction: Direction) -> Bool {
-        guard let controller else { return false }
+    func focusMonitor(direction: Direction) {
+        guard let controller else { return }
         guard let currentMonitorId = interactionMonitorId(for: controller)
-        else { return false }
+        else { return }
 
         guard let target = controller.workspaceManager.adjacentMonitor(
             from: currentMonitorId,
             direction: direction
-        ) else { return false }
+        ) else { return }
 
         switchToMonitor(target.id, fromMonitor: currentMonitorId)
-        return true
     }
 
     private func switchToMonitor(_ targetMonitorId: Monitor.ID, fromMonitor currentMonitorId: Monitor.ID) {


### PR DESCRIPTION
Closes #423.

## Summary

Directional focus (Focus Up/Down/Left/Right) previously stopped at the workspace boundary. When `focusNeighbor` finds no in-workspace target, it now falls back to focusing the physically-adjacent monitor in that direction, auto-detecting the monitor layout. If no monitor exists in that direction, it's a no-op.

Applies to both Niri and Dwindle layouts.

## Changes

- `WorkspaceNavigationHandler`: add `focusMonitor(direction:)`, reusing the existing `adjacentMonitor` lookup and `switchToMonitor`.
- `NiriLayoutHandler` / `DwindleLayoutHandler`: in `focusNeighbor`, fall back to `focusMonitor(direction:)` when there is no in-workspace target.

## Test plan

- [ ] Two monitors stacked vertically (top/bottom). Focus the bottom-most window of the top monitor, press focus down (`Option+J`): focus moves to the app on the bottom monitor.
- [ ] Reverse: top-most window of the bottom monitor, focus up (`Option+K`): focus moves to the top monitor.
- [ ] At an outer edge with no monitor in that direction: no-op.
- [ ] Within a workspace that has a neighbor in that direction: unchanged (normal in-workspace focus).
- [ ] Verified on both Niri and Dwindle layouts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced focus navigation behavior: when the window layout system cannot move focus in the requested direction, the system now automatically falls back to switching focus to the adjacent monitor instead of stopping, providing improved multi-monitor workspace navigation and eliminating focus dead-ends.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->