### PR TITLE
fix: centre the workspace bar island and keep the active workspace when hiding empty ones

### DIFF
--- a/Sources/OmniWM/UI/WorkspaceBar/WorkspaceBarDataSource.swift
+++ b/Sources/OmniWM/UI/WorkspaceBar/WorkspaceBarDataSource.swift
@@ -75,11 +75,13 @@ enum WorkspaceBarDataSource {
             )
         }
 
-        if options.hideEmptyWorkspaces {
-            workspaces = workspaces.filter(\.hasBarOccupancy)
-        }
-
         let activeWorkspaceId = workspaceManager.activeWorkspace(on: monitor.id)?.id
+
+        if options.hideEmptyWorkspaces {
+            // The active workspace stays on the bar even when empty: it is the only item that
+            // reports focus, and the split layouts anchor their active island on it.
+            workspaces = workspaces.filter { $0.hasBarOccupancy || $0.workspace.id == activeWorkspaceId }
+        }
 
         return workspaces.map { snapshot in
             let topology = workspaceManager.layoutTopology(for: snapshot.workspace.id)

--- a/Sources/OmniWM/UI/WorkspaceBar/WorkspaceBarGeometry.swift
+++ b/Sources/OmniWM/UI/WorkspaceBar/WorkspaceBarGeometry.swift
@@ -11,7 +11,7 @@ struct WorkspaceBarSplitLayout: Equatable {
 struct WorkspaceBarGeometry: Equatable {
     static let notchGap: CGFloat = 8
     static let minimumSplitSideSpace: CGFloat = 60
-    static let minimumActiveIslandWidth: CGFloat = 40
+    static let minimumIslandWidth: CGFloat = 40
     static func statsButtonAnchor(buttonFrame: CGRect) -> CGPoint {
         CGPoint(x: buttonFrame.midX, y: buttonFrame.minY)
     }
@@ -45,7 +45,9 @@ struct WorkspaceBarGeometry: Equatable {
         monitor: Monitor,
         resolved: ResolvedBarSettings
     ) -> CGRect {
-        let width = max(fittingWidth, 300)
+        // The island hugs its measured content: SwiftUI draws the bar against the panel's
+        // leading edge, so a panel wider than the content offsets the visible bar from centre.
+        let width = max(fittingWidth, Self.minimumIslandWidth)
         var x = monitor.frame.midX - width / 2
         var y = originY(for: monitor)
 
@@ -84,7 +86,7 @@ struct WorkspaceBarGeometry: Equatable {
             availableActive
         )
         let y = originY(for: monitor)
-        let activeSize = max(activeWidth, Self.minimumActiveIslandWidth)
+        let activeSize = max(activeWidth, Self.minimumIslandWidth)
         var active = if activeSize <= zoneWidth {
             CGRect(x: activeAnchor - zoneWidth / 2 - activeSize / 2, y: y, width: activeSize, height: barHeight)
         } else {

--- a/Tests/OmniWMTests/WorkspaceBarDataSourceTests.swift
+++ b/Tests/OmniWMTests/WorkspaceBarDataSourceTests.swift
@@ -108,6 +108,9 @@ final class WorkspaceBarDataSourceTests: XCTestCase {
             mode: .tiling,
             to: fixture
         )
+        // Focus elsewhere so the empty policy, not the active-workspace carve-out, decides.
+        _ = try XCTUnwrap(fixture.workspaceManager.workspaceId(for: "2", createIfMissing: true))
+        _ = fixture.workspaceManager.focusWorkspace(named: "2")
 
         let visibleEmptyProjection = project(
             fixture,
@@ -127,6 +130,37 @@ final class WorkspaceBarDataSourceTests: XCTestCase {
         )
         XCTAssertFalse(hiddenEmptyProjection.items.contains { $0.id == fixture.workspaceId })
         XCTAssertEqual(fixture.workspaceManager.entry(for: token)?.workspaceId, fixture.workspaceId)
+    }
+
+    func testActiveWorkspaceStaysOnBarWhileEmptyWorkspacesAreHidden() throws {
+        let fixture = try makeFixture()
+        let occupiedId = try XCTUnwrap(
+            fixture.workspaceManager.workspaceId(for: "2", createIfMissing: true)
+        )
+        _ = addWindow(
+            token: WindowToken(pid: 47_001, windowId: 47_101),
+            bundleId: "com.example.retained",
+            mode: .tiling,
+            workspaceId: occupiedId,
+            workspaceManager: fixture.workspaceManager
+        )
+        let idleId = try XCTUnwrap(
+            fixture.workspaceManager.workspaceId(for: "3", createIfMissing: true)
+        )
+        // The fixture focuses "1", which holds no windows.
+        XCTAssertEqual(fixture.workspaceManager.activeWorkspace(on: fixture.monitor.id)?.id, fixture.workspaceId)
+
+        let projection = project(
+            fixture,
+            hideEmptyWorkspaces: true,
+            excludedBundleIDs: []
+        )
+
+        let activeItem = try XCTUnwrap(projection.items.first { $0.id == fixture.workspaceId })
+        XCTAssertTrue(activeItem.isFocused)
+        XCTAssertTrue(activeItem.windows.isEmpty)
+        XCTAssertTrue(projection.items.contains { $0.id == occupiedId })
+        XCTAssertFalse(projection.items.contains { $0.id == idleId })
     }
 
     func testExcludedScratchpadSuppressesOnlyItsBarPill() throws {

--- a/Tests/OmniWMTests/WorkspaceBarSplitGeometryTests.swift
+++ b/Tests/OmniWMTests/WorkspaceBarSplitGeometryTests.swift
@@ -206,6 +206,24 @@ final class WorkspaceBarSplitGeometryTests: XCTestCase {
         }
     }
 
+    func testCenteredIslandHugsMeasuredWidth() {
+        let monitor = makeMonitor()
+        let resolved = makeResolved(notchMode: .off)
+        let geometry = WorkspaceBarGeometry.resolve(monitor: monitor, resolved: resolved, isVisible: true)
+
+        // A panel wider than the content leaves the bar drawn against the panel's leading
+        // edge, which pushes the visible bar left of centre by half the slack.
+        for fittingWidth: CGFloat in [40, 60, 221, 288, 355, 700] {
+            let frame = geometry.frame(fittingWidth: fittingWidth, monitor: monitor, resolved: resolved)
+            XCTAssertEqual(frame.width, fittingWidth, accuracy: 0.01, "fitting \(fittingWidth)")
+            XCTAssertEqual(frame.midX, monitor.frame.midX, accuracy: 0.01, "fitting \(fittingWidth)")
+        }
+
+        let degenerate = geometry.frame(fittingWidth: 4, monitor: monitor, resolved: resolved)
+        XCTAssertEqual(degenerate.width, WorkspaceBarGeometry.minimumIslandWidth)
+        XCTAssertEqual(degenerate.midX, monitor.frame.midX, accuracy: 0.01)
+    }
+
     func testSplitReturnsNilForNonSplitModes() {
         XCTAssertNil(splitLayout(activeWidth: 100, resolved: makeResolved(notchMode: .off)))
         XCTAssertNil(splitLayout(activeWidth: 100, resolved: makeResolved(notchMode: .moveBelowMenuBar)))


### PR DESCRIPTION
Fixes #503.

## Problem

Two independent faults, both surfaced by Hide Empty Workspaces because that setting is what makes the bar narrow.

**1. The centred island is not centred.** `WorkspaceBarGeometry.frame` sized the panel `max(fittingWidth, 300)`, but SwiftUI draws the bar against the panel's leading edge, so any bar under 300pt renders offset left by half the slack. Measured from the recording on #503: 288pt of content sat 6pt left of centre and 221pt sat 40pt left, with the panel's left edge pinned at `midX - 150` in every frame.

**2. The active workspace is dropped when it is empty.** `WorkspaceBarDataSource.workspaceItems` filtered on occupancy before it resolved the active workspace, so standing on an empty workspace produced a projection where no item reports `isFocused`. `WorkspaceBarManager.splitLayout` guards on exactly that, so it bailed out and the bar fell back to the single centred island - behind the notch, indistinguishable from Notch Mode Off.

## Approach

`436cff3` sizes the panel to the measured content the way `splitFrame` already does, keeping a small floor for degenerate measurements. The floor is renamed `minimumIslandWidth` since both paths now share it.

`ac0a028` filters on occupancy **or** focus, so the empty policy only hides workspaces you are not standing on. The kept item renders as a bare label, which is what the split active island needs to stay anchored.

Two things improve alongside the centring: the panel no longer covers menu-bar space it never draws on, and the Hidden Bar fallback icon, which anchors on `barFrame.minX`, lands next to the visible bar instead of an invisible edge.

This may also cover #122 (bar not centred on a secondary monitor), which was closed with a per-monitor x-offset workaround. The same leading-edge pin would explain it whenever that bar measured under 300pt, though I cannot confirm it without that setup.

## Behavior change

With Hide Empty Workspaces enabled, the active workspace remains on the bar even when it has no projected windows; every other empty workspace remains hidden. There is no settings, config, documentation, command, or IPC wire-schema change. The existing `workspace-bar` IPC query and subscription payloads—and structured CLI output derived from that query—now include the active empty workspace; the human-readable CLI summary is unchanged.

## Verification

- `swift test --filter WorkspaceBar` - 54 tests, 0 failures.
- `testCenteredIslandHugsMeasuredWidth` fails against the old geometry with exactly the widths measured from the bug recording (`300.0 is not equal to 221.0`, `288.0`) and passes with the fix, so it pins the regression rather than restating the new code.
- `testActiveWorkspaceStaysOnBarWhileEmptyWorkspacesAreHidden` covers the focused-but-empty carve-out. The existing post-filter policy test was retargeted at a non-active workspace so it still covers exclusion feeding the empty policy.
- Frame-by-frame on the recordings below: the bar centre reads exactly 900 at widths 328, 288, 261 and 221pt, where the bug recording had 288pt at 894 and 221pt at 860.
- Caveat: I do not have the GhosttyKit archive, so this was built against a locally stubbed libghostty. That only stubs the quake terminal and does not touch these paths.

### Centring, Notch Mode Off


https://github.com/user-attachments/assets/66ac4c82-1a50-4de2-987f-188d676c9a59

### Split - Active Left, focusing an empty workspace


https://github.com/user-attachments/assets/b057882d-2d14-461c-a65d-d91a6cc35e43

