### PR TITLE
Clamp Niri viewport to remaining content after window removal

### DIFF
--- a/Sources/OmniWM/Core/Layout/Niri/NiriLayoutEngine+Windows.swift
+++ b/Sources/OmniWM/Core/Layout/Niri/NiriLayoutEngine+Windows.swift
@@ -275,6 +275,18 @@ extension NiriLayoutEngine {
             visibilityWasCorrected = true
         }
 
+        if !removedTokens.isEmpty,
+           clampViewportToRemainingContent(
+               in: workspaceId,
+               state: &state,
+               motion: motion,
+               workingFrame: workingFrame,
+               gaps: gaps
+           )
+        {
+            viewportNeedsRecalc = true
+        }
+
         return NiriRemovalResult(
             removedTokens: removedTokens,
             removedNodeIds: removedNodeIds.union(batchRemovedNodeIds),
@@ -498,6 +510,42 @@ extension NiriLayoutEngine {
         guard !cols.isEmpty else { return nil }
         let idx = activeIndex.clamped(to: 0 ... (cols.count - 1))
         return fallbackSelectionInColumn(cols[idx], excluding: removedNodeIds)
+    }
+
+    /// Removal shrinks the strip, but none of the per-branch fixups re-check the viewport against the
+    /// remaining content: a close landing right of the active column (focus-follows-mouse refocuses the
+    /// neighbor before the destroy event arrives) skips every recalculation, and a stale
+    /// `activatePrevColumnOnRemoval` offset can restore a position past the new content edge. Clamp the
+    /// settled view origin so the viewport never straddles space the surviving columns no longer occupy.
+    private func clampViewportToRemainingContent(
+        in workspaceId: WorkspaceDescriptor.ID,
+        state: inout ViewportState,
+        motion: MotionSnapshot,
+        workingFrame: CGRect,
+        gaps: CGFloat
+    ) -> Bool {
+        let cols = columns(in: workspaceId)
+        guard !cols.isEmpty else { return false }
+
+        for col in cols where col.cachedWidth <= 0 {
+            col.resolveAndCacheWidth(workingAreaWidth: workingFrame.width, gaps: gaps)
+        }
+
+        let activeIdx = state.activeColumnIndex.clamped(to: 0 ... (cols.count - 1))
+        state.activeColumnIndex = activeIdx
+
+        let viewStart = state.viewPosPixels(columns: cols, gap: gaps)
+        let contentEdge = state.totalWidth(columns: cols, gap: gaps) - workingFrame.width + gaps
+        let clampedStart = viewStart.clamped(to: min(-gaps, contentEdge) ... max(-gaps, contentEdge))
+        guard abs(clampedStart - viewStart) > 0.5 else { return false }
+
+        let activeX = state.columnX(at: activeIdx, columns: cols, gap: gaps)
+        state.animateToOffset(
+            clampedStart - activeX,
+            motion: motion,
+            scale: displayScale(in: workspaceId)
+        )
+        return true
     }
 
     @discardableResult

--- a/Tests/OmniWMTests/NiriRemovalViewportTests.swift
+++ b/Tests/OmniWMTests/NiriRemovalViewportTests.swift
@@ -1,0 +1,183 @@
+// SPDX-License-Identifier: GPL-2.0-only
+// Copyright (C) 2026 BarutSRB — https://github.com/BarutSRB/OmniWM
+
+import CoreGraphics
+import Foundation
+@testable import OmniWM
+import XCTest
+
+/// Regression tests for issue #498: closing a column must not leave the viewport
+/// straddling space the remaining columns no longer occupy.
+@MainActor
+final class NiriRemovalViewportTests: XCTestCase {
+    private struct Fixture {
+        let engine: NiriLayoutEngine
+        let workspaceId: WorkspaceDescriptor.ID
+        let tokens: [WindowToken]
+        let workingFrame: CGRect
+        let gap: CGFloat
+        var state: ViewportState
+    }
+
+    private func makeFixture(
+        widths: [CGFloat],
+        gap: CGFloat,
+        span: CGFloat
+    ) -> Fixture {
+        let engine = NiriLayoutEngine()
+        let workspaceId = WorkspaceDescriptor.ID()
+        var tokens: [WindowToken] = []
+        for index in 0 ..< widths.count {
+            let token = WindowToken(pid: 1, windowId: index + 1)
+            _ = engine.addWindow(token: token, to: workspaceId, afterSelection: nil)
+            tokens.append(token)
+        }
+        let columns = engine.columns(in: workspaceId)
+        for (column, width) in zip(columns, widths) {
+            column.cachedWidth = width
+        }
+
+        var state = ViewportState()
+        let lastIdx = columns.count - 1
+        state.activeColumnIndex = lastIdx
+        state.selectedNodeId = columns[lastIdx].windowNodes.first?.id
+        let lastColX = state.columnX(at: lastIdx, columns: columns, gap: gap)
+        state.viewOffset = (lastColX + widths[lastIdx] - span) - lastColX
+
+        return Fixture(
+            engine: engine,
+            workspaceId: workspaceId,
+            tokens: tokens,
+            workingFrame: CGRect(x: 0, y: 0, width: span, height: 800),
+            gap: gap,
+            state: state
+        )
+    }
+
+    private func removeToken(at index: Int, from fixture: inout Fixture) {
+        _ = fixture.engine.removeWindows(
+            [fixture.tokens[index]],
+            in: fixture.workspaceId,
+            state: &fixture.state,
+            motion: .disabled,
+            workingFrame: fixture.workingFrame,
+            gaps: fixture.gap,
+            selectedNodeId: fixture.state.selectedNodeId,
+            removedNodeIds: []
+        )
+    }
+
+    private func assertViewportSane(_ fixture: Fixture, file: StaticString = #filePath, line: UInt = #line) {
+        let columns = fixture.engine.columns(in: fixture.workspaceId)
+        XCTAssertFalse(columns.isEmpty, "expected surviving columns", file: file, line: line)
+
+        let gap = fixture.gap
+        let span = fixture.workingFrame.width
+        let activePos = fixture.state.columnX(
+            at: fixture.state.activeColumnIndex,
+            columns: columns,
+            gap: gap
+        )
+        let viewStart = activePos + fixture.state.viewOffset
+        let total = fixture.state.totalWidth(columns: columns, gap: gap)
+        let contentEdge = total - span + gap
+
+        XCTAssertGreaterThanOrEqual(
+            viewStart,
+            min(-gap, contentEdge) - 1,
+            "viewport shows void left of the remaining columns",
+            file: file,
+            line: line
+        )
+        XCTAssertLessThanOrEqual(
+            viewStart,
+            max(-gap, contentEdge) + 1,
+            "viewport shows void right of the remaining columns",
+            file: file,
+            line: line
+        )
+
+        guard let selectedId = fixture.state.selectedNodeId,
+              let node = fixture.engine.findNode(by: selectedId, in: fixture.workspaceId),
+              let column = fixture.engine.column(of: node),
+              let columnIdx = fixture.engine.columnIndex(of: column, in: fixture.workspaceId)
+        else {
+            return XCTFail("no valid selection after removal", file: file, line: line)
+        }
+        let selX = fixture.state.columnX(at: columnIdx, columns: columns, gap: gap)
+        XCTAssertGreaterThanOrEqual(selX, viewStart - 1, "focused column cut on the left", file: file, line: line)
+        XCTAssertLessThanOrEqual(
+            selX + columns[columnIdx].cachedWidth,
+            viewStart + span + 1,
+            "focused column cut on the right",
+            file: file,
+            line: line
+        )
+    }
+
+    /// Issue #498: focus-follows-mouse refocuses the neighbor before the AX destroy
+    /// event arrives, so the removal lands right of the already-active column and
+    /// previously skipped every viewport recalculation.
+    func testCloseRightmostAfterFocusMovedToNeighbor() {
+        var fixture = makeFixture(widths: [700, 700, 700], gap: 8, span: 1440)
+
+        let columns = fixture.engine.columns(in: fixture.workspaceId)
+        let neighbor = columns[1].windowNodes[0]
+        fixture.state.selectedNodeId = neighbor.id
+        fixture.engine.ensureSelectionVisible(
+            node: neighbor,
+            in: fixture.workspaceId,
+            motion: .disabled,
+            state: &fixture.state,
+            workingFrame: fixture.workingFrame,
+            gaps: fixture.gap
+        )
+
+        removeToken(at: fixture.tokens.count - 1, from: &fixture)
+
+        assertViewportSane(fixture)
+
+        let remaining = fixture.engine.columns(in: fixture.workspaceId)
+        let activePos = fixture.state.columnX(
+            at: fixture.state.activeColumnIndex,
+            columns: remaining,
+            gap: fixture.gap
+        )
+        let viewStart = activePos + fixture.state.viewOffset
+        for (idx, column) in remaining.enumerated() {
+            let x = fixture.state.columnX(at: idx, columns: remaining, gap: fixture.gap)
+            XCTAssertGreaterThanOrEqual(
+                x,
+                viewStart - fixture.gap - 1,
+                "column \(idx) pushed off-screen left even though everything fits"
+            )
+            XCTAssertLessThanOrEqual(
+                x + column.cachedWidth,
+                viewStart + fixture.workingFrame.width + fixture.gap + 1,
+                "column \(idx) pushed off-screen right even though everything fits"
+            )
+        }
+    }
+
+    func testCloseRightmostFocusedColumn() {
+        var fixture = makeFixture(widths: [500, 500, 500], gap: 8, span: 1000)
+        removeToken(at: fixture.tokens.count - 1, from: &fixture)
+        assertViewportSane(fixture)
+    }
+
+    func testCloseRightmostWithStaleRestoreOffset() {
+        var fixture = makeFixture(widths: [500, 500, 500], gap: 0, span: 1000)
+        fixture.state.activatePrevColumnOnRemoval = 300
+        removeToken(at: fixture.tokens.count - 1, from: &fixture)
+        assertViewportSane(fixture)
+    }
+
+    /// Removing a column left of the active one rebases the offset to keep the view origin
+    /// stationary, but the strip is now shorter: viewing the far right end must not leave
+    /// the viewport hanging past the remaining content.
+    func testCloseLeftmostWhileViewingFarRight() {
+        var fixture = makeFixture(widths: [500, 500, 500], gap: 0, span: 1000)
+        removeToken(at: 0, from: &fixture)
+        assertViewportSane(fixture)
+    }
+}


### PR DESCRIPTION
## Problem

Fixes #498.

With the Niri (Scrolling) layout, closing the rightmost window can leave the newly focused window partially off-screen on the left, with unused empty space where the closed column used to be, and no immediate recalculation.

Root cause: `removeWindows` → `removeColumnByIdx` handles viewport correction per branch, and the branch taken when the removed column lies **right of the active column** performs no viewport recalculation at all. That branch is exactly what the reported repro hits with focus-follows-mouse: focus moves to the neighbor before the AX destroy event arrives, so by the time the removal lands the active column is already the neighbor. The viewport keeps its old origin, which now extends past the end of the shortened strip — the focused column renders partially off-screen left and the vacated space stays empty. Two sibling shapes strand the viewport the same way: a stale `activatePrevColumnOnRemoval` offset restored past the new content edge, and a removal left of the active column while scrolled to the far right end (the offset rebase keeps the view origin stationary over content that no longer reaches it).

## Fix

One clamp at the single choke point every close-driven removal routes through: after `removeWindows` finishes its per-branch fixups, clamp the settled view origin into the range the surviving columns actually occupy (with the usual one-gap padding), animate the correction, and report it via `viewportNeedsRecalc` so the scroll-animation directive fires. Paths that already produce an in-range origin are untouched — the clamp is a no-op for them.

## Verification

- Added `Tests/OmniWMTests/NiriRemovalViewportTests.swift` with four regression tests: the reported focus-follows-mouse shape, closing the focused rightmost column, a stale `activatePrevColumnOnRemoval` offset, and closing the leftmost column while viewing the far right end.
- My local toolchain cannot build the full package (needs Swift 6.4 + a locally built GhosttyKit archive), so I verified with a standalone harness that compiles the real Niri engine sources (`Core/Layout/Niri/*` plus support files) unmodified and runs exactly the test bodies from the added test file: all four tests fail before the change (viewport origin stranded at the old content edge, e.g. `676` where the allowed maximum is `-8`) and pass after it.
- Please run `swift test` on CI / a Swift 6.4 toolchain to confirm the new test file compiles in the package context.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011xFgrvCew6VxTjdbLaTrpu

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved viewport positioning after windows or columns are removed.
  * Prevented the viewport from showing empty space or excessively clipping the focused column.
  * Added handling for stale viewport offsets and removals near the active or focused column.

* **Tests**
  * Added regression coverage for viewport recalculation across multiple removal scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->