### PR TITLE
Document trace files in contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,6 +31,10 @@ Bug fixes, documentation improvements, performance work, focused cleanups, featu
 - Add screenshots, recordings, or CLI examples when they help explain the change.
 - Update documentation when behavior, workflows, or interfaces change.
 
+## Trace Files
+
+Include a trace file when possible, especially with bug reports. It records OmniWM activity and state around the problem. Open **Settings → Troubleshooting**, click **Start Recording**, reproduce the bug, then click **Stop & Save Recording** and attach the saved `.log` file.
+
 ## Basic Workflow
 
 1. Fork the repository.


### PR DESCRIPTION
Adds a short note explaining when to include a trace file and how to record one.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for attaching OmniWM trace logs to bug reports.
  * Included steps for starting, reproducing, stopping, saving, and attaching trace recordings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->