### PR TITLE
fix: prevent rapid Niri focus desync

### DIFF
--- a/Sources/OmniWM/Core/Controller/NiriLayoutHandler.swift
+++ b/Sources/OmniWM/Core/Controller/NiriLayoutHandler.swift
@@ -220,23 +220,15 @@ import QuartzCore
     }
 
     func requestSelectedWindowFocusAfterLayout(in workspaceId: WorkspaceDescriptor.ID) {
-        requestLayoutCommandRelayout(
-            in: workspaceId,
-            postLayout: { [weak controller] in
-                guard let controller else {
-                    return
-                }
-                let viewportState = controller.workspaceManager.niriViewportState(for: workspaceId)
-                guard let selectedNodeId = viewportState.selectedNodeId,
-                      let selectedWindow = controller.niriEngine?.findNode(by: selectedNodeId) as? NiriWindow,
-                      controller.workspaceManager.entry(for: selectedWindow.token)?.workspaceId == workspaceId
-                else {
-                    return
-                }
-                controller.focusWindow(selectedWindow.token)
-            },
-            postLayoutDomains: [.workspace, .layout, .focus, .fullscreen]
-        )
+        guard let controller else { return }
+        let viewportState = controller.workspaceManager.niriViewportState(for: workspaceId)
+        if let selectedNodeId = viewportState.selectedNodeId,
+           let selectedWindow = controller.niriEngine?.findNode(by: selectedNodeId) as? NiriWindow,
+           controller.workspaceManager.entry(for: selectedWindow.token)?.workspaceId == workspaceId
+        {
+            controller.focusWindow(selectedWindow.token)
+        }
+        requestLayoutCommandRelayout(in: workspaceId)
     }
 
     func layoutWithNiriEngine(

--- a/Tests/OmniWMTests/RuntimeArchitectureTests.swift
+++ b/Tests/OmniWMTests/RuntimeArchitectureTests.swift
@@ -2080,7 +2080,7 @@ final class RuntimeArchitectureTests: XCTestCase {
     }
 
     @MainActor
-    func testNiriPostLayoutFocusRejectsFocusInvalidation() throws {
+    func testNiriPostLayoutFocusAppliesSynchronously() throws {
         var focusedTokens: [WindowToken] = []
         let controller = Self.controller(
             windowFocusOperations: WindowFocusOperations(
@@ -2124,23 +2124,6 @@ final class RuntimeArchitectureTests: XCTestCase {
             in: workspaceId,
             onMonitor: controller.workspaceManager.monitorId(for: workspaceId)
         )
-        let blocker = Task { @MainActor in
-            while !Task.isCancelled {
-                try? await Task.sleep(for: .seconds(1))
-            }
-        }
-        controller.layoutRefreshController.layoutState.activeRefreshTask = blocker
-        controller.layoutRefreshController.layoutState.activeRefresh = .init(
-            kind: .immediateRelayout,
-            reason: .layoutCommand,
-            affectedWorkspaceIds: [workspaceId]
-        )
-        defer {
-            blocker.cancel()
-            controller.layoutRefreshController.layoutState.activeRefreshTask = nil
-            controller.layoutRefreshController.layoutState.activeRefresh = nil
-            controller.layoutRefreshController.layoutState.pendingRefresh = nil
-        }
 
         var state = controller.workspaceManager.niriViewportState(for: workspaceId)
         controller.niriLayoutHandler.activateNode(
@@ -2164,13 +2147,12 @@ final class RuntimeArchitectureTests: XCTestCase {
             )
         )
         controller.niriLayoutHandler.requestSelectedWindowFocusAfterLayout(in: workspaceId)
-        let action = try XCTUnwrap(controller.layoutRefreshController.layoutState.pendingRefresh?.postLayoutActions
-            .first)
+
+        XCTAssertEqual(focusedTokens.last, selectedToken)
+
         _ = controller.workspaceManager.rememberFocus(staleLastFocusedToken, in: workspaceId)
 
-        action.runIfCurrent(using: controller.workspaceManager)
-
-        XCTAssertNil(focusedTokens.last)
+        XCTAssertEqual(focusedTokens.last, selectedToken)
         XCTAssertEqual(controller.workspaceManager.lastFocusedToken(in: workspaceId), staleLastFocusedToken)
     }
 


### PR DESCRIPTION
## Problem

TL;DR: rapid Niri navigation could desync the focused window from the centered/selected window. For example, with windows 1, 2, and 3, moving right, right, then left from window 1 could leave focus/the focus border on window 3 while window 2 was centered on screen.

## Root cause

Selected-window focus was queued as a post-layout action. During rapid navigation, focus state could change again before that relayout completed, causing the queued focus action to be rejected as stale.

## Fix

Apply the currently selected Niri window focus synchronously before requesting the layout refresh, so the selected window receives focus immediately and the later relayout only updates layout state.

## Changes

- Move selected Niri window focusing out of the post-layout callback path.
- Keep requesting the Niri layout refresh after applying focus.
- Update the regression test to assert that focus is applied synchronously and is not replaced by later stale remembered focus.

## Test plan

- [x] `swift test --filter RuntimeArchitectureTests/testNiriPostLayoutFocusAppliesSynchronously`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Refactored window focus handling during layout operations for more consistent and responsive behavior.

* **Tests**
  * Updated focus synchronization tests to reflect improved focus application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->