### PR TITLE
fix: admit and focus floating windows correctly, and stop managing helper windows and menu-bar popovers

### DIFF
--- a/Sources/OmniWM/Core/Ax/AXWindow.swift
+++ b/Sources/OmniWM/Core/Ax/AXWindow.swift
@@ -199,6 +199,15 @@ func sameAXWindowIdentity(_ lhs: AXWindowRef, _ rhs: AXWindowRef) -> Bool {
     lhs.windowId == rhs.windowId && CFEqual(lhs.element, rhs.element)
 }
 
+enum AXFullscreenButtonEvidence: Equatable, Sendable {
+    /// No fullscreen button: the attribute was missing or came back as an AX error placeholder.
+    case absent
+    /// A real button element the caller can query for `AXEnabled`.
+    case element
+    /// Present but not a button element, so the surrounding attribute fetch is untrustworthy.
+    case malformed
+}
+
 enum AXWindowHeuristicReason: String, Sendable {
     case attributeFetchFailed
     case browserPictureInPicture
@@ -652,28 +661,28 @@ enum AXWindowService {
 
         let fullscreenButtonElement = attributeValue(.fullScreenButton)
         var attributeFetchSucceeded = true
-        let hasFullscreenButton = resolvedAttribute(fullscreenButtonElement)
+        let buttonEvidence = fullscreenButtonEvidence(fullscreenButtonElement)
 
         var fullscreenButtonEnabled: Bool?
-        if hasFullscreenButton, let fullscreenButtonElement {
-            guard CFGetTypeID(fullscreenButtonElement as CFTypeRef) == AXUIElementGetTypeID() else {
-                attributeFetchSucceeded = false
-                return makeWindowFacts(
-                    AXWindowFactAttributeValues(
-                        role: attributeValue(.role) as? String,
-                        subrole: attributeValue(.subrole) as? String,
-                        title: includeTitle ? (attributeValue(.title) as? String) : nil,
-                        closeButton: attributeValue(.closeButton),
-                        fullscreenButton: nil,
-                        fullscreenButtonEnabled: nil,
-                        zoomButton: attributeValue(.zoomButton),
-                        minimizeButton: attributeValue(.minimizeButton)
-                    ),
-                    appPolicy: appPolicy,
-                    bundleId: bundleId,
-                    attributeFetchSucceeded: attributeFetchSucceeded
-                )
-            }
+        if buttonEvidence == .malformed {
+            attributeFetchSucceeded = false
+            return makeWindowFacts(
+                AXWindowFactAttributeValues(
+                    role: attributeValue(.role) as? String,
+                    subrole: attributeValue(.subrole) as? String,
+                    title: includeTitle ? (attributeValue(.title) as? String) : nil,
+                    closeButton: attributeValue(.closeButton),
+                    fullscreenButton: nil,
+                    fullscreenButtonEnabled: nil,
+                    zoomButton: attributeValue(.zoomButton),
+                    minimizeButton: attributeValue(.minimizeButton)
+                ),
+                appPolicy: appPolicy,
+                bundleId: bundleId,
+                attributeFetchSucceeded: attributeFetchSucceeded
+            )
+        }
+        if buttonEvidence == .element, let fullscreenButtonElement {
             let buttonElement = unsafeDowncast(fullscreenButtonElement as AnyObject, to: AXUIElement.self)
             var enabledValue: CFTypeRef?
             let enabledResult = AXUIElementCopyAttributeValue(
@@ -731,8 +740,24 @@ enum AXWindowService {
     }
 
     static func resolvedAttribute(_ value: Any?) -> Bool {
-        guard let value else { return false }
-        return !(value is NSError)
+        guard let value, !(value is NSError) else { return false }
+        return !isAXErrorPlaceholder(value)
+    }
+
+    /// `AXUIElementCopyMultipleAttributeValues` reports per-attribute failures by substituting an
+    /// `AXValue` of type `.axError` instead of leaving the slot empty, so an unavailable attribute
+    /// only shows up as a placeholder of that shape - never as `nil` or `NSError`.
+    static func isAXErrorPlaceholder(_ value: Any?) -> Bool {
+        guard let value, CFGetTypeID(value as CFTypeRef) == AXValueGetTypeID() else { return false }
+        return AXValueGetType(unsafeDowncast(value as AnyObject, to: AXValue.self)) == .axError
+    }
+
+    static func fullscreenButtonEvidence(_ value: Any?) -> AXFullscreenButtonEvidence {
+        guard resolvedAttribute(value) else { return .absent }
+        guard let value, CFGetTypeID(value as CFTypeRef) == AXUIElementGetTypeID() else {
+            return .malformed
+        }
+        return .element
     }
 
     static func sizeValue(_ value: Any?) -> CGSize? {
@@ -857,10 +882,10 @@ enum AXWindowService {
         var maxSize: CGSize?
 
         if result == .success, let valuesArray = values as? [Any?] {
-            if !valuesArray.isEmpty, valuesArray[0] != nil, !(valuesArray[0] is NSError) {
+            if !valuesArray.isEmpty, resolvedAttribute(valuesArray[0]) {
                 hasGrowArea = true
             }
-            if valuesArray.count > 1, valuesArray[1] != nil, !(valuesArray[1] is NSError) {
+            if valuesArray.count > 1, resolvedAttribute(valuesArray[1]) {
                 hasZoomButton = true
             }
             if valuesArray.count > 2, let subrole = valuesArray[2] as? String {

--- a/Sources/OmniWM/Core/Ax/AXWindow.swift
+++ b/Sources/OmniWM/Core/Ax/AXWindow.swift
@@ -232,6 +232,10 @@ struct AXWindowFacts: Equatable, Sendable {
     let appPolicy: NSApplication.ActivationPolicy?
     let bundleId: String?
     let attributeFetchSucceeded: Bool
+
+    var hasAnyWindowButton: Bool {
+        hasCloseButton || hasFullscreenButton || hasZoomButton || hasMinimizeButton
+    }
 }
 
 struct AXWindowDecisionEvidence: Equatable, Sendable {
@@ -802,10 +806,7 @@ enum AXWindowService {
             )
         }
 
-        let hasAnyButton = facts.hasCloseButton
-            || facts.hasFullscreenButton
-            || facts.hasZoomButton
-            || facts.hasMinimizeButton
+        let hasAnyButton = facts.hasAnyWindowButton
 
         if facts.appPolicy == .accessory && !facts.hasCloseButton {
             return AXWindowHeuristicDisposition(

--- a/Sources/OmniWM/Core/Ax/AXWindowEnumeration.swift
+++ b/Sources/OmniWM/Core/Ax/AXWindowEnumeration.swift
@@ -357,11 +357,9 @@ enum AXWindowEnumerationInspector {
         deadline: TimeInterval,
         checkCancellation: () throws -> Void
     ) throws -> (enabled: Bool?, succeeded: Bool) {
-        guard AXWindowService.resolvedAttribute(value) else { return (nil, true) }
-        guard let value,
-              CFGetTypeID(value as CFTypeRef) == AXUIElementGetTypeID()
-        else {
-            return (nil, false)
+        let evidence = AXWindowService.fullscreenButtonEvidence(value)
+        guard evidence == .element, let value else {
+            return (nil, evidence == .absent)
         }
         let button = unsafeDowncast(value as AnyObject, to: AXUIElement.self)
         try setRemainingTimeout(on: button, until: deadline)

--- a/Sources/OmniWM/Core/Controller/AXEventHandler.swift
+++ b/Sources/OmniWM/Core/Controller/AXEventHandler.swift
@@ -2688,13 +2688,12 @@ final class AXEventHandler {
                 ? .pending(token: token, axRef: axRef, reason: .factsDeferred)
                 : .ignored(token: token, reason: .policyIgnored)
         }
-        if trackedMode == .tiling,
-           controller.shouldDeferTilingAdmission(
-               evaluation: evaluation,
-               axRef: axRef,
-               windowInfo: matchingWindowInfo
-           )
-        {
+        if controller.shouldDeferAdmission(
+            evaluation: evaluation,
+            axRef: axRef,
+            windowInfo: matchingWindowInfo,
+            trackedMode: trackedMode
+        ) {
             return .pending(token: token, axRef: axRef, reason: .degenerateGeometry)
         }
         subscribeToWindows([windowId])

--- a/Sources/OmniWM/Core/Controller/LayoutRefreshController+MonitorGeometry.swift
+++ b/Sources/OmniWM/Core/Controller/LayoutRefreshController+MonitorGeometry.swift
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: GPL-2.0-only
+// Copyright (C) 2026 BarutSRB — https://github.com/BarutSRB/OmniWM
+
+import AppKit
+import Foundation
+
+@MainActor
+extension LayoutRefreshController {
+    /// Internal rather than private: `LayoutRefreshController` itself still calls this, and the
+    /// two types now live in different files.
+    func preferredHideSides(for monitors: [Monitor]) -> [Monitor.ID: HideSide] {
+        let important = 10
+        var preferredSides: [Monitor.ID: HideSide] = [:]
+
+        for monitor in monitors {
+            let monitorFrame = monitor.frame
+            let xOff = monitorFrame.width * 0.1
+            let yOff = monitorFrame.height * 0.1
+
+            let bottomRight = CGPoint(x: monitorFrame.maxX, y: monitorFrame.minY)
+            let bottomLeft = CGPoint(x: monitorFrame.minX, y: monitorFrame.minY)
+
+            let rightPoints = [
+                CGPoint(x: bottomRight.x + 2, y: bottomRight.y - yOff),
+                CGPoint(x: bottomRight.x - xOff, y: bottomRight.y + 2),
+                CGPoint(x: bottomRight.x + 2, y: bottomRight.y + 2)
+            ]
+
+            let leftPoints = [
+                CGPoint(x: bottomLeft.x - 2, y: bottomLeft.y - yOff),
+                CGPoint(x: bottomLeft.x + xOff, y: bottomLeft.y + 2),
+                CGPoint(x: bottomLeft.x - 2, y: bottomLeft.y + 2)
+            ]
+
+            func sideScore(_ points: [CGPoint]) -> Int {
+                monitors.reduce(0) { partial, other in
+                    let c1 = other.frame.contains(points[0]) ? 1 : 0
+                    let c2 = other.frame.contains(points[1]) ? 1 : 0
+                    let c3 = other.frame.contains(points[2]) ? 1 : 0
+                    return partial + c1 + c2 + important * c3
+                }
+            }
+
+            let leftScore = sideScore(leftPoints)
+            let rightScore = sideScore(rightPoints)
+            preferredSides[monitor.id] = leftScore < rightScore ? .left : .right
+        }
+
+        return preferredSides
+    }
+
+    func preferredHideSide(for monitor: Monitor) -> HideSide {
+        guard let controller else { return .right }
+        return preferredHideSides(for: controller.workspaceManager.monitors)[monitor.id] ?? .right
+    }
+
+    func backingScale(for monitor: Monitor) -> CGFloat {
+        NSScreen.screens.first(where: { $0.displayId == monitor.displayId })?.backingScaleFactor ?? 2.0
+    }
+}

--- a/Sources/OmniWM/Core/Controller/LayoutRefreshController+WindowLifecycle.swift
+++ b/Sources/OmniWM/Core/Controller/LayoutRefreshController+WindowLifecycle.swift
@@ -61,6 +61,33 @@ extension LayoutRefreshController {
         isNewEntry && trackedMode == .floating && hasCreatePlacementContext
     }
 
+    /// Focuses a just-admitted floating window that qualifies under
+    /// `shouldFocusNewlyAdmittedFloatingWindow`, routing through the focus-operation seam
+    /// (`raiseFloatingWindow` -> `focusWindow` -> `WindowFocusOperations`). No-op before services
+    /// start or if the token is no longer a live floating entry. Returns whether it raised.
+    @discardableResult
+    func focusNewlyAdmittedFloatingWindow(
+        token: WindowToken,
+        isNewEntry: Bool,
+        trackedMode: TrackedWindowMode,
+        hasCreatePlacementContext: Bool
+    ) -> Bool {
+        guard Self.shouldFocusNewlyAdmittedFloatingWindow(
+            isNewEntry: isNewEntry,
+            trackedMode: trackedMode,
+            hasCreatePlacementContext: hasCreatePlacementContext
+        ) else {
+            return false
+        }
+        guard let controller,
+              controller.hasStartedServices,
+              controller.workspaceManager.entry(for: token)?.mode == .floating
+        else {
+            return false
+        }
+        return controller.windowActionHandler.raiseFloatingWindow(token)
+    }
+
     func observedWindowFrame(_ entry: WindowState) -> CGRect? {
         fastFrame(for: entry.token, axRef: entry.axRef)
     }

--- a/Sources/OmniWM/Core/Controller/LayoutRefreshController+WindowLifecycle.swift
+++ b/Sources/OmniWM/Core/Controller/LayoutRefreshController+WindowLifecycle.swift
@@ -47,6 +47,20 @@ extension LayoutRefreshController {
             || entry.ruleEffects != ruleEffects
     }
 
+    /// A brand-new floating window that macOS just created and fronted must take focus, mirroring
+    /// the AXWindowCreated fast path (`trackPreparedCreate`). Without it the workspace focused token
+    /// stays on the previously focused tiled window, and the post-admission relayout's focus recovery
+    /// re-fronts that window, stealing focus from the one the user just opened. The create-placement
+    /// context is the same signal the fast path uses to tell a user-created window from a window
+    /// merely discovered during startup enumeration, which must not steal focus.
+    static func shouldFocusNewlyAdmittedFloatingWindow(
+        isNewEntry: Bool,
+        trackedMode: TrackedWindowMode,
+        hasCreatePlacementContext: Bool
+    ) -> Bool {
+        isNewEntry && trackedMode == .floating && hasCreatePlacementContext
+    }
+
     func observedWindowFrame(_ entry: WindowState) -> CGRect? {
         fastFrame(for: entry.token, axRef: entry.axRef)
     }

--- a/Sources/OmniWM/Core/Controller/LayoutRefreshController.swift
+++ b/Sources/OmniWM/Core/Controller/LayoutRefreshController.swift
@@ -1440,7 +1440,6 @@ import QuartzCore
         }
         var seenKeys: Set<WindowToken> = []
         var decisionBasedRemovals: [WindowToken] = []
-        var newlyCreatedFloatingFocus: WindowToken?
         let focusedWorkspaceId = controller.activeWorkspace()?.id
         let screenFrames = NSScreen.screens.map(\.frame)
 
@@ -1719,21 +1718,13 @@ import QuartzCore
                     allowLiveFrameFallback: false
                 )
             }
-            if Self.shouldFocusNewlyAdmittedFloatingWindow(
+            focusNewlyAdmittedFloatingWindow(
+                token: admittedToken,
                 isNewEntry: existingEntry == nil,
                 trackedMode: trackedMode,
                 hasCreatePlacementContext: createPlacementContext != nil
-            ) {
-                newlyCreatedFloatingFocus = admittedToken
-            }
+            )
             seenKeys.insert(admittedToken)
-        }
-
-        if let newlyCreatedFloatingFocus,
-           controller.hasStartedServices,
-           controller.workspaceManager.entry(for: newlyCreatedFloatingFocus)?.mode == .floating
-        {
-            _ = controller.windowActionHandler.raiseFloatingWindow(newlyCreatedFloatingFocus)
         }
 
         controller.axEventHandler.updateIdentityAliases(

--- a/Sources/OmniWM/Core/Controller/LayoutRefreshController.swift
+++ b/Sources/OmniWM/Core/Controller/LayoutRefreshController.swift
@@ -1530,15 +1530,14 @@ import QuartzCore
                 controller.axEventHandler.cancelTrackedTilingPromotionRetry(windowId: winId)
             }
 
-            if trackedMode == .tiling,
-               controller.axEventHandler.deferTilingAdmissionIfNeeded(
-                   evaluation: evaluation,
-                   axRef: ax,
-                   pid: pid,
-                   windowId: winId,
-                   existingEntry: existingEntry
-               )
-            {
+            if controller.axEventHandler.deferAdmissionIfNeeded(
+                evaluation: evaluation,
+                axRef: ax,
+                pid: pid,
+                windowId: winId,
+                trackedMode: trackedMode,
+                existingEntry: existingEntry
+            ) {
                 if let existingEntry {
                     seenKeys.insert(existingEntry.token)
                 }

--- a/Sources/OmniWM/Core/Controller/LayoutRefreshController.swift
+++ b/Sources/OmniWM/Core/Controller/LayoutRefreshController.swift
@@ -1440,6 +1440,7 @@ import QuartzCore
         }
         var seenKeys: Set<WindowToken> = []
         var decisionBasedRemovals: [WindowToken] = []
+        var newlyCreatedFloatingFocus: WindowToken?
         let focusedWorkspaceId = controller.activeWorkspace()?.id
         let screenFrames = NSScreen.screens.map(\.frame)
 
@@ -1718,7 +1719,21 @@ import QuartzCore
                     allowLiveFrameFallback: false
                 )
             }
+            if Self.shouldFocusNewlyAdmittedFloatingWindow(
+                isNewEntry: existingEntry == nil,
+                trackedMode: trackedMode,
+                hasCreatePlacementContext: createPlacementContext != nil
+            ) {
+                newlyCreatedFloatingFocus = admittedToken
+            }
             seenKeys.insert(admittedToken)
+        }
+
+        if let newlyCreatedFloatingFocus,
+           controller.hasStartedServices,
+           controller.workspaceManager.entry(for: newlyCreatedFloatingFocus)?.mode == .floating
+        {
+            _ = controller.windowActionHandler.raiseFloatingWindow(newlyCreatedFloatingFocus)
         }
 
         controller.axEventHandler.updateIdentityAliases(

--- a/Sources/OmniWM/Core/Controller/LayoutRefreshController.swift
+++ b/Sources/OmniWM/Core/Controller/LayoutRefreshController.swift
@@ -1533,8 +1533,7 @@ import QuartzCore
             if controller.axEventHandler.deferAdmissionIfNeeded(
                 evaluation: evaluation,
                 axRef: ax,
-                pid: pid,
-                windowId: winId,
+                token: token,
                 trackedMode: trackedMode,
                 existingEntry: existingEntry
             ) {
@@ -2409,10 +2408,6 @@ import QuartzCore
         layoutState.pendingRefresh = pendingRefresh
     }
 
-    func backingScale(for monitor: Monitor) -> CGFloat {
-        NSScreen.screens.first(where: { $0.displayId == monitor.displayId })?.backingScaleFactor ?? 2.0
-    }
-
     private func workspaceEntriesSnapshot(
         on controller: WMController
     ) -> [(workspace: WorkspaceDescriptor, entries: [WindowState])] {
@@ -2991,52 +2986,6 @@ import QuartzCore
         let x = (topLeft.x - frame.minX) / width
         let y = (frame.maxY - topLeft.y) / height
         return CGPoint(x: min(max(0, x), 1), y: min(max(0, y), 1))
-    }
-
-    private func preferredHideSides(for monitors: [Monitor]) -> [Monitor.ID: HideSide] {
-        let important = 10
-        var preferredSides: [Monitor.ID: HideSide] = [:]
-
-        for monitor in monitors {
-            let monitorFrame = monitor.frame
-            let xOff = monitorFrame.width * 0.1
-            let yOff = monitorFrame.height * 0.1
-
-            let bottomRight = CGPoint(x: monitorFrame.maxX, y: monitorFrame.minY)
-            let bottomLeft = CGPoint(x: monitorFrame.minX, y: monitorFrame.minY)
-
-            let rightPoints = [
-                CGPoint(x: bottomRight.x + 2, y: bottomRight.y - yOff),
-                CGPoint(x: bottomRight.x - xOff, y: bottomRight.y + 2),
-                CGPoint(x: bottomRight.x + 2, y: bottomRight.y + 2)
-            ]
-
-            let leftPoints = [
-                CGPoint(x: bottomLeft.x - 2, y: bottomLeft.y - yOff),
-                CGPoint(x: bottomLeft.x + xOff, y: bottomLeft.y + 2),
-                CGPoint(x: bottomLeft.x - 2, y: bottomLeft.y + 2)
-            ]
-
-            func sideScore(_ points: [CGPoint]) -> Int {
-                monitors.reduce(0) { partial, other in
-                    let c1 = other.frame.contains(points[0]) ? 1 : 0
-                    let c2 = other.frame.contains(points[1]) ? 1 : 0
-                    let c3 = other.frame.contains(points[2]) ? 1 : 0
-                    return partial + c1 + c2 + important * c3
-                }
-            }
-
-            let leftScore = sideScore(leftPoints)
-            let rightScore = sideScore(rightPoints)
-            preferredSides[monitor.id] = leftScore < rightScore ? .left : .right
-        }
-
-        return preferredSides
-    }
-
-    func preferredHideSide(for monitor: Monitor) -> HideSide {
-        guard let controller else { return .right }
-        return preferredHideSides(for: controller.workspaceManager.monitors)[monitor.id] ?? .right
     }
 
     fileprivate func hasPendingRevealTransaction(for windowId: Int) -> Bool {

--- a/Sources/OmniWM/Core/Controller/WMController.swift
+++ b/Sources/OmniWM/Core/Controller/WMController.swift
@@ -1734,13 +1734,37 @@ final class WMController {
         return nil
     }
 
-    func shouldDeferTilingAdmission(
+    func shouldDeferAdmission(
+        evaluation: WindowDecisionEvaluation,
+        axRef: AXWindowRef,
+        windowInfo: WindowServerInfo?,
+        trackedMode: TrackedWindowMode
+    ) -> Bool {
+        // Only a tiled window has to accept a size we choose for it; a floating window is allowed
+        // to be fixed-size, so resizability gates tiling admission alone.
+        if trackedMode == .tiling {
+            let sizeSettable = evaluation.admissionGeometry?.isSizeSettable
+                ?? AXWindowService.isSizeSettable(axRef)
+            guard sizeSettable else { return true }
+        }
+        return hasDegenerateAdmissionFrame(
+            evaluation: evaluation,
+            axRef: axRef,
+            windowInfo: windowInfo
+        )
+    }
+
+    /// A window that is a point or thinner on either axis is not something the user can see, click,
+    /// or focus. Apps park invisible helper windows at that size - BetterDisplay keeps a 1x1 window
+    /// below the bottom of the screen for the lifetime of the process - so admitting one leaves a
+    /// workspace-bar entry that opens nothing and, once focus lands on it, bounces focus back to the
+    /// previous window. Frame-only, so it applies whatever mode the window would be admitted into.
+    func hasDegenerateAdmissionFrame(
         evaluation: WindowDecisionEvaluation,
         axRef: AXWindowRef,
         windowInfo: WindowServerInfo?
     ) -> Bool {
         if let admissionGeometry = evaluation.admissionGeometry {
-            guard admissionGeometry.isSizeSettable else { return true }
             guard let frame = evaluation.facts.windowServer?.frame
                 ?? windowInfo?.frame
                 ?? admissionGeometry.frame
@@ -1749,7 +1773,6 @@ final class WMController {
             }
             return !Self.isMeaningfulAdmissionFrame(frame)
         }
-        guard AXWindowService.isSizeSettable(axRef) else { return true }
         if let frame = evaluation.facts.windowServer?.frame ?? windowInfo?.frame,
            Self.isMeaningfulAdmissionFrame(frame)
         {
@@ -2231,15 +2254,14 @@ final class WMController {
                 axEventHandler.cancelTrackedTilingPromotionRetry(windowId: token.windowId)
             }
 
-            if effectiveTrackedMode == .tiling,
-               axEventHandler.deferTilingAdmissionIfNeeded(
-                   evaluation: evaluation,
-                   axRef: axRef,
-                   pid: token.pid,
-                   windowId: token.windowId,
-                   existingEntry: existingEntry
-               )
-            {
+            if axEventHandler.deferAdmissionIfNeeded(
+                evaluation: evaluation,
+                axRef: axRef,
+                pid: token.pid,
+                windowId: token.windowId,
+                trackedMode: effectiveTrackedMode,
+                existingEntry: existingEntry
+            ) {
                 continue
             }
 
@@ -2521,15 +2543,14 @@ final class WMController {
             axEventHandler.cancelTrackedTilingPromotionRetry(windowId: token.windowId)
         }
 
-        if trackedMode == .tiling,
-           axEventHandler.deferTilingAdmissionIfNeeded(
-               evaluation: evaluation,
-               axRef: entry.axRef,
-               pid: token.pid,
-               windowId: token.windowId,
-               existingEntry: entry
-           )
-        {
+        if axEventHandler.deferAdmissionIfNeeded(
+            evaluation: evaluation,
+            axRef: entry.axRef,
+            pid: token.pid,
+            windowId: token.windowId,
+            trackedMode: trackedMode,
+            existingEntry: entry
+        ) {
             return
         }
 

--- a/Sources/OmniWM/Core/Controller/WMController.swift
+++ b/Sources/OmniWM/Core/Controller/WMController.swift
@@ -2257,8 +2257,7 @@ final class WMController {
             if axEventHandler.deferAdmissionIfNeeded(
                 evaluation: evaluation,
                 axRef: axRef,
-                pid: token.pid,
-                windowId: token.windowId,
+                token: token,
                 trackedMode: effectiveTrackedMode,
                 existingEntry: existingEntry
             ) {
@@ -2546,8 +2545,7 @@ final class WMController {
         if axEventHandler.deferAdmissionIfNeeded(
             evaluation: evaluation,
             axRef: entry.axRef,
-            pid: token.pid,
-            windowId: token.windowId,
+            token: token,
             trackedMode: trackedMode,
             existingEntry: entry
         ) {

--- a/Sources/OmniWM/Core/Controller/WindowAdmissionRetry.swift
+++ b/Sources/OmniWM/Core/Controller/WindowAdmissionRetry.swift
@@ -15,8 +15,7 @@ extension AXEventHandler {
     func deferAdmissionIfNeeded(
         evaluation: WMController.WindowDecisionEvaluation,
         axRef: AXWindowRef,
-        pid: pid_t,
-        windowId: Int,
+        token: WindowToken,
         trackedMode: TrackedWindowMode,
         existingEntry: WindowState?
     ) -> Bool {
@@ -31,7 +30,7 @@ extension AXEventHandler {
                   windowInfo: evaluation.facts.windowServer,
                   trackedMode: trackedMode
               ),
-              let windowId = UInt32(exactly: windowId)
+              let windowId = UInt32(exactly: token.windowId)
         else {
             return false
         }
@@ -44,7 +43,7 @@ extension AXEventHandler {
         } else {
             _ = scheduleCandidateAdmissionRetry(
                 windowId: windowId,
-                pid: pid,
+                pid: token.pid,
                 axRef: axRef,
                 reason: .degenerateGeometry
             )

--- a/Sources/OmniWM/Core/Controller/WindowAdmissionRetry.swift
+++ b/Sources/OmniWM/Core/Controller/WindowAdmissionRetry.swift
@@ -12,19 +12,24 @@ extension AXEventHandler {
         pid == getpid()
     }
 
-    func deferTilingAdmissionIfNeeded(
+    func deferAdmissionIfNeeded(
         evaluation: WMController.WindowDecisionEvaluation,
         axRef: AXWindowRef,
         pid: pid_t,
         windowId: Int,
+        trackedMode: TrackedWindowMode,
         existingEntry: WindowState?
     ) -> Bool {
+        // Geometry gates entry only: a window already tracked keeps its slot, and of the tracked
+        // ones only a promotion into tiling re-checks it.
+        guard trackedMode == .tiling || existingEntry == nil else { return false }
         guard existingEntry?.mode != .tiling else { return false }
         guard let controller,
-              controller.shouldDeferTilingAdmission(
+              controller.shouldDeferAdmission(
                   evaluation: evaluation,
                   axRef: axRef,
-                  windowInfo: evaluation.facts.windowServer
+                  windowInfo: evaluation.facts.windowServer,
+                  trackedMode: trackedMode
               ),
               let windowId = UInt32(exactly: windowId)
         else {

--- a/Sources/OmniWM/Core/Rules/WindowRuleEngine.swift
+++ b/Sources/OmniWM/Core/Rules/WindowRuleEngine.swift
@@ -225,6 +225,7 @@ final class WindowRuleEngine {
     static let systemTextInputPanelRuleName = "systemTextInputPanel"
     static let ownedWindowRuleName = "ownedWindow"
     static let elevatedWindowLevelRuleName = "elevatedWindowLevel"
+    static let transientPopupRuleName = "transientPopup"
     private static let cleanShotRecordingOverlayRuleName = "cleanShotRecordingOverlay"
 
     /// `kCGPopUpMenuWindowLevel`. At and above it macOS stacks menus, popovers, help tags, drag
@@ -433,6 +434,29 @@ final class WindowRuleEngine {
             )
         }
 
+        // Chromium browsers draw their transient surfaces - the omnibox suggestion dropdown, the
+        // link-target status bubble, hover cards - as borderless widget windows at the normal
+        // window level, so the elevated-level gate never sees them. The window server still marks
+        // them: they carry the floating tag without the document tag every ordinary window gets.
+        // Those tags alone also fit panels a user may want floated, so the gate additionally
+        // requires the AX side to show no real-window evidence - an AXUnknown subrole and not a
+        // single window button. Chrome's Picture-in-Picture window keeps its document tag,
+        // standard subrole and close button, so it stays classifiable. Runs ahead of the user
+        // rules for the same reason as the elevated-level gate: a rule that floats a browser's
+        // windows must not resurrect its popups.
+        if Self.isTransientPopupSurface(facts) {
+            return WindowDecision(
+                disposition: .unmanaged,
+                source: .builtInRule(Self.transientPopupRuleName),
+                layoutDecisionKind: .explicitLayout,
+                workspaceName: nil,
+                ruleEffects: .none,
+                admissionHints: .none,
+                heuristicReasons: [],
+                deferredReason: nil
+            )
+        }
+
         let userRule = bestMatch(in: compiledUserRules, facts: facts)
         let builtInRule = bestMatch(in: builtInRules, facts: facts)
 
@@ -576,6 +600,24 @@ final class WindowRuleEngine {
             heuristicReasons: heuristicReasons,
             deferredReason: nil
         )
+    }
+
+    /// A popup drawn as a real window at the normal window level, recognizable only by combining
+    /// window-server tags (floating without document, and not modal - a modal keeps its existing
+    /// handling) with an AX side that shows nothing a user-facing window would have. Requires a
+    /// successful attribute fetch: a degraded fetch reports no buttons for every window, and those
+    /// windows already go through the deferred/degraded-evidence path.
+    static func isTransientPopupSurface(_ facts: WindowRuleFacts) -> Bool {
+        guard let windowServer = facts.windowServer,
+              windowServer.hasFloatingTag,
+              !windowServer.hasDocumentTag,
+              !windowServer.hasModalTag
+        else {
+            return false
+        }
+        return facts.ax.attributeFetchSucceeded
+            && facts.ax.subrole == (kAXUnknownSubrole as String)
+            && !facts.ax.hasAnyWindowButton
     }
 
     /// CleanShot's recording overlay is a genuine window the user works with, even though it sits

--- a/Sources/OmniWM/Core/Rules/WindowRuleEngine.swift
+++ b/Sources/OmniWM/Core/Rules/WindowRuleEngine.swift
@@ -414,8 +414,13 @@ final class WindowRuleEngine {
         // AX facts separates it from a utility panel the user would want floated - only its window
         // level does. Tracking one is never right: the popover dismisses itself as soon as we front
         // it or move it, and it leaves a workspace-bar entry behind. Takes precedence over user
-        // rules, because no rule should be able to make OmniWM manage a menu.
-        if let level = facts.windowServer?.level, level >= Self.transientSurfaceWindowLevel {
+        // rules, because no rule should be able to make OmniWM manage a menu. CleanShot's recording
+        // overlay is the one elevated surface that is a real window, and keeps being decided by its
+        // own built-in rule further down, where it still picks up any matching user rule's effects.
+        if let level = facts.windowServer?.level,
+           level >= Self.transientSurfaceWindowLevel,
+           !Self.isCleanShotRecordingOverlay(facts)
+        {
             return WindowDecision(
                 disposition: .unmanaged,
                 source: .builtInRule(Self.elevatedWindowLevelRuleName),
@@ -573,18 +578,22 @@ final class WindowRuleEngine {
         )
     }
 
+    /// CleanShot's recording overlay is a genuine window the user works with, even though it sits
+    /// above the transient-surface level. It is the one known exception to the elevated-level gate,
+    /// so both that gate and the decision below read the same predicate.
+    static func isCleanShotRecordingOverlay(_ facts: WindowRuleFacts) -> Bool {
+        facts.ax.bundleId == cleanShotBundleId
+            && facts.ax.subrole == (kAXStandardWindowSubrole as String)
+            && facts.windowServer?.level == 103
+    }
+
     private func cleanShotRecordingOverlayDecision(
         for facts: WindowRuleFacts,
         workspaceName: String?,
         effects: ManagedWindowRuleEffects,
         admissionHints: ManagedWindowAdmissionHints
     ) -> WindowDecision? {
-        guard facts.ax.bundleId == Self.cleanShotBundleId,
-              facts.ax.subrole == (kAXStandardWindowSubrole as String),
-              facts.windowServer?.level == 103
-        else {
-            return nil
-        }
+        guard Self.isCleanShotRecordingOverlay(facts) else { return nil }
 
         return WindowDecision(
             disposition: .floating,

--- a/Sources/OmniWM/Core/Rules/WindowRuleEngine.swift
+++ b/Sources/OmniWM/Core/Rules/WindowRuleEngine.swift
@@ -224,7 +224,14 @@ final class WindowRuleEngine {
     static let cleanShotBundleId = "pl.maketheweb.cleanshotx"
     static let systemTextInputPanelRuleName = "systemTextInputPanel"
     static let ownedWindowRuleName = "ownedWindow"
+    static let elevatedWindowLevelRuleName = "elevatedWindowLevel"
     private static let cleanShotRecordingOverlayRuleName = "cleanShotRecordingOverlay"
+
+    /// `kCGPopUpMenuWindowLevel`. At and above it macOS stacks menus, popovers, help tags, drag
+    /// images and screensavers - transient chrome that belongs to whatever spawned it. Ordinary app
+    /// windows sit at level 0, and the panels and dialogs a user may still want floated stay well
+    /// below this (floating 3, modal 8, utility 19).
+    static let transientSurfaceWindowLevel: Int32 = 101
     private static let systemTextInputPanelBundleIds: Set<String> = [
         "com.apple.characterpaletteim",
         "com.apple.emojifunctionrowitem-container",
@@ -394,6 +401,24 @@ final class WindowRuleEngine {
             return WindowDecision(
                 disposition: .unmanaged,
                 source: .builtInRule(Self.systemTextInputPanelRuleName),
+                layoutDecisionKind: .explicitLayout,
+                workspaceName: nil,
+                ruleEffects: .none,
+                admissionHints: .none,
+                heuristicReasons: [],
+                deferredReason: nil
+            )
+        }
+
+        // A menu-bar app's popover is a real AX window of an accessory process, so nothing in the
+        // AX facts separates it from a utility panel the user would want floated - only its window
+        // level does. Tracking one is never right: the popover dismisses itself as soon as we front
+        // it or move it, and it leaves a workspace-bar entry behind. Takes precedence over user
+        // rules, because no rule should be able to make OmniWM manage a menu.
+        if let level = facts.windowServer?.level, level >= Self.transientSurfaceWindowLevel {
+            return WindowDecision(
+                disposition: .unmanaged,
+                source: .builtInRule(Self.elevatedWindowLevelRuleName),
                 layoutDecisionKind: .explicitLayout,
                 workspaceName: nil,
                 ruleEffects: .none,

--- a/Tests/OmniWMTests/AXFullRescanBoundaryTests.swift
+++ b/Tests/OmniWMTests/AXFullRescanBoundaryTests.swift
@@ -1162,6 +1162,68 @@ final class AXFullRescanBoundaryTests: XCTestCase {
         XCTAssertNil(controller.workspaceManager.cachedConstraints(for: token))
     }
 
+    private func axErrorPlaceholder(_ error: AXError) -> Any {
+        var error = error
+        return AXValueCreate(.axError, &error)! as Any
+    }
+
+    func testUnavailableAttributeReadsAsAbsent() {
+        let placeholder = axErrorPlaceholder(.noValue)
+
+        XCTAssertTrue(AXWindowService.isAXErrorPlaceholder(placeholder))
+        XCTAssertFalse(AXWindowService.resolvedAttribute(placeholder))
+        XCTAssertEqual(AXWindowService.fullscreenButtonEvidence(placeholder), .absent)
+
+        XCTAssertFalse(AXWindowService.resolvedAttribute(nil))
+        XCTAssertTrue(AXWindowService.resolvedAttribute(AXUIElementCreateSystemWide()))
+        XCTAssertEqual(AXWindowService.fullscreenButtonEvidence(AXUIElementCreateSystemWide()), .element)
+        XCTAssertEqual(AXWindowService.fullscreenButtonEvidence("not-an-element"), .malformed)
+    }
+
+    func testWindowWithoutFullscreenButtonFloatsInsteadOfDeferringAdmission() {
+        // Shape of an Activity Monitor window: standard subrole with close/zoom/minimize buttons,
+        // and an AXFullScreenButton the AX API answers with a kAXErrorNoValue placeholder.
+        let fullscreenButton = axErrorPlaceholder(.noValue)
+        let buttonEvidence = AXWindowService.fullscreenButtonEvidence(fullscreenButton)
+        let facts = AXWindowService.makeWindowFacts(
+            AXWindowFactAttributeValues(
+                role: kAXWindowRole as String,
+                subrole: kAXStandardWindowSubrole as String,
+                title: nil,
+                closeButton: AXUIElementCreateSystemWide(),
+                fullscreenButton: fullscreenButton,
+                fullscreenButtonEnabled: nil,
+                zoomButton: AXUIElementCreateSystemWide(),
+                minimizeButton: AXUIElementCreateSystemWide()
+            ),
+            appPolicy: .regular,
+            bundleId: "com.apple.ActivityMonitor",
+            attributeFetchSucceeded: buttonEvidence != .malformed
+        )
+
+        XCTAssertTrue(facts.attributeFetchSucceeded)
+        XCTAssertFalse(facts.hasFullscreenButton)
+
+        let heuristic = AXWindowService.heuristicDisposition(for: facts)
+        XCTAssertEqual(heuristic.disposition, .floating)
+        XCTAssertEqual(heuristic.reasons, [.missingFullscreenButton])
+
+        let decision = WindowRuleEngine().decision(
+            for: WindowRuleFacts(
+                appName: "Activity Monitor",
+                ax: facts,
+                sizeConstraints: nil,
+                windowServer: nil
+            ),
+            token: nil,
+            appFullscreen: false
+        )
+
+        XCTAssertEqual(decision.disposition, .floating)
+        XCTAssertEqual(decision.trackedMode, .floating)
+        XCTAssertNil(decision.deferredReason)
+    }
+
     func testCapturedConstraintParserUsesObservedSizeForFixedWindow() {
         let size = CGSize(width: 420, height: 280)
 

--- a/Tests/OmniWMTests/FullRescanReadmissionTests.swift
+++ b/Tests/OmniWMTests/FullRescanReadmissionTests.swift
@@ -49,6 +49,82 @@ final class FullRescanReadmissionTests: XCTestCase {
         )
     }
 
+    // Integration-level coverage: drive the admission focus step through the real create-placement
+    // context store and the injected focus-operation seam, not just the pure predicate.
+    // `buildFullEffectPlan` itself cannot run headless (it enumerates live AX windows), so these
+    // exercise the same `focusNewlyAdmittedFloatingWindow` entry point the admission loop calls.
+
+    func testUserCreatedFloatingWindowRaisesThroughFocusOperationSeam() throws {
+        let recorder = ActivationRecorder()
+        let controller = makeRecordingController(recorder)
+        let workspaceId = try XCTUnwrap(
+            controller.workspaceManager.workspaceId(for: "1", createIfMissing: true)
+        )
+        XCTAssertTrue(
+            controller.workspaceManager.visibleWorkspaceIds().contains(workspaceId),
+            "precondition: the first workspace is the visible one"
+        )
+        controller.hasStartedServices = true
+
+        let token = WindowToken(pid: 470_101, windowId: 470_111)
+        _ = controller.workspaceManager.addWindow(
+            WindowAdmissionTestSupport.axRef(for: token),
+            pid: token.pid,
+            windowId: token.windowId,
+            to: workspaceId,
+            mode: .floating
+        )
+
+        // A user-created window records a create-placement context when AXWindowCreated fires.
+        controller.axEventHandler.captureCreatePlacementContext(windowId: UInt32(token.windowId), spaceId: 0)
+        let hasContext = controller.axEventHandler.pendingCreatePlacementContext(for: token.windowId) != nil
+        XCTAssertTrue(hasContext, "create-placement context should be recorded for a user-created window")
+
+        let raised = controller.layoutRefreshController.focusNewlyAdmittedFloatingWindow(
+            token: token,
+            isNewEntry: true,
+            trackedMode: .floating,
+            hasCreatePlacementContext: hasContext
+        )
+
+        XCTAssertTrue(raised)
+        XCTAssertEqual(recorder.activatedPids, [token.pid], "the new floating window is fronted via the seam")
+        XCTAssertTrue(recorder.orderedWindowIds.contains(UInt32(token.windowId)))
+    }
+
+    func testStartupDiscoveredFloatingWindowDoesNotRaiseOrStealFocus() throws {
+        let recorder = ActivationRecorder()
+        let controller = makeRecordingController(recorder)
+        let workspaceId = try XCTUnwrap(
+            controller.workspaceManager.workspaceId(for: "1", createIfMissing: true)
+        )
+        controller.hasStartedServices = true
+
+        let token = WindowToken(pid: 470_201, windowId: 470_211)
+        _ = controller.workspaceManager.addWindow(
+            WindowAdmissionTestSupport.axRef(for: token),
+            pid: token.pid,
+            windowId: token.windowId,
+            to: workspaceId,
+            mode: .floating
+        )
+
+        // No create-placement context is recorded: this window was merely discovered by a rescan.
+        let hasContext = controller.axEventHandler.pendingCreatePlacementContext(for: token.windowId) != nil
+        XCTAssertFalse(hasContext, "a startup-discovered window has no create-placement context")
+
+        let raised = controller.layoutRefreshController.focusNewlyAdmittedFloatingWindow(
+            token: token,
+            isNewEntry: true,
+            trackedMode: .floating,
+            hasCreatePlacementContext: hasContext
+        )
+
+        XCTAssertFalse(raised)
+        XCTAssertTrue(recorder.activatedPids.isEmpty, "no window is fronted, so focus is not stolen")
+        XCTAssertTrue(recorder.orderedWindowIds.isEmpty)
+    }
+
     func testUnchangedTrackedEntryIsNotReadmitted() throws {
         let manager = makeManager()
         let workspaceId = try XCTUnwrap(manager.workspaceId(for: "1", createIfMissing: true))
@@ -116,6 +192,32 @@ final class FullRescanReadmissionTests: XCTestCase {
         )
     }
 
+    private func makeRecordingController(_ recorder: ActivationRecorder) -> WMController {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("OmniWMFullRescanFocusTests-\(UUID().uuidString)", isDirectory: true)
+        let settings = SettingsStore(
+            persistence: SettingsFilePersistence(
+                directory: root.appendingPathComponent("config", isDirectory: true),
+                startWatching: false,
+                deferSaves: false
+            ),
+            runtimeState: RuntimeStateStore(
+                directory: root.appendingPathComponent("state", isDirectory: true),
+                deferSaves: false
+            ),
+            autosaveEnabled: false
+        )
+        return WMController(
+            settings: settings,
+            windowFocusOperations: WindowFocusOperations(
+                activateApp: { recorder.activatedPids.append($0) },
+                focusSpecificWindow: { pid, windowId, _ in recorder.focusedWindows.append((pid, windowId)) },
+                raiseWindow: { _ in recorder.raisedWindows += 1 },
+                orderWindow: { recorder.orderedWindowIds.append($0) }
+            )
+        )
+    }
+
     private func makeManager() -> WorkspaceManager {
         let root = FileManager.default.temporaryDirectory
             .appendingPathComponent("OmniWMFullRescanTests-\(UUID().uuidString)", isDirectory: true)
@@ -137,4 +239,14 @@ final class FullRescanReadmissionTests: XCTestCase {
     private func axRef(_ pid: pid_t, _ windowId: Int) -> AXWindowRef {
         AXWindowRef(element: AXUIElementCreateApplication(pid), windowId: windowId)
     }
+}
+
+/// Records the focus-operation seam calls a controller makes, so tests can assert whether a window
+/// was actually fronted.
+@MainActor
+private final class ActivationRecorder {
+    var activatedPids: [pid_t] = []
+    var focusedWindows: [(pid_t, UInt32)] = []
+    var raisedWindows = 0
+    var orderedWindowIds: [UInt32] = []
 }

--- a/Tests/OmniWMTests/FullRescanReadmissionTests.swift
+++ b/Tests/OmniWMTests/FullRescanReadmissionTests.swift
@@ -9,6 +9,46 @@ import XCTest
 
 @MainActor
 final class FullRescanReadmissionTests: XCTestCase {
+    func testNewlyCreatedFloatingWindowTakesFocus() {
+        // A user-created floating window (create-placement context present) must be focused so the
+        // post-admission focus recovery does not steal focus back to the previously focused window.
+        XCTAssertTrue(
+            LayoutRefreshController.shouldFocusNewlyAdmittedFloatingWindow(
+                isNewEntry: true,
+                trackedMode: .floating,
+                hasCreatePlacementContext: true
+            )
+        )
+    }
+
+    func testExistingOrTiledOrDiscoveredWindowsDoNotStealFocus() {
+        // Already-tracked floating window seen again by a rescan must not re-grab focus.
+        XCTAssertFalse(
+            LayoutRefreshController.shouldFocusNewlyAdmittedFloatingWindow(
+                isNewEntry: false,
+                trackedMode: .floating,
+                hasCreatePlacementContext: true
+            )
+        )
+        // New tiled windows are focused through the layout path, not this floating fast path.
+        XCTAssertFalse(
+            LayoutRefreshController.shouldFocusNewlyAdmittedFloatingWindow(
+                isNewEntry: true,
+                trackedMode: .tiling,
+                hasCreatePlacementContext: true
+            )
+        )
+        // A floating window discovered during startup enumeration has no create-placement context
+        // and must not yank focus from wherever the user currently is.
+        XCTAssertFalse(
+            LayoutRefreshController.shouldFocusNewlyAdmittedFloatingWindow(
+                isNewEntry: true,
+                trackedMode: .floating,
+                hasCreatePlacementContext: false
+            )
+        )
+    }
+
     func testUnchangedTrackedEntryIsNotReadmitted() throws {
         let manager = makeManager()
         let workspaceId = try XCTUnwrap(manager.workspaceId(for: "1", createIfMissing: true))

--- a/Tests/OmniWMTests/WindowAdmissionPolicyTests.swift
+++ b/Tests/OmniWMTests/WindowAdmissionPolicyTests.swift
@@ -27,11 +27,90 @@ final class WindowAdmissionPolicyTests: XCTestCase {
         let evaluation = explicitProxyEvaluation(pid: pid, windowId: windowId, windowInfo: windowInfo)
 
         XCTAssertTrue(
-            controller.shouldDeferTilingAdmission(
+            controller.shouldDeferAdmission(
                 evaluation: evaluation,
                 axRef: AXWindowRef(element: AXUIElementCreateApplication(pid), windowId: windowId),
-                windowInfo: windowInfo
+                windowInfo: windowInfo,
+                trackedMode: .tiling
             )
+        )
+    }
+
+    func testDegenerateFloatingWindowIsNotAdmitted() {
+        // A menu-bar app's invisible helper window (BetterDisplay parks a 1x1 window off the bottom
+        // of the screen) classifies as floating, because an accessory app's window without a close
+        // button floats. Geometry has to keep it out: admitting it puts a workspace-bar entry there
+        // that opens nothing, and focus landing on it bounces straight back to the previous window.
+        let controller = WindowAdmissionTestSupport.controller()
+        let pid: pid_t = 468_101
+        let windowId = 468_102
+        let windowInfo = WindowServerInfo(
+            id: UInt32(windowId),
+            pid: pid,
+            level: 0,
+            frame: CGRect(x: 0, y: 1889, width: 1, height: 1)
+        )
+        let evaluation = accessoryHelperEvaluation(
+            pid: pid,
+            windowId: windowId,
+            windowInfo: windowInfo,
+            frame: windowInfo.frame
+        )
+
+        XCTAssertEqual(
+            AXWindowService.heuristicDisposition(for: evaluation.facts.ax).disposition,
+            .floating,
+            "precondition: the classifier floats this window, so only geometry can keep it out"
+        )
+        XCTAssertTrue(
+            controller.shouldDeferAdmission(
+                evaluation: evaluation,
+                axRef: AXWindowRef(element: AXUIElementCreateApplication(pid), windowId: windowId),
+                windowInfo: windowInfo,
+                trackedMode: .floating
+            )
+        )
+    }
+
+    func testFixedSizeFloatingWindowIsStillAdmitted() {
+        // The geometry gate must not swallow ordinary floating windows, including ones that refuse
+        // to be resized - unlike tiling, floating admission does not require a settable size.
+        let controller = WindowAdmissionTestSupport.controller()
+        let pid: pid_t = 468_201
+        let windowId = 468_202
+        let frame = CGRect(x: 120, y: 80, width: 420, height: 260)
+        let windowInfo = WindowServerInfo(id: UInt32(windowId), pid: pid, level: 0, frame: frame)
+        var evaluation = accessoryHelperEvaluation(
+            pid: pid,
+            windowId: windowId,
+            windowInfo: windowInfo,
+            frame: frame
+        )
+        evaluation = WMController.WindowDecisionEvaluation(
+            token: evaluation.token,
+            facts: evaluation.facts,
+            decision: evaluation.decision,
+            appFullscreen: false,
+            manualOverride: nil,
+            admissionGeometry: WindowAdmissionGeometryEvidence(isSizeSettable: false, frame: frame)
+        )
+
+        XCTAssertFalse(
+            controller.shouldDeferAdmission(
+                evaluation: evaluation,
+                axRef: AXWindowRef(element: AXUIElementCreateApplication(pid), windowId: windowId),
+                windowInfo: windowInfo,
+                trackedMode: .floating
+            )
+        )
+        XCTAssertTrue(
+            controller.shouldDeferAdmission(
+                evaluation: evaluation,
+                axRef: AXWindowRef(element: AXUIElementCreateApplication(pid), windowId: windowId),
+                windowInfo: windowInfo,
+                trackedMode: .tiling
+            ),
+            "the same window still cannot be tiled, because it refuses a size"
         )
     }
 
@@ -69,6 +148,51 @@ final class WindowAdmissionPolicyTests: XCTestCase {
         XCTAssertNil(controller.axEventHandler.admissionRetryStateByWindowId[UInt32(windowId)])
         controller.axEventHandler.handleCGSEvent(.destroyed(windowId: UInt32(windowId), spaceId: 0))
     }
+}
+
+/// Mirrors what the AX layer reports for a menu-bar app's helper window: an accessory-policy
+/// process, `AXUnknown` subrole, and every window button absent.
+private func accessoryHelperEvaluation(
+    pid: pid_t,
+    windowId: Int,
+    windowInfo: WindowServerInfo,
+    frame: CGRect
+) -> WMController.WindowDecisionEvaluation {
+    let facts = WindowRuleFacts(
+        appName: "BetterDisplay",
+        ax: AXWindowFacts(
+            role: kAXWindowRole as String,
+            subrole: "AXUnknown",
+            title: nil,
+            hasCloseButton: false,
+            hasFullscreenButton: false,
+            fullscreenButtonEnabled: nil,
+            hasZoomButton: false,
+            hasMinimizeButton: false,
+            appPolicy: .accessory,
+            bundleId: "pro.betterdisplay.BetterDisplay",
+            attributeFetchSucceeded: true
+        ),
+        sizeConstraints: nil,
+        windowServer: windowInfo
+    )
+    return WMController.WindowDecisionEvaluation(
+        token: WindowToken(pid: pid, windowId: windowId),
+        facts: facts,
+        decision: WindowDecision(
+            disposition: .floating,
+            source: .heuristic,
+            layoutDecisionKind: .fallbackLayout,
+            workspaceName: nil,
+            ruleEffects: .none,
+            admissionHints: .none,
+            heuristicReasons: [.accessoryWithoutClose],
+            deferredReason: nil
+        ),
+        appFullscreen: false,
+        manualOverride: nil,
+        admissionGeometry: WindowAdmissionGeometryEvidence(isSizeSettable: true, frame: frame)
+    )
 }
 
 private func explicitProxyEvaluation(

--- a/Tests/OmniWMTests/WindowRuleEngineTests.swift
+++ b/Tests/OmniWMTests/WindowRuleEngineTests.swift
@@ -40,6 +40,70 @@ final class WindowRuleEngineTests: XCTestCase {
         engine.decision(for: facts, token: nil, appFullscreen: false)
     }
 
+    private func facts(
+        appName: String?,
+        bundleId: String?,
+        windowLevel: Int32
+    ) -> WindowRuleFacts {
+        let base = facts(appName: appName, bundleId: bundleId, subrole: "AXUnknown")
+        return WindowRuleFacts(
+            appName: base.appName,
+            ax: base.ax,
+            sizeConstraints: base.sizeConstraints,
+            windowServer: WindowServerInfo(
+                id: 1,
+                pid: 4321,
+                level: windowLevel,
+                frame: CGRect(x: 1420, y: 27, width: 310, height: 824)
+            )
+        )
+    }
+
+    func testMenuBarPopoverAboveNormalLevelsIsUnmanaged() {
+        // A menu-bar app's popover (BetterDisplay's opens at the screensaver level) must never be
+        // tracked: fronting or moving it makes the app dismiss it, and it strands a workspace-bar
+        // entry. Only the window level distinguishes it from a floatable panel.
+        let engine = WindowRuleEngine()
+        let popover = evaluate(
+            engine,
+            facts(appName: "BetterDisplay", bundleId: "pro.betterdisplay.BetterDisplay", windowLevel: 1000)
+        )
+
+        XCTAssertEqual(popover.disposition, .unmanaged)
+        XCTAssertEqual(popover.source, .builtInRule(WindowRuleEngine.elevatedWindowLevelRuleName))
+    }
+
+    func testUserRuleCannotForceAnElevatedSurfaceToBeManaged() {
+        let engine = WindowRuleEngine()
+        let rule = AppRule(bundleId: "pro.betterdisplay.BetterDisplay", layout: .tile)
+        engine.rebuild(rules: [rule])
+
+        let popover = evaluate(
+            engine,
+            facts(appName: "BetterDisplay", bundleId: "pro.betterdisplay.BetterDisplay", windowLevel: 1000)
+        )
+
+        XCTAssertEqual(popover.disposition, .unmanaged)
+        XCTAssertNotEqual(popover.source, .userRule(rule.id))
+    }
+
+    func testOrdinaryAndFloatingLevelWindowsStayManageable() {
+        // The gate must sit above the levels apps use for panels and dialogs, so those keep being
+        // classified normally rather than being dropped wholesale.
+        let engine = WindowRuleEngine()
+        for level: Int32 in [0, 3, 8, 19] {
+            let decision = evaluate(
+                engine,
+                facts(appName: "Preview", bundleId: "com.apple.Preview", windowLevel: level)
+            )
+            XCTAssertNotEqual(
+                decision.disposition,
+                .unmanaged,
+                "level \(level) is an ordinary app window level and must still be classified"
+            )
+        }
+    }
+
     func testAppNameWildcardMatchesNoBundleWindows() {
         let engine = WindowRuleEngine()
         let rule = AppRule(bundleId: "", appNameSubstring: "VMD", layout: .float)

--- a/Tests/OmniWMTests/WindowRuleEngineTests.swift
+++ b/Tests/OmniWMTests/WindowRuleEngineTests.swift
@@ -87,6 +87,46 @@ final class WindowRuleEngineTests: XCTestCase {
         XCTAssertNotEqual(popover.source, .userRule(rule.id))
     }
 
+    func testCleanShotRecordingOverlaySurvivesTheElevatedLevelGate() {
+        // CleanShot's recording overlay sits at level 103, above the transient-surface gate, but is
+        // a real window the user works with. Its built-in rule must still win, and must still be
+        // reached at the point where a matching user rule's workspace and sizing effects apply.
+        let engine = WindowRuleEngine()
+        let rule = AppRule(
+            bundleId: WindowRuleEngine.cleanShotBundleId,
+            layout: .float,
+            assignToWorkspace: "5",
+            minWidth: 320
+        )
+        engine.rebuild(rules: [rule])
+
+        let base = facts(
+            appName: "CleanShot X",
+            bundleId: WindowRuleEngine.cleanShotBundleId
+        )
+        let overlay = WindowRuleFacts(
+            appName: base.appName,
+            ax: base.ax,
+            sizeConstraints: base.sizeConstraints,
+            windowServer: WindowServerInfo(
+                id: 2,
+                pid: 8765,
+                level: 103,
+                frame: CGRect(x: 0, y: 0, width: 900, height: 600)
+            )
+        )
+        let decision = evaluate(engine, overlay)
+
+        XCTAssertEqual(decision.disposition, .floating)
+        XCTAssertNotEqual(
+            decision.source,
+            .builtInRule(WindowRuleEngine.elevatedWindowLevelRuleName),
+            "the elevated-level gate must not intercept the recording overlay"
+        )
+        XCTAssertEqual(decision.workspaceName, "5", "it still picks up the matching user rule")
+        XCTAssertEqual(decision.ruleEffects.minWidth, 320)
+    }
+
     func testOrdinaryAndFloatingLevelWindowsStayManageable() {
         // The gate must sit above the levels apps use for panels and dialogs, so those keep being
         // classified normally rather than being dropped wholesale.

--- a/Tests/OmniWMTests/WindowRuleEngineTests.swift
+++ b/Tests/OmniWMTests/WindowRuleEngineTests.swift
@@ -144,6 +144,125 @@ final class WindowRuleEngineTests: XCTestCase {
         }
     }
 
+    private func chromePopupFacts(
+        subrole: String? = "AXUnknown",
+        hasButtons: Bool = false,
+        attributeFetchSucceeded: Bool = true,
+        tags: UInt64 = 0x1_400C_0402
+    ) -> WindowRuleFacts {
+        // Captured from Chrome's omnibox suggestion dropdown: a borderless widget window at the
+        // normal window level whose tags carry floating (0x2) without document (0x1).
+        WindowRuleFacts(
+            appName: "Google Chrome",
+            ax: AXWindowFacts(
+                role: kAXWindowRole as String,
+                subrole: subrole,
+                title: nil,
+                hasCloseButton: hasButtons,
+                hasFullscreenButton: hasButtons,
+                fullscreenButtonEnabled: hasButtons ? true : nil,
+                hasZoomButton: hasButtons,
+                hasMinimizeButton: hasButtons,
+                appPolicy: .regular,
+                bundleId: "com.google.Chrome",
+                attributeFetchSucceeded: attributeFetchSucceeded
+            ),
+            sizeConstraints: nil,
+            windowServer: WindowServerInfo(
+                id: 1207,
+                pid: 43657,
+                level: 0,
+                frame: CGRect(x: 99, y: 55, width: 3144, height: 418),
+                tags: tags
+            )
+        )
+    }
+
+    func testChromiumTransientPopupIsUnmanaged() {
+        // Chrome's omnibox dropdown and link-target status bubble are real AX windows at the
+        // normal level, so the elevated-level gate never fires, and the heuristic floated them -
+        // filling the workspace bar with untitled entries that open nothing when clicked.
+        let engine = WindowRuleEngine()
+        let popup = evaluate(engine, chromePopupFacts())
+
+        XCTAssertEqual(popup.disposition, .unmanaged)
+        XCTAssertEqual(popup.source, .builtInRule(WindowRuleEngine.transientPopupRuleName))
+    }
+
+    func testUserFloatRuleCannotResurrectABrowserPopup() {
+        let engine = WindowRuleEngine()
+        let rule = AppRule(bundleId: "com.google.Chrome", layout: .float)
+        engine.rebuild(rules: [rule])
+
+        let popup = evaluate(engine, chromePopupFacts())
+
+        XCTAssertEqual(popup.disposition, .unmanaged)
+        XCTAssertNotEqual(popup.source, .userRule(rule.id))
+    }
+
+    func testPictureInPictureWindowSurvivesThePopupGate() {
+        // Chrome's Picture-in-Picture window is the transient gate's nearest real neighbor: same
+        // app, also floating-by-nature - but it keeps the document tag, a standard subrole and a
+        // close button, and the user wants it tracked.
+        let engine = WindowRuleEngine()
+        let pip = WindowRuleFacts(
+            appName: "Google Chrome",
+            ax: AXWindowFacts(
+                role: kAXWindowRole as String,
+                subrole: kAXStandardWindowSubrole as String,
+                title: nil,
+                hasCloseButton: true,
+                hasFullscreenButton: false,
+                fullscreenButtonEnabled: nil,
+                hasZoomButton: true,
+                hasMinimizeButton: true,
+                appPolicy: .regular,
+                bundleId: "com.google.Chrome",
+                attributeFetchSucceeded: true
+            ),
+            sizeConstraints: nil,
+            windowServer: WindowServerInfo(
+                id: 1569,
+                pid: 43657,
+                level: 3,
+                frame: CGRect(x: 2657, y: 1476, width: 661, height: 372),
+                tags: 0x1_0008_2C01
+            )
+        )
+        let decision = evaluate(engine, pip)
+
+        XCTAssertEqual(decision.disposition, .floating)
+        XCTAssertNotEqual(decision.source, .builtInRule(WindowRuleEngine.transientPopupRuleName))
+    }
+
+    func testFloatingTaggedPanelWithWindowEvidenceStaysClassifiable() {
+        // A utility panel can share the popup's floating-without-document tags; a proper subrole
+        // or any window button is enough real-window evidence to keep it out of the gate.
+        let engine = WindowRuleEngine()
+
+        let dialogSubrole = evaluate(
+            engine,
+            chromePopupFacts(subrole: kAXDialogSubrole as String)
+        )
+        XCTAssertNotEqual(dialogSubrole.disposition, .unmanaged)
+
+        let buttonedPopup = evaluate(engine, chromePopupFacts(hasButtons: true))
+        XCTAssertNotEqual(buttonedPopup.disposition, .unmanaged)
+    }
+
+    func testDegradedFetchDoesNotTriggerThePopupGate() {
+        // A failed attribute fetch reports AXUnknown-with-no-buttons for every window, so the gate
+        // must stand down and leave those to the deferred/degraded-evidence path.
+        let engine = WindowRuleEngine()
+        let degraded = evaluate(
+            engine,
+            chromePopupFacts(attributeFetchSucceeded: false)
+        )
+
+        XCTAssertNotEqual(degraded.disposition, .unmanaged)
+        XCTAssertNotEqual(degraded.source, .builtInRule(WindowRuleEngine.transientPopupRuleName))
+    }
+
     func testAppNameWildcardMatchesNoBundleWindows() {
         let engine = WindowRuleEngine()
         let rule = AppRule(bundleId: "", appNameSubstring: "VMD", layout: .float)


### PR DESCRIPTION
Fixes #511

Four bugs in the same window-admission path. The first two are what #511 reports; the last two surfaced while verifying the fix for them end-to-end, and one of them is a regression introduced by the first fix in this branch.

## Problem

**1. A window with no fullscreen button was never tracked.** `AXUIElementCopyMultipleAttributeValues` reports a missing attribute as an `AXValue` of type `kAXValueAXErrorType`, not `nil`/`NSError`. `resolvedAttribute` only treated `NSError` as absent, so a missing `AXFullScreenButton` read as present. `fullscreenButtonEnabled` then reported the fetch as failed, forcing classification to `.undecided`, so the window was never admitted. Activity Monitor, and any window that lacks a fullscreen button, appeared in neither the tiled nor the floating group of the workspace bar and was ignored by every window command.

**2. A newly created floating window lost focus.** When admitted through the full-rescan path rather than the AXWindowCreated fast path, `buildFullEffectPlan` only seeded the window's geometry and never focused it, so the workspace focused token stayed on the previously focused tiled window. The post-admission relayout's focus recovery then re-fronted that tiled window about 47 ms after macOS had brought the new window forward.

**3. Invisible 1x1 helper windows were admitted as floating windows.** Menu-bar apps park permanently-hidden helper windows at a degenerate size; BetterDisplay keeps a 1x1 window below the bottom of the screen for the lifetime of the process. An accessory app's window without a close button classifies as `.floating`, so one of these was admitted and left an entry in the workspace bar that shows nothing and opens nothing when clicked.

`isMeaningfulAdmissionFrame` already existed to reject exactly this shape, but only the tiling path consulted it, so floating admission accepted any geometry. **This is a regression from fix 1 in this branch**: before it, these windows' attribute fetch was misreported as failed, which forced the classifier to `.undecided` and filtered them out by accident.

**4. Menu-bar popovers were managed, and dismissed themselves as a result.** A menu-bar app's popover is a real AX window of an accessory process, so nothing in its AX facts separates it from a utility panel a user would want floated, and OmniWM admitted it as a floating window. Fronting it made the owning app dismiss it immediately: clicking BetterDisplay's status item opened its panel and closed it again roughly 700 ms later, every time. This one is not a regression - it predates the branch.

## Approach

1. Reject the AX-error placeholder in `resolvedAttribute`, and route the fullscreen-button probe through a single `fullscreenButtonEvidence` helper (absent / element / malformed) that replaces the duplicated button-shape check in `collectWindowFacts` and the enumeration inspector. The previously unreachable `missingFullscreenButton -> .floating` heuristic branch now floats these windows.
2. Focus a genuinely user-created floating window on admission, mirroring the fast path (`trackPreparedCreate`). Gated on the create-placement context so a floating window merely discovered during startup enumeration does not steal focus. The gate and the raise are folded into one `focusNewlyAdmittedFloatingWindow` entry point that the admission loop calls per window, so production and tests exercise the same path including the focus-operation seam.
3. Split the frame check out of `shouldDeferTilingAdmission` into `hasDegenerateAdmissionFrame` and run it for every admission mode, keeping the resizability requirement on tiling alone since a floating window is allowed to be fixed-size. Reuses the existing `.degenerateGeometry` retry, so a window that simply has not been sized yet is still admitted once it grows.
4. Classify anything at or above `kCGPopUpMenuWindowLevel` (101) as `.unmanaged`. Only the window-server level distinguishes these surfaces: at and above that level macOS stacks menus, popovers, help tags, drag images and screensavers, while ordinary app windows sit at level 0 and the panels and dialogs still worth floating stay well below it (floating 3, modal 8, utility 19). A level survey on the test machine was unambiguous - every manageable window at 0, both BetterDisplay surfaces at 1000, OmniWM's own bar panels at 101. The rule runs ahead of the user rules, alongside the existing `systemTextInputPanel` rule, so no rule can make OmniWM manage a menu.

## Behavior change

- Windows without a fullscreen button (Activity Monitor, some utility and preferences windows) are now tracked as floating windows and shown in the workspace bar.
- A newly opened floating window keeps focus and stays in front instead of dropping behind the previously focused window.
- Invisible helper windows no longer appear in the workspace bar as entries that do nothing.
- Menu-bar popovers (BetterDisplay, and any status-item panel) open and stay open, and are left out of the workspace bar entirely.
- Floating, modal and utility panels are unaffected by the new level gate and remain manageable.

## Verification

Every bug was reproduced end-to-end against the running app before being fixed, and each fix confirmed live afterwards.

- **1 and 2**: the window now appears in the bar, and a newly opened floating window keeps focus. Verified against the window-server z-order and OmniWM's own focus state; the old focus-steal signature no longer fires.
- **3 and 4**: drove the real status item with a synthesized click while sampling `CGWindowListCopyWindowInfo` at 30 ms and subscribing to OmniWM's focus channel over IPC.
  - Before: popup opened and died in ~700 ms, every time, and OmniWM's focus channel reported it as the focused window. A control run with OmniWM stopped showed the same panel staying open indefinitely, which pins OmniWM as the cause.
  - After: the panel opens and stays open for the full 11 s observation window and toggles closed normally; OmniWM's focus channel never reports it; `omniwmctl query windows` and `query workspace-bar` show no BetterDisplay entry.
  - Confirmed bug 3 was a regression by probing the live AX attributes of the helper window and evaluating the old and new absence checks side by side (`attributeFetchSucceeded` OLD=false, NEW=true).

Regression tests, each confirmed to fail against the old behavior:

- `AXFullRescanBoundaryTests`: the AX-error placeholder reads as absent, and an Activity-Monitor-shaped window classifies as `.floating` instead of deferring.
- `FullRescanReadmissionTests`: `shouldFocusNewlyAdmittedFloatingWindow` covers the new-floating, already-tracked, tiled and startup-discovery cases, plus integration-level tests that drive `focusNewlyAdmittedFloatingWindow` through a recording `WindowFocusOperations` with a real create-placement context.
- `WindowAdmissionPolicyTests`: a BetterDisplay-shaped 1x1 accessory window is kept out (asserting first that the classifier does float it, so only geometry can reject it), while a fixed-size 420x260 floating window is still admitted so the gate cannot over-block.
- `WindowRuleEngineTests`: a level-1000 popover is `.unmanaged`, a user rule cannot force it to be managed, and levels 0/3/8/19 stay classifiable.

Full suite: **1472 tests, 0 failures.**

Five commits, one per logical change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an elevated window-level short-circuit to the window rule engine, including dedicated handling for CleanShot recording overlays.
  * Improved monitor edge hide-side preference calculations using monitor geometry.
* **Bug Fixes**
  * Improved accessibility fullscreen-button interpretation by treating “no value”/error placeholders as absent, reducing window misclassification.
  * During full rescans/readmissions, newly admitted floating windows with create-placement context are now more reliably focused/raised.
  * Updated admission deferral to apply consistently across window modes, including degenerate-geometry and size-settable scenarios.
* **Tests**
  * Expanded AX placeholder, elevated-level rule, and full-rescan readmission focus/activation coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
