### PR TITLE
Fix workspace bar click on emoji-named workspaces

### DIFF
--- a/Sources/OmniWM/Core/Controller/WMController.swift
+++ b/Sources/OmniWM/Core/Controller/WMController.swift
@@ -742,6 +742,10 @@ final class WMController {
         windowActionHandler.focusWorkspaceFromBar(named: name)
     }
 
+    func focusWorkspaceFromBar(id workspaceId: WorkspaceDescriptor.ID) {
+        windowActionHandler.focusWorkspaceFromBar(id: workspaceId)
+    }
+
     func focusWindowFromBar(token: WindowToken) {
         windowActionHandler.focusWindowFromBar(token: token)
     }

--- a/Sources/OmniWM/Core/Controller/WindowActionHandler.swift
+++ b/Sources/OmniWM/Core/Controller/WindowActionHandler.swift
@@ -695,6 +695,28 @@ final class WindowActionHandler {
     }
 
     @discardableResult
+    func focusWorkspaceFromBar(id workspaceId: WorkspaceDescriptor.ID) -> Bool {
+        guard let controller else { return false }
+        if let currentWorkspace = controller.activeWorkspace() {
+            controller.workspaceNavigationHandler.saveNiriViewportState(for: currentWorkspace.id)
+        }
+
+        guard let result = controller.workspaceManager.focusWorkspace(id: workspaceId) else { return false }
+
+        let focusedToken = controller.resolveAndSetWorkspaceFocusToken(for: result.workspace.id)
+        if let focusedToken {
+            _ = prepareDwindleNavigationTarget(focusedToken, workspaceId: result.workspace.id)
+        }
+        controller.layoutRefreshController
+            .commitWorkspaceTransition(reason: .workspaceTransition) { [weak controller] in
+                if let focusedToken {
+                    controller?.focusWindow(focusedToken)
+                }
+            }
+        return true
+    }
+
+    @discardableResult
     func focusWindowFromBar(token: WindowToken) -> Bool {
         guard let controller else { return false }
         guard let entry = controller.workspaceManager.entry(for: token) else { return false }

--- a/Sources/OmniWM/Core/Workspace/WorkspaceManager.swift
+++ b/Sources/OmniWM/Core/Workspace/WorkspaceManager.swift
@@ -1967,6 +1967,14 @@ final class WorkspaceManager {
         return (workspace, targetMonitor)
     }
 
+    func focusWorkspace(id workspaceId: WorkspaceDescriptor.ID) -> (workspace: WorkspaceDescriptor, monitor: Monitor)? {
+        ensureVisibleWorkspaces()
+        guard let targetMonitor = monitorForWorkspace(workspaceId) else { return nil }
+        guard setActiveWorkspace(workspaceId, on: targetMonitor.id) else { return nil }
+        guard let workspace = descriptor(for: workspaceId) else { return nil }
+        return (workspace, targetMonitor)
+    }
+
     func applySettings() {
         invalidateSettingsProjectionCaches()
         invalidateWorkspaceProjectionCaches()

--- a/Sources/OmniWM/UI/WorkspaceBar/WorkspaceBarManager.swift
+++ b/Sources/OmniWM/UI/WorkspaceBar/WorkspaceBarManager.swift
@@ -314,7 +314,7 @@ final class WorkspaceBarManager {
             showsSystemStatsButton: showsSystemStatsButton,
             motionPolicy: motionPolicy,
             onFocusWorkspace: { [weak controller] item in
-                controller?.focusWorkspaceFromBar(named: item.name)
+                controller?.focusWorkspaceFromBar(id: item.id)
             },
             onFocusWindow: { [weak controller] token in
                 controller?.focusWindowFromBar(token: token)


### PR DESCRIPTION
Clicking a workspace pill in the workspace bar did nothing when that workspace's name was an emoji.

## Cause

Bar clicks resolved the target workspace by name:

WorkspaceBarManager → focusWorkspaceFromBar(named:) → WorkspaceManager.focusWorkspace(named:) → workspaceId(for: name) → workspaceIdByName[name]

For emoji-named workspaces that name lookup returns nil, so the switch was silently dropped.

## Fix

Route bar clicks by workspace id instead — the bar item already carries WorkspaceDescriptor.ID, so the fragile name round-trip isn't needed:

- WorkspaceManager.focusWorkspace(id:) — id-based sibling of focusWorkspace(named:)
- WindowActionHandler.focusWorkspaceFromBar(id:) — id-based bar-focus path
- WMController.focusWorkspaceFromBar(id:) — forwarder
- WorkspaceBarManager — click wiring changed from item.name to item.id

The named: paths are left in place for other callers. Ported from guria/nehir.

## Testing

`make build` was not run — my machine has no Swift 6.4 toolchain (Package.swift requires it; only 6.3.3 is installed), which blocks make build repo-wide.

The change is a mechanical mirror of the existing working named: code and was verified by hand

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workspace switching from the workspace bar by targeting workspaces through their unique identifiers.
  * Preserved window focus and navigation state during workspace transitions.
  * Improved reliability when workspace names are duplicated or changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->