### PR TITLE
feat: hold-to-show workspace bar visibility mode

### DIFF
--- a/Sources/OmniWM/Core/Config/CanonicalTOMLConfig.swift
+++ b/Sources/OmniWM/Core/Config/CanonicalTOMLConfig.swift
@@ -106,6 +106,7 @@ struct CanonicalTOMLConfig: Codable, Equatable {
 
     struct WorkspaceBar: Codable, Equatable {
         var enabled: Bool
+        var visibilityMode: String
         var showLabels: Bool
         var showFloatingWindows: Bool
         var windowLevel: String
@@ -121,6 +122,64 @@ struct CanonicalTOMLConfig: Codable, Equatable {
         var labelFontSize: Double
         var accentColor: Color?
         var textColor: Color?
+
+        private enum CodingKeys: String, CodingKey {
+            case enabled
+            case visibilityMode
+            case showLabels
+            case showFloatingWindows
+            case windowLevel
+            case position
+            case notchAware
+            case deduplicateAppIcons
+            case hideEmptyWorkspaces
+            case reserveLayoutSpace
+            case height
+            case backgroundOpacity
+            case xOffset
+            case yOffset
+            case labelFontSize
+            case accentColor
+            case textColor
+        }
+
+        init(
+            enabled: Bool,
+            visibilityMode: String,
+            showLabels: Bool,
+            showFloatingWindows: Bool,
+            windowLevel: String,
+            position: String,
+            notchAware: Bool,
+            deduplicateAppIcons: Bool,
+            hideEmptyWorkspaces: Bool,
+            reserveLayoutSpace: Bool,
+            height: Double,
+            backgroundOpacity: Double,
+            xOffset: Double,
+            yOffset: Double,
+            labelFontSize: Double,
+            accentColor: Color?,
+            textColor: Color?
+        ) {
+            self.enabled = enabled
+            self.visibilityMode = visibilityMode
+            self.showLabels = showLabels
+            self.showFloatingWindows = showFloatingWindows
+            self.windowLevel = windowLevel
+            self.position = position
+            self.notchAware = notchAware
+            self.deduplicateAppIcons = deduplicateAppIcons
+            self.hideEmptyWorkspaces = hideEmptyWorkspaces
+            self.reserveLayoutSpace = reserveLayoutSpace
+            self.height = height
+            self.backgroundOpacity = backgroundOpacity
+            self.xOffset = xOffset
+            self.yOffset = yOffset
+            self.labelFontSize = labelFontSize
+            self.accentColor = accentColor
+            self.textColor = textColor
+        }
 
         struct Color: Codable, Equatable {
             var red: Double
@@ -637,6 +696,12 @@ extension CanonicalTOMLConfig.WorkspaceBar {
         let defaults = CanonicalTOMLConfig.recoveryDefaults().workspaceBar
 
         enabled = try container.decode(Bool.self, forKey: .enabled, default: defaults.enabled, recovering: recovering)
+        visibilityMode = try container.decode(
+            String.self,
+            forKey: .visibilityMode,
+            default: defaults.visibilityMode,
+            recovering: recovering
+        )
         showLabels = try container.decode(
             Bool.self,
             forKey: .showLabels,
@@ -941,6 +1006,7 @@ extension CanonicalTOMLConfig {
         )
         workspaceBar = WorkspaceBar(
             enabled: export.workspaceBarEnabled,
+            visibilityMode: export.workspaceBarVisibilityMode,
             showLabels: export.workspaceBarShowLabels,
             showFloatingWindows: export.workspaceBarShowFloatingWindows,
             windowLevel: export.workspaceBarWindowLevel,
@@ -1034,6 +1100,7 @@ extension CanonicalTOMLConfig {
             hotkeyBindings: HotkeyBindingRegistry.migrateLegacyDefaultWorkspaceBindings(hotkeys),
             systemHyperTrigger: general.systemHyperTrigger,
             workspaceBarEnabled: workspaceBar.enabled,
+            workspaceBarVisibilityMode: workspaceBar.visibilityMode,
             workspaceBarShowLabels: workspaceBar.showLabels,
             workspaceBarShowFloatingWindows: workspaceBar.showFloatingWindows,
             workspaceBarWindowLevel: workspaceBar.windowLevel,

--- a/Sources/OmniWM/Core/Config/SettingsExport.swift
+++ b/Sources/OmniWM/Core/Config/SettingsExport.swift
@@ -52,6 +52,7 @@ struct SettingsExport: Equatable {
     var systemHyperTrigger: SystemHyperTrigger
 
     var workspaceBarEnabled: Bool
+    var workspaceBarVisibilityMode: String
     var workspaceBarShowLabels: Bool
     var workspaceBarShowFloatingWindows: Bool
     var workspaceBarWindowLevel: String
@@ -156,6 +157,7 @@ extension SettingsExport {
             hotkeyBindings: HotkeyBindingRegistry.defaults(),
             systemHyperTrigger: .default,
             workspaceBarEnabled: true,
+            workspaceBarVisibilityMode: WorkspaceBarVisibilityMode.always.rawValue,
             workspaceBarShowLabels: true,
             workspaceBarShowFloatingWindows: false,
             workspaceBarWindowLevel: WorkspaceBarWindowLevel.popup.rawValue,

--- a/Sources/OmniWM/Core/Config/SettingsStore.swift
+++ b/Sources/OmniWM/Core/Config/SettingsStore.swift
@@ -168,6 +168,12 @@ final class SettingsStore {
         didSet { scheduleSave() }
     }
 
+    var workspaceBarVisibilityMode = WorkspaceBarVisibilityMode(
+        rawValue: SettingsStore.defaultExport.workspaceBarVisibilityMode
+    ) ?? .always {
+        didSet { scheduleSave() }
+    }
+
     var workspaceBarShowLabels = SettingsStore.defaultExport.workspaceBarShowLabels {
         didSet { scheduleSave() }
     }
@@ -549,6 +555,7 @@ final class SettingsStore {
             hotkeyBindings: hotkeyBindings,
             systemHyperTrigger: systemHyperTrigger,
             workspaceBarEnabled: workspaceBarEnabled,
+            workspaceBarVisibilityMode: workspaceBarVisibilityMode.rawValue,
             workspaceBarShowLabels: workspaceBarShowLabels,
             workspaceBarShowFloatingWindows: workspaceBarShowFloatingWindows,
             workspaceBarWindowLevel: workspaceBarWindowLevel.rawValue,
@@ -656,6 +663,7 @@ final class SettingsStore {
         systemHyperTrigger = export.systemHyperTrigger
 
         workspaceBarEnabled = export.workspaceBarEnabled
+        workspaceBarVisibilityMode = WorkspaceBarVisibilityMode(rawValue: export.workspaceBarVisibilityMode) ?? .always
         workspaceBarShowLabels = export.workspaceBarShowLabels
         workspaceBarShowFloatingWindows = export.workspaceBarShowFloatingWindows
         workspaceBarWindowLevel = WorkspaceBarWindowLevel(rawValue: export.workspaceBarWindowLevel) ?? .popup

--- a/Sources/OmniWM/Core/Config/WorkspaceBarVisibilityMode.swift
+++ b/Sources/OmniWM/Core/Config/WorkspaceBarVisibilityMode.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+enum WorkspaceBarVisibilityMode: String, CaseIterable, Identifiable {
+    case always
+    case holdKey
+
+    var id: String {
+        rawValue
+    }
+
+    var displayName: String {
+        switch self {
+        case .always: "Always"
+        case .holdKey: "While Hotkey Is Pressed"
+        }
+    }
+}

--- a/Sources/OmniWM/Core/Controller/CommandHandler.swift
+++ b/Sources/OmniWM/Core/Controller/CommandHandler.swift
@@ -213,6 +213,8 @@ final class CommandHandler {
             controller.openMenuAnywhere()
         case .toggleWorkspaceBarVisibility:
             controller.toggleWorkspaceBarVisibility()
+        case .holdWorkspaceBarVisibility:
+            controller.beginWorkspaceBarHoldVisibility()
         case .toggleHiddenBar:
             controller.toggleHiddenBar()
         case .toggleQuakeTerminal:

--- a/Sources/OmniWM/Core/Controller/WMController.swift
+++ b/Sources/OmniWM/Core/Controller/WMController.swift
@@ -131,6 +131,8 @@ final class WMController {
     @ObservationIgnored
     private var hiddenWorkspaceBarMonitorIds: Set<Monitor.ID> = []
     @ObservationIgnored
+    private var workspaceBarHoldVisibilityCount = 0
+    @ObservationIgnored
     private let hiddenBarController: HiddenBarController
     @ObservationIgnored
     private lazy var quakeTerminalController: QuakeTerminalController = .init(
@@ -231,6 +233,18 @@ final class WMController {
             guard let self else { return }
             if !eventIntake.enqueue(.hotkeyCommand(command)) {
                 _ = commandHandler.handleHotkeyCommand(command)
+            }
+        }
+        hotkeys.onCommandRelease = { [weak self] command in
+            guard case .holdWorkspaceBarVisibility = command else { return }
+            self?.endWorkspaceBarHoldVisibility()
+        }
+        hotkeys.onHyperTriggerActiveChanged = { [weak self] isActive in
+            guard let self, self.settings.workspaceBarVisibilityMode == .holdKey else { return }
+            if isActive {
+                self.beginWorkspaceBarHoldVisibility()
+            } else {
+                self.endWorkspaceBarHoldVisibility()
             }
         }
         tabbedOverlayManager.onSelect = { [weak self] info, visualIndex, token in
@@ -466,6 +480,7 @@ final class WMController {
         guard let monitor = monitorForInteraction() else { return false }
         let resolved = settings.resolvedBarSettings(for: monitor)
         guard resolved.enabled else { return false }
+        guard settings.workspaceBarVisibilityMode == .always else { return false }
 
         if hiddenWorkspaceBarMonitorIds.contains(monitor.id) {
             hiddenWorkspaceBarMonitorIds.remove(monitor.id)
@@ -476,6 +491,22 @@ final class WMController {
         layoutRefreshController.requestRelayout(reason: .monitorSettingsChanged)
         surfaceReconciler.noteWorldChanged()
         return true
+    }
+
+    func beginWorkspaceBarHoldVisibility() {
+        guard settings.workspaceBarVisibilityMode == .holdKey else { return }
+        workspaceBarHoldVisibilityCount += 1
+        guard workspaceBarHoldVisibilityCount == 1 else { return }
+        workspaceBarManager.setup(controller: self, settings: settings)
+        layoutRefreshController.requestRelayout(reason: .monitorSettingsChanged)
+    }
+
+    func endWorkspaceBarHoldVisibility() {
+        guard workspaceBarHoldVisibilityCount > 0 else { return }
+        workspaceBarHoldVisibilityCount -= 1
+        guard workspaceBarHoldVisibilityCount == 0 else { return }
+        workspaceBarManager.setup(controller: self, settings: settings)
+        layoutRefreshController.requestRelayout(reason: .monitorSettingsChanged)
     }
 
     func setQuakeTerminalEnabled(_ enabled: Bool) {
@@ -791,7 +822,13 @@ final class WMController {
 
     func isWorkspaceBarVisible(on monitor: Monitor, resolved: ResolvedBarSettings? = nil) -> Bool {
         let effective = resolved ?? settings.resolvedBarSettings(for: monitor)
-        return effective.enabled && !hiddenWorkspaceBarMonitorIds.contains(monitor.id)
+        guard effective.enabled else { return false }
+        switch settings.workspaceBarVisibilityMode {
+        case .always:
+            return !hiddenWorkspaceBarMonitorIds.contains(monitor.id)
+        case .holdKey:
+            return workspaceBarHoldVisibilityCount > 0
+        }
     }
 
     private func pruneHiddenWorkspaceBarMonitorIds() {

--- a/Sources/OmniWM/Core/Controller/WMController.swift
+++ b/Sources/OmniWM/Core/Controller/WMController.swift
@@ -240,8 +240,9 @@ final class WMController {
             self?.endWorkspaceBarHoldVisibility()
         }
         hotkeys.onHyperTriggerActiveChanged = { [weak self] isActive in
-            guard let self, self.settings.workspaceBarVisibilityMode == .holdKey else { return }
+            guard let self else { return }
             if isActive {
+                guard self.settings.workspaceBarVisibilityMode == .holdKey else { return }
                 self.beginWorkspaceBarHoldVisibility()
             } else {
                 self.endWorkspaceBarHoldVisibility()

--- a/Sources/OmniWM/Core/Input/ActionCatalog.swift
+++ b/Sources/OmniWM/Core/Input/ActionCatalog.swift
@@ -810,6 +810,13 @@ enum ActionCatalog {
                 keywords: ["workspace bar", "bar"]
             ),
             action(
+                id: "holdWorkspaceBarVisibility",
+                command: .holdWorkspaceBarVisibility,
+                category: .focus,
+                binding: .unassigned,
+                keywords: ["workspace bar", "bar", "hold", "show while pressed"]
+            ),
+            action(
                 id: "toggleHiddenBar",
                 command: .toggleHiddenBar,
                 category: .focus,
@@ -947,6 +954,7 @@ enum ActionCatalog {
              .toggleScratchpadWindow,
              .openMenuAnywhere,
              .toggleWorkspaceBarVisibility,
+             .holdWorkspaceBarVisibility,
              .toggleHiddenBar,
              .toggleQuakeTerminal,
              .toggleWorkspaceLayout,
@@ -1032,6 +1040,7 @@ enum ActionCatalog {
         case .toggleScratchpadWindow: "Toggle Scratchpad Window"
         case .openMenuAnywhere: "Open Menu Anywhere"
         case .toggleWorkspaceBarVisibility: "Toggle Workspace Bar"
+        case .holdWorkspaceBarVisibility: "Hold Workspace Bar"
         case .toggleHiddenBar: "Toggle Hidden Bar"
         case .toggleQuakeTerminal: "Toggle Quake Terminal"
         case .toggleWorkspaceLayout: "Toggle Workspace Layout"
@@ -1189,6 +1198,8 @@ enum ActionCatalog {
             .toggleQuakeTerminal
         case .toggleWorkspaceBarVisibility:
             .toggleWorkspaceBar
+        case .holdWorkspaceBarVisibility:
+            nil
         case .toggleHiddenBar:
             .toggleHiddenBar
         case .toggleFocusedWindowFloating:

--- a/Sources/OmniWM/Core/Input/HotkeyCommand.swift
+++ b/Sources/OmniWM/Core/Input/HotkeyCommand.swift
@@ -93,6 +93,7 @@ enum HotkeyCommand: Codable, Equatable, Hashable {
     case openMenuAnywhere
 
     case toggleWorkspaceBarVisibility
+    case holdWorkspaceBarVisibility
     case toggleHiddenBar
     case toggleQuakeTerminal
     case toggleWorkspaceLayout
@@ -104,5 +105,14 @@ enum HotkeyCommand: Codable, Equatable, Hashable {
 
     var layoutCompatibility: LayoutCompatibility {
         ActionCatalog.layoutCompatibility(for: self) ?? .shared
+    }
+
+    var isMomentary: Bool {
+        switch self {
+        case .holdWorkspaceBarVisibility:
+            return true
+        default:
+            return false
+        }
     }
 }

--- a/Sources/OmniWM/Core/Input/Hotkeys.swift
+++ b/Sources/OmniWM/Core/Input/Hotkeys.swift
@@ -196,12 +196,15 @@ struct HyperTriggerStateMachine: Equatable {
 @MainActor
 final class HotkeyCenter {
     var onCommand: ((HotkeyCommand) -> Void)?
+    var onCommandRelease: ((HotkeyCommand) -> Void)?
+    var onHyperTriggerActiveChanged: ((Bool) -> Void)?
 
     private var refs: [EventHotKeyRef?] = []
     private var handler: EventHandlerRef?
     private var isRunning = false
     private var commandHotkeysSuspended = false
     private var idToCommand: [UInt32: HotkeyCommand] = [:]
+    private var activeMomentaryCommands: Set<HotkeyCommand> = []
 
     private var configuration = HotkeyRuntimeConfiguration()
     private var sideSpecificDispatch: [CommandHotkeyTapMatcher.Entry] = []
@@ -209,6 +212,7 @@ final class HotkeyCenter {
     private var hyperTriggerTap: CFMachPort?
     private var hyperTriggerRunLoopSource: CFRunLoopSource?
     private var hyperTrigger = HyperTriggerStateMachine(trigger: .none, capsLockRemapped: false)
+    private var previousHyperTriggerActive = false
     private let capsLockHyperRemapper = CapsLockHyperRemapper()
     private let capsLockToggler = CapsLockToggler()
     private var capsLockHyperRemapActive = false
@@ -237,7 +241,10 @@ final class HotkeyCenter {
         guard !isRunning else { return }
         isRunning = true
 
-        var eventSpec = EventTypeSpec(eventClass: OSType(kEventClassKeyboard), eventKind: UInt32(kEventHotKeyPressed))
+        var eventSpecs = [
+            EventTypeSpec(eventClass: OSType(kEventClassKeyboard), eventKind: UInt32(kEventHotKeyPressed)),
+            EventTypeSpec(eventClass: OSType(kEventClassKeyboard), eventKind: UInt32(kEventHotKeyReleased))
+        ]
         let callback: EventHandlerUPP = { _, event, userData in
             guard let userData, let event else { return noErr }
             let center = Unmanaged<HotkeyCenter>.fromOpaque(userData).takeUnretainedValue()
@@ -251,13 +258,14 @@ final class HotkeyCenter {
                 nil,
                 &hotKeyID
             )
+            let eventKind = GetEventKind(event)
             MainActor.assumeIsolated {
-                center.dispatch(id: hotKeyID.id)
+                center.dispatch(id: hotKeyID.id, isRelease: eventKind == UInt32(kEventHotKeyReleased))
             }
             return noErr
         }
         let selfPtr = Unmanaged.passUnretained(self).toOpaque()
-        InstallEventHandler(GetApplicationEventTarget(), callback, 1, &eventSpec, selfPtr, &handler)
+        InstallEventHandler(GetApplicationEventTarget(), callback, 2, &eventSpecs, selfPtr, &handler)
 
         refreshCommandHotkeyRegistrations()
     }
@@ -299,6 +307,7 @@ final class HotkeyCenter {
     }
 
     private func unregisterCommandHotkeys() {
+        releaseActiveMomentaryCommands()
         for ref in refs {
             if let ref { UnregisterEventHotKey(ref) }
         }
@@ -382,9 +391,33 @@ final class HotkeyCenter {
         }
     }
 
-    private func dispatch(id: UInt32) {
+    private func dispatch(id: UInt32, isRelease: Bool = false) {
         guard let command = idToCommand[id] else { return }
+        if isRelease {
+            if command.isMomentary, activeMomentaryCommands.remove(command) != nil {
+                onCommandRelease?(command)
+            }
+            return
+        }
+        if command.isMomentary {
+            guard activeMomentaryCommands.insert(command).inserted else { return }
+        }
         onCommand?(command)
+    }
+
+    private func releaseActiveMomentaryCommands() {
+        let commands = activeMomentaryCommands
+        activeMomentaryCommands.removeAll()
+        for command in commands {
+            onCommandRelease?(command)
+        }
+    }
+
+    private func checkHyperTriggerActiveChanged() {
+        let isActive = hyperTrigger.isActive
+        guard previousHyperTriggerActive != isActive else { return }
+        previousHyperTriggerActive = isActive
+        onHyperTriggerActiveChanged?(isActive)
     }
 
     private func activateCapsLockHyperRemapIfNeeded() -> Bool {
@@ -438,7 +471,9 @@ final class HotkeyCenter {
 
     private func stopHyperTriggerTap() {
         hyperTrigger.reset()
+        previousHyperTriggerActive = false
         suppressedHotkeyKeyCodes.removeAll()
+        releaseActiveMomentaryCommands()
         if let source = hyperTriggerRunLoopSource {
             CFRunLoopRemoveSource(CFRunLoopGetMain(), source, .commonModes)
             hyperTriggerRunLoopSource = nil
@@ -450,6 +485,7 @@ final class HotkeyCenter {
     }
 
     private func handleHyperTriggerEvent(type: CGEventType, event: CGEvent) -> Unmanaged<CGEvent>? {
+        let result: Unmanaged<CGEvent>?
         switch type {
         case .tapDisabledByTimeout:
             if let tap = hyperTriggerTap {
@@ -457,22 +493,26 @@ final class HotkeyCenter {
             }
             hyperTrigger.reset()
             suppressedHotkeyKeyCodes.removeAll()
+            checkHyperTriggerActiveChanged()
             return Unmanaged.passUnretained(event)
         case .tapDisabledByUserInput:
             hyperTrigger.reset()
             suppressedHotkeyKeyCodes.removeAll()
+            checkHyperTriggerActiveChanged()
             return Unmanaged.passUnretained(event)
         case .keyDown,
              .keyUp:
-            return handleHyperTriggerKeyEvent(type: type, event: event)
+            result = handleHyperTriggerKeyEvent(type: type, event: event)
         case .flagsChanged:
-            return handleHyperTriggerFlagsChanged(event)
+            result = handleHyperTriggerFlagsChanged(event)
         case .otherMouseDown,
              .otherMouseUp:
-            return handleHyperTriggerMouseEvent(type: type, event: event)
+            result = handleHyperTriggerMouseEvent(type: type, event: event)
         default:
             return Unmanaged.passUnretained(event)
         }
+        checkHyperTriggerActiveChanged()
+        return result
     }
 
     private func handleHyperTriggerKeyEvent(type: CGEventType, event: CGEvent) -> Unmanaged<CGEvent>? {
@@ -502,12 +542,22 @@ final class HotkeyCenter {
                )
             {
                 suppressedHotkeyKeyCodes.insert(keyCode)
+                if command.isMomentary {
+                    guard activeMomentaryCommands.insert(command).inserted else { return nil }
+                }
                 onCommand?(command)
                 return nil
             }
             return Unmanaged.passUnretained(event)
         case .keyUp:
             if suppressedHotkeyKeyCodes.remove(keyCode) != nil {
+                if let command = CommandHotkeyTapMatcher.match(
+                    keyCode: keyCode,
+                    rawFlags: event.flags.rawValue,
+                    entries: sideSpecificDispatch
+                ), command.isMomentary, activeMomentaryCommands.remove(command) != nil {
+                    onCommandRelease?(command)
+                }
                 return nil
             }
             return applyHyperTriggerDecision(

--- a/Sources/OmniWM/Core/Input/Hotkeys.swift
+++ b/Sources/OmniWM/Core/Input/Hotkeys.swift
@@ -209,10 +209,13 @@ final class HotkeyCenter {
     private var configuration = HotkeyRuntimeConfiguration()
     private var sideSpecificDispatch: [CommandHotkeyTapMatcher.Entry] = []
     private var suppressedHotkeyKeyCodes: Set<UInt32> = []
+    private var suppressedKeyDownCommands: [UInt32: HotkeyCommand] = [:]
     private var hyperTriggerTap: CFMachPort?
     private var hyperTriggerRunLoopSource: CFRunLoopSource?
     private var hyperTrigger = HyperTriggerStateMachine(trigger: .none, capsLockRemapped: false)
     private var previousHyperTriggerActive = false
+    private var modifierChordWatchEnabled = false
+    private var modifierChordActive = false
     private let capsLockHyperRemapper = CapsLockHyperRemapper()
     private let capsLockToggler = CapsLockToggler()
     private var capsLockHyperRemapActive = false
@@ -320,9 +323,14 @@ final class HotkeyCenter {
         restoreCapsLockHyperRemap()
         systemHyperTriggerFailure = nil
         hyperTrigger = HyperTriggerStateMachine(trigger: .none, capsLockRemapped: false)
+        modifierChordWatchEnabled = false
+        modifierChordActive = false
 
         let hyperEnabled = configuration.systemHyperTrigger.isEnabled
-        guard hyperEnabled || !sideSpecificDispatch.isEmpty else { return }
+        let hasMomentary = configuration.bindings.contains { $0.command.isMomentary }
+        let needsTap = hyperEnabled || !sideSpecificDispatch.isEmpty || hasMomentary
+
+        guard needsTap else { return }
 
         if hyperEnabled {
             if activateCapsLockHyperRemapIfNeeded() {
@@ -333,6 +341,8 @@ final class HotkeyCenter {
             } else {
                 systemHyperTriggerFailure = .capsLockRemapUnavailable
             }
+        } else if hasMomentary {
+            modifierChordWatchEnabled = true
         }
 
         if !setupHyperTriggerTapIfNeeded() {
@@ -341,6 +351,7 @@ final class HotkeyCenter {
             }
             restoreCapsLockHyperRemap()
             hyperTrigger = HyperTriggerStateMachine(trigger: .none, capsLockRemapped: false)
+            modifierChordWatchEnabled = false
         }
     }
 
@@ -414,7 +425,7 @@ final class HotkeyCenter {
     }
 
     private func checkHyperTriggerActiveChanged() {
-        let isActive = hyperTrigger.isActive
+        let isActive = hyperTrigger.isActive || modifierChordActive
         guard previousHyperTriggerActive != isActive else { return }
         previousHyperTriggerActive = isActive
         onHyperTriggerActiveChanged?(isActive)
@@ -471,8 +482,10 @@ final class HotkeyCenter {
 
     private func stopHyperTriggerTap() {
         hyperTrigger.reset()
-        previousHyperTriggerActive = false
+        modifierChordActive = false
+        checkHyperTriggerActiveChanged()
         suppressedHotkeyKeyCodes.removeAll()
+        suppressedKeyDownCommands.removeAll()
         releaseActiveMomentaryCommands()
         if let source = hyperTriggerRunLoopSource {
             CFRunLoopRemoveSource(CFRunLoopGetMain(), source, .commonModes)
@@ -492,12 +505,18 @@ final class HotkeyCenter {
                 CGEvent.tapEnable(tap: tap, enable: true)
             }
             hyperTrigger.reset()
+            modifierChordActive = false
             suppressedHotkeyKeyCodes.removeAll()
+            suppressedKeyDownCommands.removeAll()
+            releaseActiveMomentaryCommands()
             checkHyperTriggerActiveChanged()
             return Unmanaged.passUnretained(event)
         case .tapDisabledByUserInput:
             hyperTrigger.reset()
+            modifierChordActive = false
             suppressedHotkeyKeyCodes.removeAll()
+            suppressedKeyDownCommands.removeAll()
+            releaseActiveMomentaryCommands()
             checkHyperTriggerActiveChanged()
             return Unmanaged.passUnretained(event)
         case .keyDown,
@@ -542,6 +561,7 @@ final class HotkeyCenter {
                )
             {
                 suppressedHotkeyKeyCodes.insert(keyCode)
+                suppressedKeyDownCommands[keyCode] = command
                 if command.isMomentary {
                     guard activeMomentaryCommands.insert(command).inserted else { return nil }
                 }
@@ -551,11 +571,10 @@ final class HotkeyCenter {
             return Unmanaged.passUnretained(event)
         case .keyUp:
             if suppressedHotkeyKeyCodes.remove(keyCode) != nil {
-                if let command = CommandHotkeyTapMatcher.match(
-                    keyCode: keyCode,
-                    rawFlags: event.flags.rawValue,
-                    entries: sideSpecificDispatch
-                ), command.isMomentary, activeMomentaryCommands.remove(command) != nil {
+                if let command = suppressedKeyDownCommands.removeValue(forKey: keyCode),
+                   command.isMomentary,
+                   activeMomentaryCommands.remove(command) != nil
+                {
                     onCommandRelease?(command)
                 }
                 return nil
@@ -570,6 +589,10 @@ final class HotkeyCenter {
     }
 
     private func handleHyperTriggerFlagsChanged(_ event: CGEvent) -> Unmanaged<CGEvent>? {
+        if modifierChordWatchEnabled {
+            let flags = event.flags.rawValue
+            modifierChordActive = (flags & Self.hyperFlagMask) == Self.hyperFlagMask
+        }
         let keyCode = UInt32(event.getIntegerValueField(.keyboardEventKeycode))
         return applyHyperTriggerDecision(
             hyperTrigger.handleFlagsChanged(keyCode: keyCode, rawFlags: event.flags.rawValue),

--- a/Sources/OmniWM/UI/WorkspaceBarSettingsTab.swift
+++ b/Sources/OmniWM/UI/WorkspaceBarSettingsTab.swift
@@ -58,6 +58,15 @@ private struct GlobalBarSettingsSection: View {
                 }
 
             if settings.workspaceBarEnabled {
+                Picker("Show", selection: $settings.workspaceBarVisibilityMode) {
+                    ForEach(WorkspaceBarVisibilityMode.allCases) { mode in
+                        Text(mode.displayName).tag(mode)
+                    }
+                }
+                .onChange(of: settings.workspaceBarVisibilityMode) { _, _ in
+                    controller.updateWorkspaceBarSettings()
+                }
+
                 Toggle("Show Workspace Labels", isOn: $settings.workspaceBarShowLabels)
                     .onChange(of: settings.workspaceBarShowLabels) { _, _ in
                         controller.updateWorkspaceBarSettings()

--- a/Tests/OmniWMTests/HotkeyChordTests.swift
+++ b/Tests/OmniWMTests/HotkeyChordTests.swift
@@ -531,4 +531,10 @@ final class HotkeyChordTests: XCTestCase {
         XCTAssertEqual(decoded, binding)
         XCTAssertEqual(decoded.side, .right)
     }
+
+    func testMomentaryCommandPropertyIsSetForHoldWorkspaceBar() {
+        XCTAssertTrue(HotkeyCommand.holdWorkspaceBarVisibility.isMomentary)
+        XCTAssertFalse(HotkeyCommand.toggleWorkspaceBarVisibility.isMomentary)
+        XCTAssertFalse(HotkeyCommand.focus(.left).isMomentary)
+    }
 }


### PR DESCRIPTION
## Summary

Adds a "hold to show" visibility mode for the workspace bar. When enabled, the bar stays hidden until the user holds a configured hotkey (the modifier combination itself), at which point it appears — and hides again on release.

## Motivation

Closes #275 — "Feature: Only display workspace bar when holding modifier combination"
Related to #106 — "Keyboard shortcut for workspace bar"

Both issues describe the desire to keep the workspace bar hidden most of the time but reveal it on demand via a keyboard modifier hold, rather than toggling. This is especially useful on smaller displays (14") where screen real estate is precious.

## Implementation

- **WorkspaceBarVisibilityMode** enum (`.always`, `.holdKey`) with TOML codec support
- **holdWorkspaceBarVisibility** hotkey command marked as `isMomentary` — triggers on key-down, releases on key-up
- **Hotkeys.swift** — tracks active momentary commands; fires `onCommandRelease` via Carbon `kEventHotKeyReleased` and the existing event tap; also hooks into `HyperTriggerStateMachine` so the System Hyper Trigger key itself can serve as the hold modifier
- **WMController** — `beginWorkspaceBarHoldVisibility()` / `endWorkspaceBarHoldVisibility()` show/hide the bar panel
- **Settings UI** — picker in Workspace Bar settings tab

## Testing

- All 280 existing tests pass (including the 44 HotkeyChord tests covering the v0.5.0 chord system)
- Added `testMomentaryCommandPropertyIsSetForHoldWorkspaceBar` in HotkeyChordTests

Built and tested against v0.5.0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added workspace bar visibility modes: **Always** (default) and **Hold Key** (bar shows only while holding the assigned hotkey).
  * Introduced a new momentary **“Hold Workspace Bar”** hotkey action.
  * Added a **workspace bar visibility mode** picker to the Workspace Bar settings UI.

* **Bug Fixes**
  * Improved hotkey release handling and momentary-state tracking to prevent stuck “pressed” behavior.  

* **Chores**
  * Updated configuration import/export to persist the new visibility mode setting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->