### PR TITLE
Focus the snapped column's window when a trackpad scroll gesture ends

### DIFF
--- a/Sources/OmniWM/Core/Controller/MouseEventHandler.swift
+++ b/Sources/OmniWM/Core/Controller/MouseEventHandler.swift
@@ -1740,6 +1740,7 @@ final class MouseEventHandler {
         }
         if let selectedWindow {
             rememberViewportFocusAnchor(selectedWindow, engine: engine, wsId: wsId)
+            focusViewportSelectionAfterGesture(selectedWindow)
         }
         if controller.workspaceManager.animationDriver.hasMotion(in: wsId) {
             controller.layoutRefreshController.startScrollAnimation(for: wsId)
@@ -1864,6 +1865,16 @@ final class MouseEventHandler {
         let selectedWindow = windows[activeTileIndex]
         state.selectedNodeId = selectedWindow.id
         return selectedWindow
+    }
+
+    // Applies AX focus to the column the gesture snapped to (issue #479). Runs only once per
+    // gesture at touch release — never per frame — and routes through the managed-focus request
+    // path so the resulting AX focus echo is classified as our own intent, not a user action.
+    private func focusViewportSelectionAfterGesture(_ window: NiriWindow) {
+        guard let controller else { return }
+        guard !controller.hasFrontmostOwnedWindow else { return }
+        guard controller.workspaceManager.focusedToken != window.token else { return }
+        controller.focusWindow(window.token, origin: .pointerHover)
     }
 
     private func rememberViewportFocusAnchor(


### PR DESCRIPTION
Fixes #479.

## Problem

Trackpad column-scroll gestures move the viewport and update the engine selection (`endGesture` snaps `activeColumnIndex`, `syncViewportSelectionToActiveColumn` sets `selectedNodeId`, and the focus anchor is remembered), but AX focus was never applied — the initially focused window kept focus after scrolling.

## Fix

One call site in `finalizeOrCancelCommittedGesture`: after the gesture-end snap syncs the viewport selection, apply focus to the selected window via the existing managed-focus path.

## Why this shouldn't reintroduce the old gesture-focus bugs

I know a previous attempt at this was reverted for being buggy, so the fix is deliberately narrow:

- **Fires once per gesture at touch release** — never per frame, so no focus churn while scrolling.
- **Routes through `WMController.focusWindow` → `IntentLedger.beginManagedRequest`**, the same path focus-follows-mouse uses. The resulting AX focus echo is classified as OmniWM's own intent, so it can't be mistaken for a user action and can't re-anchor the viewport (no scroll → focus → reveal-scroll feedback loop).
- **`.pointerHover` origin** — mouse-warp-to-focused-window policy stays out of the way, same as FFM.
- **Guards**: no-op when the snapped column's window is already focused (the common case), and skipped when an OmniWM-owned window (command palette etc.) is frontmost.
- **Both scroll styles covered**: snap mode focuses the snapped column; momentum mode focuses the projected landing column computed at touch release, so focus is correct even while the deceleration animation is still running.

Mouse-wheel column ticks (`applyMouseWheelColumnTicks`) still intentionally set `axFocus: false` — untouched here to keep the diff minimal; happy to align it in a follow-up if you want wheel scrolling to focus too.

## Testing

- Full suite passes: 1426 tests, 0 failures.
- Built and running locally (Niri layout); no automated coverage for the AX-focus leg of gesture end — that path needs a live `WMController`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011xFgrvCew6VxTjdbLaTrpu

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved focus handling after completing or canceling a window gesture.
  * Ensured the snapped-to window column receives focus when appropriate, providing more consistent keyboard and accessibility focus behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->