### PR TITLE
Fix Focus Previous with stale selection

### DIFF
--- a/Sources/OmniWM/Core/Controller/CommandHandler.swift
+++ b/Sources/OmniWM/Core/Controller/CommandHandler.swift
@@ -262,6 +262,26 @@ final class CommandHandler {
             engine: engine,
             fallbackWorkspaceId: wsId
         )
+        if let anchor {
+            _ = controller.workspaceManager.rememberFocus(
+                anchor.token,
+                in: anchor.workspaceId
+            )
+            if let nodeId = anchor.nodeId {
+                controller.workspaceManager.withEngineMutationScope {
+                    engine.updateFocusTimestamp(for: nodeId, in: anchor.workspaceId)
+                }
+            }
+            if let target = controller.workspaceManager.mostRecentlyFocusedTiledToken(excluding: anchor.token),
+               let targetWorkspaceId = controller.workspaceManager.entry(for: target)?.workspaceId,
+               controller.windowActionHandler.navigateToWindowInternal(
+                   token: target,
+                   workspaceId: targetWorkspaceId
+               )
+            {
+                return
+            }
+        }
         if focusGloballyPreviousNiriWindowIfNeeded(
             controller: controller,
             engine: engine,
@@ -334,10 +354,11 @@ final class CommandHandler {
     private func focusGloballyPreviousNiriWindowIfNeeded(
         controller: WMController,
         engine: NiriLayoutEngine,
-        anchor: (workspaceId: WorkspaceDescriptor.ID, nodeId: NodeId)?
+        anchor: FocusHistoryAnchor?
     ) -> Bool {
         guard let anchor,
-              let target = engine.findMostRecentlyFocusedWindow(excluding: anchor.nodeId, in: nil),
+              let nodeId = anchor.nodeId,
+              let target = engine.findMostRecentlyFocusedWindow(excluding: nodeId, in: nil),
               let targetWorkspaceId = controller.workspaceManager.entry(for: target.token)?.workspaceId,
               targetWorkspaceId != anchor.workspaceId
         else {
@@ -345,8 +366,8 @@ final class CommandHandler {
         }
 
         controller.workspaceManager.withEngineMutationScope {
-            engine.updateFocusTimestamp(for: anchor.nodeId, in: anchor.workspaceId)
-            engine.activateWindow(anchor.nodeId, in: anchor.workspaceId)
+            engine.updateFocusTimestamp(for: nodeId, in: anchor.workspaceId)
+            engine.activateWindow(nodeId, in: anchor.workspaceId)
         }
         controller.windowActionHandler.navigateToWindowInternal(
             token: target.token,
@@ -359,23 +380,41 @@ final class CommandHandler {
         controller: WMController,
         engine: NiriLayoutEngine,
         fallbackWorkspaceId: WorkspaceDescriptor.ID
-    ) -> (workspaceId: WorkspaceDescriptor.ID, nodeId: NodeId)? {
+    ) -> FocusHistoryAnchor? {
         let frontmostPid = frontmostAppPidProvider?()
             ?? NSWorkspace.shared.frontmostApplication?.processIdentifier
         let observedToken = frontmostFocusedWindowTokenProvider?()
             ?? frontmostPid.flatMap { controller.axEventHandler.focusedWindowToken(for: $0) }
 
         if let observedToken,
-           let entry = controller.workspaceManager.entry(for: observedToken),
-           let node = engine.findNode(for: observedToken, in: entry.workspaceId)
+           let entry = controller.workspaceManager.entry(for: observedToken)
         {
-            return (entry.workspaceId, node.id)
+            return FocusHistoryAnchor(
+                workspaceId: entry.workspaceId,
+                token: observedToken,
+                nodeId: engine.findNode(for: observedToken, in: entry.workspaceId)?.id
+            )
         }
 
         let selectedNodeId = controller.workspaceManager
             .niriViewportState(for: fallbackWorkspaceId)
             .selectedNodeId
-        return selectedNodeId.map { (fallbackWorkspaceId, $0) }
+        guard let selectedNodeId,
+              let node = engine.findNode(by: selectedNodeId, in: fallbackWorkspaceId) as? NiriWindow
+        else {
+            return nil
+        }
+        return FocusHistoryAnchor(
+            workspaceId: fallbackWorkspaceId,
+            token: node.token,
+            nodeId: node.id
+        )
+    }
+
+    private struct FocusHistoryAnchor {
+        let workspaceId: WorkspaceDescriptor.ID
+        let token: WindowToken
+        let nodeId: NodeId?
     }
 
     private func focusDownOrLeftInNiri() {

--- a/Sources/OmniWM/Core/Controller/CommandHandler.swift
+++ b/Sources/OmniWM/Core/Controller/CommandHandler.swift
@@ -281,6 +281,14 @@ final class CommandHandler {
             {
                 return
             }
+            if anchor.representsCurrentFocus {
+                _ = focusGloballyPreviousNiriWindowIfNeeded(
+                    controller: controller,
+                    engine: engine,
+                    anchor: anchor
+                )
+                return
+            }
         }
         if focusGloballyPreviousNiriWindowIfNeeded(
             controller: controller,
@@ -392,7 +400,19 @@ final class CommandHandler {
             return FocusHistoryAnchor(
                 workspaceId: entry.workspaceId,
                 token: observedToken,
-                nodeId: engine.findNode(for: observedToken, in: entry.workspaceId)?.id
+                nodeId: engine.findNode(for: observedToken, in: entry.workspaceId)?.id,
+                representsCurrentFocus: true
+            )
+        }
+
+        if let token = controller.workspaceManager.focusedToken,
+           let entry = controller.workspaceManager.entry(for: token)
+        {
+            return FocusHistoryAnchor(
+                workspaceId: entry.workspaceId,
+                token: token,
+                nodeId: engine.findNode(for: token, in: entry.workspaceId)?.id,
+                representsCurrentFocus: true
             )
         }
 
@@ -407,7 +427,8 @@ final class CommandHandler {
         return FocusHistoryAnchor(
             workspaceId: fallbackWorkspaceId,
             token: node.token,
-            nodeId: node.id
+            nodeId: node.id,
+            representsCurrentFocus: false
         )
     }
 
@@ -415,6 +436,7 @@ final class CommandHandler {
         let workspaceId: WorkspaceDescriptor.ID
         let token: WindowToken
         let nodeId: NodeId?
+        let representsCurrentFocus: Bool
     }
 
     private func focusDownOrLeftInNiri() {

--- a/Sources/OmniWM/Core/Controller/CommandHandler.swift
+++ b/Sources/OmniWM/Core/Controller/CommandHandler.swift
@@ -257,10 +257,15 @@ final class CommandHandler {
         guard let controller else { return }
         guard let engine = controller.niriEngine else { return }
         guard let wsId = controller.activeWorkspace()?.id else { return }
+        let anchor = focusHistoryAnchor(
+            controller: controller,
+            engine: engine,
+            fallbackWorkspaceId: wsId
+        )
         if focusGloballyPreviousNiriWindowIfNeeded(
             controller: controller,
             engine: engine,
-            workspaceId: wsId
+            anchor: anchor
         ) {
             return
         }
@@ -329,27 +334,48 @@ final class CommandHandler {
     private func focusGloballyPreviousNiriWindowIfNeeded(
         controller: WMController,
         engine: NiriLayoutEngine,
-        workspaceId: WorkspaceDescriptor.ID
+        anchor: (workspaceId: WorkspaceDescriptor.ID, nodeId: NodeId)?
     ) -> Bool {
-        let selectedNodeId = controller.workspaceManager.niriViewportState(for: workspaceId).selectedNodeId
-        guard let target = engine.findMostRecentlyFocusedWindow(excluding: selectedNodeId, in: nil),
+        guard let anchor,
+              let target = engine.findMostRecentlyFocusedWindow(excluding: anchor.nodeId, in: nil),
               let targetWorkspaceId = controller.workspaceManager.entry(for: target.token)?.workspaceId,
-              targetWorkspaceId != workspaceId
+              targetWorkspaceId != anchor.workspaceId
         else {
             return false
         }
 
         controller.workspaceManager.withEngineMutationScope {
-            if let selectedNodeId {
-                engine.updateFocusTimestamp(for: selectedNodeId, in: workspaceId)
-                engine.activateWindow(selectedNodeId, in: workspaceId)
-            }
+            engine.updateFocusTimestamp(for: anchor.nodeId, in: anchor.workspaceId)
+            engine.activateWindow(anchor.nodeId, in: anchor.workspaceId)
         }
         controller.windowActionHandler.navigateToWindowInternal(
             token: target.token,
             workspaceId: targetWorkspaceId
         )
         return true
+    }
+
+    private func focusHistoryAnchor(
+        controller: WMController,
+        engine: NiriLayoutEngine,
+        fallbackWorkspaceId: WorkspaceDescriptor.ID
+    ) -> (workspaceId: WorkspaceDescriptor.ID, nodeId: NodeId)? {
+        let frontmostPid = frontmostAppPidProvider?()
+            ?? NSWorkspace.shared.frontmostApplication?.processIdentifier
+        let observedToken = frontmostFocusedWindowTokenProvider?()
+            ?? frontmostPid.flatMap { controller.axEventHandler.focusedWindowToken(for: $0) }
+
+        if let observedToken,
+           let entry = controller.workspaceManager.entry(for: observedToken),
+           let node = engine.findNode(for: observedToken, in: entry.workspaceId)
+        {
+            return (entry.workspaceId, node.id)
+        }
+
+        let selectedNodeId = controller.workspaceManager
+            .niriViewportState(for: fallbackWorkspaceId)
+            .selectedNodeId
+        return selectedNodeId.map { (fallbackWorkspaceId, $0) }
     }
 
     private func focusDownOrLeftInNiri() {

--- a/Sources/OmniWM/Core/Input/ActionCatalog.swift
+++ b/Sources/OmniWM/Core/Input/ActionCatalog.swift
@@ -953,7 +953,6 @@ enum ActionCatalog {
              .setColumnWidth,
              .setWindowWidth,
              .setWindowHeight,
-             .focusPrevious,
              .focusDownOrLeft,
              .focusUpOrRight,
              .focusWindowInColumn,
@@ -971,6 +970,7 @@ enum ActionCatalog {
             .niri
 
         case .focus,
+             .focusPrevious,
              .moveWindowDown,
              .moveWindowUp,
              .focusWindowDownOrTop,

--- a/Sources/OmniWM/Core/Reconcile/ReconcileSnapshot.swift
+++ b/Sources/OmniWM/Core/Reconcile/ReconcileSnapshot.swift
@@ -142,6 +142,7 @@ struct FocusSessionSnapshot: Equatable {
     var lastTiledFocusedByWorkspace: [WorkspaceDescriptor.ID: WindowToken] = [:]
     var lastFloatingFocusedByWorkspace: [WorkspaceDescriptor.ID: WindowToken] = [:]
     var lastTiledFocusedToken: WindowToken? = nil
+    var tiledFocusHistory: [WindowToken] = []
     var focusLease: FocusPolicyLease? = nil
     var isNonManagedFocusActive: Bool = false
     var nonManagedFocusToken: WindowToken? = nil
@@ -152,6 +153,18 @@ struct FocusSessionSnapshot: Equatable {
 }
 
 extension FocusSessionSnapshot {
+    @discardableResult
+    mutating func recordTiledFocus(_ token: WindowToken) -> Bool {
+        let previous = tiledFocusHistory
+        tiledFocusHistory.removeAll { $0 == token }
+        tiledFocusHistory.insert(token, at: 0)
+        if tiledFocusHistory.count > 32 {
+            tiledFocusHistory.removeLast(tiledFocusHistory.count - 32)
+        }
+        lastTiledFocusedToken = token
+        return tiledFocusHistory != previous
+    }
+
     @discardableResult
     mutating func rememberFocus(
         _ token: WindowToken,
@@ -179,6 +192,10 @@ extension FocusSessionSnapshot {
 
         if lastTiledFocusedToken == token {
             lastTiledFocusedToken = nil
+            changed = true
+        }
+        if tiledFocusHistory.contains(token) {
+            tiledFocusHistory.removeAll { $0 == token }
             changed = true
         }
 
@@ -214,6 +231,10 @@ extension FocusSessionSnapshot {
             lastTiledFocusedToken = newToken
             changed = true
         }
+        if tiledFocusHistory.contains(oldToken) {
+            tiledFocusHistory = tiledFocusHistory.map { $0 == oldToken ? newToken : $0 }
+            changed = true
+        }
 
         for (workspaceId, token) in lastTiledFocusedByWorkspace where token == oldToken {
             lastTiledFocusedByWorkspace[workspaceId] = newToken
@@ -247,6 +268,10 @@ extension FocusSessionSnapshot {
             }
             if lastTiledFocusedToken == token {
                 lastTiledFocusedToken = nil
+                changed = true
+            }
+            if tiledFocusHistory.contains(token) {
+                tiledFocusHistory.removeAll { $0 == token }
                 changed = true
             }
         }

--- a/Sources/OmniWM/Core/Reconcile/StateReducer.swift
+++ b/Sources/OmniWM/Core/Reconcile/StateReducer.swift
@@ -257,9 +257,7 @@ enum StateReducer {
 
         case let .focusRemembered(token, workspaceId, mode, _):
             var focusSession = currentSnapshot.focusSession
-            let remembered = focusSession.rememberFocus(token, in: workspaceId, mode: mode)
-            let recorded = mode == .tiling && focusSession.recordTiledFocus(token)
-            if remembered || recorded {
+            if focusSession.rememberFocus(token, in: workspaceId, mode: mode) {
                 plan.focusSession = focusSession
             }
 
@@ -478,7 +476,7 @@ enum StateReducer {
         }
         focusSession.focusedToken = token
         focusSession.pendingManagedFocus = .empty
-        if mode == .tiling {
+        if mode != .floating {
             _ = focusSession.recordTiledFocus(token)
         }
         if focusSession.interactionMonitorId != monitorId {

--- a/Sources/OmniWM/Core/Reconcile/StateReducer.swift
+++ b/Sources/OmniWM/Core/Reconcile/StateReducer.swift
@@ -257,7 +257,9 @@ enum StateReducer {
 
         case let .focusRemembered(token, workspaceId, mode, _):
             var focusSession = currentSnapshot.focusSession
-            if focusSession.rememberFocus(token, in: workspaceId, mode: mode) {
+            let remembered = focusSession.rememberFocus(token, in: workspaceId, mode: mode)
+            let recorded = mode == .tiling && focusSession.recordTiledFocus(token)
+            if remembered || recorded {
                 plan.focusSession = focusSession
             }
 
@@ -477,7 +479,7 @@ enum StateReducer {
         focusSession.focusedToken = token
         focusSession.pendingManagedFocus = .empty
         if mode == .tiling {
-            focusSession.lastTiledFocusedToken = token
+            _ = focusSession.recordTiledFocus(token)
         }
         if focusSession.interactionMonitorId != monitorId {
             if let currentMonitorId = focusSession.interactionMonitorId,

--- a/Sources/OmniWM/Core/Workspace/WorkspaceManager.swift
+++ b/Sources/OmniWM/Core/Workspace/WorkspaceManager.swift
@@ -861,6 +861,12 @@ final class WorkspaceManager {
         world.focus.lastTiledFocusedToken
     }
 
+    func mostRecentlyFocusedTiledToken(excluding token: WindowToken) -> WindowToken? {
+        world.focus.tiledFocusHistory.first { candidate in
+            candidate != token && windowMode(for: candidate) == .tiling && entry(for: candidate) != nil
+        }
+    }
+
     var focusedHandle: WindowHandle? {
         focusedToken.flatMap { world.handle(for: $0) }
     }

--- a/Sources/OmniWM/Core/Workspace/WorkspaceManager.swift
+++ b/Sources/OmniWM/Core/Workspace/WorkspaceManager.swift
@@ -863,7 +863,7 @@ final class WorkspaceManager {
 
     func mostRecentlyFocusedTiledToken(excluding token: WindowToken) -> WindowToken? {
         world.focus.tiledFocusHistory.first { candidate in
-            candidate != token && windowMode(for: candidate) == .tiling && entry(for: candidate) != nil
+            candidate != token && (windowMode(for: candidate) ?? .tiling) == .tiling && entry(for: candidate) != nil
         }
     }
 

--- a/Tests/OmniWMTests/NiriFocusPreviousTests.swift
+++ b/Tests/OmniWMTests/NiriFocusPreviousTests.swift
@@ -165,6 +165,66 @@ final class NiriFocusPreviousTests: XCTestCase {
         XCTAssertEqual(frontedTokens, [fixture.nodeB.token])
     }
 
+    func testCommandFocusPreviousUsesHistoryWhenFrontmostWindowIsOutsideNiri() throws {
+        var frontedTokens: [WindowToken] = []
+        let controller = makeController { pid, windowId, _ in
+            frontedTokens.append(WindowToken(pid: pid, windowId: Int(windowId)))
+        }
+        let workspaceA = try XCTUnwrap(
+            controller.workspaceManager.workspaceId(for: "1", createIfMissing: true)
+        )
+        let workspaceB = try XCTUnwrap(
+            controller.workspaceManager.workspaceId(for: "2", createIfMissing: true)
+        )
+        controller.settings.workspaceConfigurations = controller.settings.workspaceConfigurations.map { configuration in
+            guard configuration.name == "1" else { return configuration }
+            var configuration = configuration
+            configuration.layoutType = .dwindle
+            return configuration
+        }
+        controller.workspaceManager.applySettings()
+        _ = controller.workspaceManager.focusWorkspace(named: "2")
+        controller.niriLayoutHandler.enableNiriLayout()
+        let engine = try XCTUnwrap(controller.niriEngine)
+        let tokenA = addWindow(pid: 447_011, windowId: 447_111, to: workspaceA, controller: controller)
+        let tokenB = addWindow(pid: 447_012, windowId: 447_112, to: workspaceB, controller: controller)
+        let nodeB = engine.addWindow(token: tokenB, to: workspaceB, afterSelection: nil)
+        _ = controller.workspaceManager.commitWorkspaceSelection(
+            nodeId: nodeB.id,
+            focusedToken: tokenB,
+            in: workspaceB,
+            onMonitor: controller.workspaceManager.monitorId(for: workspaceB)
+        )
+        _ = controller.workspaceManager.rememberFocus(tokenA, in: workspaceA)
+        _ = controller.workspaceManager.rememberFocus(tokenB, in: workspaceB)
+        _ = controller.workspaceManager.focusWorkspace(named: "1")
+        XCTAssertEqual(
+            controller.workspaceManager.mostRecentlyFocusedTiledToken(excluding: tokenB),
+            tokenA
+        )
+        controller.commandHandler.frontmostAppPidProvider = { tokenA.pid }
+        controller.commandHandler.frontmostFocusedWindowTokenProvider = { tokenA }
+        let blocker = blockLayoutRefresh(controller, workspaceId: workspaceB)
+        defer { unblockLayoutRefresh(controller, blocker: blocker) }
+
+        XCTAssertEqual(controller.commandHandler.handleHotkeyCommand(.focusPrevious), .executed)
+        XCTAssertEqual(
+            controller.workspaceManager.mostRecentlyFocusedTiledToken(excluding: tokenA),
+            tokenB
+        )
+        let postLayoutActions = try XCTUnwrap(
+            controller.layoutRefreshController.layoutState.pendingRefresh?.postLayoutActions
+        )
+        XCTAssertFalse(postLayoutActions.isEmpty)
+        postLayoutActions.forEach { $0.runIfCurrent(using: controller.workspaceManager) }
+
+        XCTAssertEqual(controller.activeWorkspace()?.id, workspaceB)
+        XCTAssertEqual(
+            controller.workspaceManager.niriViewportState(for: workspaceB).selectedNodeId,
+            nodeB.id
+        )
+    }
+
     func testCommandFocusPreviousCompletesAfterTargetLayoutInvalidation() throws {
         var frontedTokens: [WindowToken] = []
         let fixture = try makeCommandFixture { pid, windowId, _ in

--- a/Tests/OmniWMTests/NiriFocusPreviousTests.swift
+++ b/Tests/OmniWMTests/NiriFocusPreviousTests.swift
@@ -138,6 +138,33 @@ final class NiriFocusPreviousTests: XCTestCase {
         XCTAssertEqual(frontedTokens, [fixture.tokenA])
     }
 
+    func testCommandFocusPreviousUsesFrontmostManagedWindowWhenSelectionIsStale() throws {
+        var frontedTokens: [WindowToken] = []
+        let fixture = try makeCommandFixture { pid, windowId, _ in
+            frontedTokens.append(WindowToken(pid: pid, windowId: Int(windowId)))
+        }
+        let blocker = blockLayoutRefresh(fixture.controller, workspaceId: fixture.workspaceB)
+        defer { unblockLayoutRefresh(fixture.controller, blocker: blocker) }
+        fixture.controller.commandHandler.frontmostAppPidProvider = { fixture.tokenA.pid }
+        fixture.controller.commandHandler.frontmostFocusedWindowTokenProvider = { fixture.tokenA }
+
+        XCTAssertEqual(
+            fixture.controller.commandHandler.handleHotkeyCommand(.focusPrevious),
+            .executed
+        )
+        XCTAssertEqual(fixture.controller.activeWorkspace()?.id, fixture.workspaceB)
+        XCTAssertGreaterThan(
+            fixture.nodeA.lastFocusedTime ?? .distantPast,
+            fixture.nodeB.lastFocusedTime ?? .distantPast
+        )
+
+        let postLayout = try XCTUnwrap(
+            fixture.controller.layoutRefreshController.layoutState.pendingRefresh?.postLayoutActions.first
+        )
+        postLayout.runIfCurrent(using: fixture.controller.workspaceManager)
+        XCTAssertEqual(frontedTokens, [fixture.nodeB.token])
+    }
+
     func testCommandFocusPreviousCompletesAfterTargetLayoutInvalidation() throws {
         var frontedTokens: [WindowToken] = []
         let fixture = try makeCommandFixture { pid, windowId, _ in

--- a/Tests/OmniWMTests/NiriFocusPreviousTests.swift
+++ b/Tests/OmniWMTests/NiriFocusPreviousTests.swift
@@ -138,31 +138,43 @@ final class NiriFocusPreviousTests: XCTestCase {
         XCTAssertEqual(frontedTokens, [fixture.tokenA])
     }
 
-    func testCommandFocusPreviousUsesFrontmostManagedWindowWhenSelectionIsStale() throws {
+    func testCommandFocusPreviousDoesNotNavigateLocallyWithoutPriorObservedFocus() throws {
         var frontedTokens: [WindowToken] = []
         let fixture = try makeCommandFixture { pid, windowId, _ in
             frontedTokens.append(WindowToken(pid: pid, windowId: Int(windowId)))
         }
+        let engine = try XCTUnwrap(fixture.controller.niriEngine)
+        let tokenC = addWindow(
+            pid: 447_004,
+            windowId: 447_104,
+            to: fixture.workspaceB,
+            controller: fixture.controller
+        )
+        let nodeC = engine.addWindow(token: tokenC, to: fixture.workspaceB, afterSelection: fixture.nodeB.id)
+        nodeC.lastFocusedTime = timestamp(3)
+        XCTAssertNotNil(
+            fixture.controller.workspaceManager.removeWindow(
+                pid: fixture.tokenA.pid,
+                windowId: fixture.tokenA.windowId
+            )
+        )
+        _ = fixture.controller.workspaceManager.setManagedFocus(fixture.nodeB.token, in: fixture.workspaceB)
+        fixture.controller.commandHandler.frontmostAppPidProvider = { fixture.nodeB.token.pid }
+        fixture.controller.commandHandler.frontmostFocusedWindowTokenProvider = { fixture.nodeB.token }
         let blocker = blockLayoutRefresh(fixture.controller, workspaceId: fixture.workspaceB)
         defer { unblockLayoutRefresh(fixture.controller, blocker: blocker) }
-        fixture.controller.commandHandler.frontmostAppPidProvider = { fixture.tokenA.pid }
-        fixture.controller.commandHandler.frontmostFocusedWindowTokenProvider = { fixture.tokenA }
 
         XCTAssertEqual(
             fixture.controller.commandHandler.handleHotkeyCommand(.focusPrevious),
             .executed
         )
         XCTAssertEqual(fixture.controller.activeWorkspace()?.id, fixture.workspaceB)
-        XCTAssertGreaterThan(
-            fixture.nodeA.lastFocusedTime ?? .distantPast,
-            fixture.nodeB.lastFocusedTime ?? .distantPast
+        XCTAssertEqual(
+            fixture.controller.workspaceManager.niriViewportState(for: fixture.workspaceB).selectedNodeId,
+            fixture.nodeB.id
         )
-
-        let postLayout = try XCTUnwrap(
-            fixture.controller.layoutRefreshController.layoutState.pendingRefresh?.postLayoutActions.first
-        )
-        postLayout.runIfCurrent(using: fixture.controller.workspaceManager)
-        XCTAssertEqual(frontedTokens, [fixture.nodeB.token])
+        XCTAssertNil(fixture.controller.layoutRefreshController.layoutState.pendingRefresh)
+        XCTAssertTrue(frontedTokens.isEmpty)
     }
 
     func testCommandFocusPreviousUsesHistoryWhenFrontmostWindowIsOutsideNiri() throws {
@@ -195,8 +207,8 @@ final class NiriFocusPreviousTests: XCTestCase {
             in: workspaceB,
             onMonitor: controller.workspaceManager.monitorId(for: workspaceB)
         )
-        _ = controller.workspaceManager.rememberFocus(tokenA, in: workspaceA)
-        _ = controller.workspaceManager.rememberFocus(tokenB, in: workspaceB)
+        _ = controller.workspaceManager.setManagedFocus(tokenA, in: workspaceA)
+        _ = controller.workspaceManager.setManagedFocus(tokenB, in: workspaceB)
         _ = controller.workspaceManager.focusWorkspace(named: "1")
         XCTAssertEqual(
             controller.workspaceManager.mostRecentlyFocusedTiledToken(excluding: tokenB),
@@ -437,6 +449,8 @@ final class NiriFocusPreviousTests: XCTestCase {
             in: workspaceB,
             onMonitor: controller.workspaceManager.monitorId(for: workspaceB)
         )
+        _ = controller.workspaceManager.setManagedFocus(tokenA, in: workspaceA)
+        _ = controller.workspaceManager.setManagedFocus(tokenB, in: workspaceB)
         return CommandFixture(
             controller: controller,
             workspaceA: workspaceA,


### PR DESCRIPTION
Closes #509.

Record Focus Previous history only after focus is confirmed.

Failure trace: [log](https://gist.github.com/henry-p/5bdbd203430a0f80dcdef1540fd76e80)
Success trace: [log](https://gist.github.com/henry-p/2033db0934dbb33a02010fe9c6811c8c)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved **Focus Previous** to use recent tiled-window focus history even when the current selection is stale or the frontmost window is outside the window manager.
  * Added safer behavior to avoid unnecessary local navigation when there’s no prior observed focus, and to prevent reselecting the currently focused window.
  * Enhanced focus tracking by maintaining and reconciling an ordered tiled-focus history across state changes.
* **Improvements**
  * **Focus Previous** is now available in shared layouts, not only Niri layouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->