### PR TITLE
Preserve focus after workspace transition invalidation

### DIFF
--- a/Sources/OmniWM/Core/Controller/LayoutRefreshController.swift
+++ b/Sources/OmniWM/Core/Controller/LayoutRefreshController.swift
@@ -998,12 +998,14 @@ import QuartzCore
         affectedWorkspaces: Set<WorkspaceDescriptor.ID> = [],
         reason: RefreshReason = .workspaceTransition,
         postLayoutGateWorkspaceIds: Set<WorkspaceDescriptor.ID>? = nil,
+        postLayoutInvalidated: PostLayoutAction? = nil,
         postLayout: PostLayoutAction? = nil
     ) {
         requestImmediateRelayout(
             reason: reason,
             affectedWorkspaceIds: affectedWorkspaces,
             postLayout: postLayout,
+            postLayoutInvalidated: postLayoutInvalidated,
             postLayoutGateWorkspaceIds: postLayoutGateWorkspaceIds
         )
     }

--- a/Sources/OmniWM/Core/Controller/WindowActionHandler.swift
+++ b/Sources/OmniWM/Core/Controller/WindowActionHandler.swift
@@ -500,10 +500,20 @@ final class WindowActionHandler {
                 )
             )
         }
-        controller.layoutRefreshController
-            .commitWorkspaceTransition(reason: .workspaceTransition) { [weak controller] in
-                controller?.focusWindow(token)
+        let focusTarget: LayoutRefreshController.PostLayoutAction = { [weak controller] in
+            guard let controller,
+                  controller.activeWorkspace()?.id == workspaceId,
+                  controller.workspaceManager.entry(for: token)?.workspaceId == workspaceId
+            else {
+                return
             }
+            controller.focusWindow(token)
+        }
+        controller.layoutRefreshController.commitWorkspaceTransition(
+            reason: .workspaceTransition,
+            postLayoutInvalidated: focusTarget,
+            postLayout: focusTarget
+        )
         return true
     }
 

--- a/Tests/OmniWMTests/RuntimeArchitectureTests.swift
+++ b/Tests/OmniWMTests/RuntimeArchitectureTests.swift
@@ -1831,6 +1831,38 @@ final class RuntimeArchitectureTests: XCTestCase {
     }
 
     @MainActor
+    func testWorkspaceTransitionPreservesInvalidatedFocusHandoff() async throws {
+        let controller = Self.controller()
+        let workspaceId = try XCTUnwrap(
+            controller.workspaceManager.workspaceId(for: "1", createIfMissing: true)
+        )
+        controller.layoutRefreshController.layoutState.hasCompletedInitialRefresh = true
+        var ranCurrentAction = false
+        var ranInvalidatedAction = false
+
+        controller.layoutRefreshController.commitWorkspaceTransition(
+            affectedWorkspaces: [workspaceId],
+            postLayoutGateWorkspaceIds: [workspaceId],
+            postLayoutInvalidated: { ranInvalidatedAction = true },
+            postLayout: { ranCurrentAction = true }
+        )
+        controller.workspaceManager.invalidateLayout(for: [workspaceId])
+
+        for _ in 0 ..< 8 {
+            if let task = controller.layoutRefreshController.layoutState.activeRefreshTask {
+                await task.value
+            } else if controller.layoutRefreshController.layoutState.pendingRefresh == nil {
+                break
+            } else {
+                await Task.yield()
+            }
+        }
+
+        XCTAssertFalse(ranCurrentAction)
+        XCTAssertTrue(ranInvalidatedAction)
+    }
+
+    @MainActor
     func testLayoutPlanAcceptedSeqIncludesAnimationDirectiveFocusMutation() throws {
         let controller = Self.controller()
         let workspaceId = try XCTUnwrap(controller.workspaceManager.workspaceId(for: "1", createIfMissing: true))


### PR DESCRIPTION
Fixes #484.

Preserves the exact-window focus handoff when a workspace reveal invalidates its relayout, without allowing stale focus steals.

Reproduced across Chrome, VS Code, Spotify, ChatGPT, Safari, Mail, and iTerm2; regression tests, format, and lint pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved window focus handling during workspace transitions, ensuring focus is applied only when the target window and workspace are still active.
  * Preserved focus handoff when layout invalidation occurs during a transition.

* **Tests**
  * Added coverage for focus behavior when workspace layouts are invalidated mid-transition.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Trace: https://gist.github.com/henry-p/a39baac2dc3ec8218436c058c854d2b8