### PR TITLE
fix: focus workspaces from the whole bar item

### DIFF
--- a/Sources/OmniWM/UI/WorkspaceBar/WorkspaceBarView.swift
+++ b/Sources/OmniWM/UI/WorkspaceBar/WorkspaceBarView.swift
@@ -346,6 +346,8 @@ private struct WorkspaceItemView: View {
         .padding(.horizontal, 8)
         .padding(.vertical, 2)
         .frame(height: itemHeight)
+        .contentShape(RoundedRectangle(cornerRadius: cornerRadius))
+        .onTapGesture(perform: onFocusWorkspace)
         .background {
             if item.isFocused || isHovered {
                 RoundedRectangle(cornerRadius: cornerRadius)


### PR DESCRIPTION
Fixes #501.

## Problem

In `WorkspaceItemView`, the only hit targets are the workspace label's text frame and each app-icon frame. The container's 8pt horizontal padding, the divider between the label and the icons, and the vertical inset have none, so clicks there are swallowed - even though `.onHover` highlights the whole pill, so the item looks like a single clickable target and behaves like two or three small ones.

A custom `displayName` makes it more noticeable: the longer name widens the pill, so there is more dead area framing the name.

## Approach

Give the item container its own hit shape and tap target:

```swift
.frame(height: itemHeight)
.contentShape(RoundedRectangle(cornerRadius: cornerRadius))
.onTapGesture(perform: onFocusWorkspace)
```

The shape is the same rounded rect already drawn as the hover/focus background, so the interactive area matches the pill the user sees. Descendant gestures still win, so clicking an app icon focuses that specific window rather than only the workspace. This is the same `.contentShape(...)` + `.onTapGesture` idiom already used for rows in `CommandPaletteController.swift`.

It also closes a smaller gap: with labels hidden, a workspace holding windows rendered no label button at all, so there was no way to focus it from the bar.

## Behavior change

Clicking anywhere inside a workspace item's pill now focuses that workspace. The 8pt gap between items stays inert. No settings, config, docs, or CLI output are affected.

## Verification

- Reproduced on v0.5.7 first: hovering a non-focused item highlighted its container (so the pointer was inside it), a synthetic click 3pt left of the label glyph did nothing, and a click on the glyph itself switched workspaces.
- `swift build --arch arm64` and `swift build --arch arm64 --build-tests` both pass.
- Caveat worth flagging: I don't have the GhosttyKit archive, so I built against a locally stubbed libghostty. That only stubs the quake terminal and doesn't touch this code path, but it means I could not do a full-app runtime pass. The one thing worth re-checking on a real build is that clicking an app icon in a non-focused workspace still focuses that window rather than just the workspace.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Expanded the clickable area for workspace items, allowing taps on the surrounding rounded container to focus the selected workspace.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->