### PR TITLE
feat: add a background blur option for the quake terminal

### DIFF
--- a/README.md
+++ b/README.md
@@ -474,7 +474,7 @@ A true quake/sticky terminal (powered by Ghostty's libghostty) that slides in fr
 - Supports multiple tabs and splits within tabs
 - Tab and pane shortcuts are listed in **Quake Terminal (Inside Terminal)**
 - Mouse resize by dragging edges; `Option + drag` to move (remembers size/position per monitor)
-- Configure position (top/bottom/left/right/center), size, and opacity in Settings
+- Configure position (top/bottom/left/right/center), size, opacity, and background blur in Settings
 - Auto-hides on focus loss (optional)
 
 #### Command Palette

--- a/Sources/OmniWM/Core/Config/CanonicalTOMLConfig.swift
+++ b/Sources/OmniWM/Core/Config/CanonicalTOMLConfig.swift
@@ -229,6 +229,7 @@ struct CanonicalTOMLConfig: Codable, Equatable {
         var animationDuration: Double
         var autoHide: Bool
         var opacity: Double?
+        var backgroundBlurRadius: Int?
         var monitorMode: String?
     }
 
@@ -1088,6 +1089,7 @@ extension CanonicalTOMLConfig.QuakeTerminal {
             recovering: recovering
         )
         opacity = try container.decodeIfPresent(Double.self, forKey: .opacity)
+        backgroundBlurRadius = try container.decodeIfPresent(Int.self, forKey: .backgroundBlurRadius)
         monitorMode = try container.decodeIfPresent(String.self, forKey: .monitorMode)
     }
 }
@@ -1230,6 +1232,7 @@ extension CanonicalTOMLConfig {
             animationDuration: export.quakeTerminalAnimationDuration,
             autoHide: export.quakeTerminalAutoHide,
             opacity: export.quakeTerminalOpacity,
+            backgroundBlurRadius: export.quakeTerminalBackgroundBlurRadius,
             monitorMode: export.quakeTerminalMonitorMode
         )
         appearance = Appearance(mode: export.appearanceMode)
@@ -1348,6 +1351,7 @@ extension CanonicalTOMLConfig {
             quakeTerminalAnimationDuration: quakeTerminal.animationDuration,
             quakeTerminalAutoHide: quakeTerminal.autoHide,
             quakeTerminalOpacity: quakeTerminal.opacity,
+            quakeTerminalBackgroundBlurRadius: quakeTerminal.backgroundBlurRadius,
             quakeTerminalMonitorMode: quakeTerminal.monitorMode,
             appearanceMode: appearance.mode
         )

--- a/Sources/OmniWM/Core/Config/SettingsExport.swift
+++ b/Sources/OmniWM/Core/Config/SettingsExport.swift
@@ -128,6 +128,7 @@ struct SettingsExport: Equatable {
     var quakeTerminalAnimationDuration: Double
     var quakeTerminalAutoHide: Bool
     var quakeTerminalOpacity: Double?
+    var quakeTerminalBackgroundBlurRadius: Int?
     var quakeTerminalMonitorMode: String?
 
     var appearanceMode: String
@@ -240,6 +241,7 @@ extension SettingsExport {
             quakeTerminalAnimationDuration: 0.2,
             quakeTerminalAutoHide: false,
             quakeTerminalOpacity: 1.0,
+            quakeTerminalBackgroundBlurRadius: QuakeTerminalAppearancePolicy.disabledBackgroundBlurRadius,
             quakeTerminalMonitorMode: QuakeTerminalMonitorMode.focusedWindow.rawValue,
             appearanceMode: AppearanceMode.dark.rawValue
         )

--- a/Sources/OmniWM/Core/Config/SettingsStore.swift
+++ b/Sources/OmniWM/Core/Config/SettingsStore.swift
@@ -517,6 +517,20 @@ final class SettingsStore {
         didSet { scheduleSave() }
     }
 
+    var quakeTerminalBackgroundBlurRadius = SettingsStore.defaultExport.quakeTerminalBackgroundBlurRadius
+        ?? QuakeTerminalAppearancePolicy.disabledBackgroundBlurRadius
+    {
+        didSet {
+            let normalized = QuakeTerminalAppearancePolicy
+                .normalizedBackgroundBlurRadius(quakeTerminalBackgroundBlurRadius)
+            if normalized != quakeTerminalBackgroundBlurRadius {
+                quakeTerminalBackgroundBlurRadius = normalized
+                return
+            }
+            scheduleSave()
+        }
+    }
+
     var quakeTerminalMonitorMode = QuakeTerminalMonitorMode(
         rawValue: SettingsStore.defaultExport.quakeTerminalMonitorMode ?? ""
     ) ?? .focusedWindow {
@@ -724,6 +738,7 @@ final class SettingsStore {
             quakeTerminalAnimationDuration: quakeTerminalAnimationDuration,
             quakeTerminalAutoHide: quakeTerminalAutoHide,
             quakeTerminalOpacity: quakeTerminalOpacity,
+            quakeTerminalBackgroundBlurRadius: quakeTerminalBackgroundBlurRadius,
             quakeTerminalMonitorMode: quakeTerminalMonitorMode.rawValue,
             appearanceMode: appearanceMode.rawValue
         )
@@ -868,6 +883,11 @@ final class SettingsStore {
         quakeTerminalAnimationDuration = export.quakeTerminalAnimationDuration
         quakeTerminalAutoHide = export.quakeTerminalAutoHide
         quakeTerminalOpacity = export.quakeTerminalOpacity ?? baseline.quakeTerminalOpacity ?? 1.0
+        quakeTerminalBackgroundBlurRadius = QuakeTerminalAppearancePolicy.normalizedBackgroundBlurRadius(
+            export.quakeTerminalBackgroundBlurRadius
+                ?? baseline.quakeTerminalBackgroundBlurRadius
+                ?? QuakeTerminalAppearancePolicy.disabledBackgroundBlurRadius
+        )
         quakeTerminalMonitorMode = QuakeTerminalMonitorMode(
             rawValue: export.quakeTerminalMonitorMode ?? baseline.quakeTerminalMonitorMode ?? ""
         ) ?? .focusedWindow

--- a/Sources/OmniWM/Core/Controller/WMController.swift
+++ b/Sources/OmniWM/Core/Controller/WMController.swift
@@ -403,6 +403,7 @@ final class WMController {
         // an app relaunch.
         quakeTerminalController.applyGeometryToVisibleWindow()
         quakeTerminalController.reloadOpacityConfig()
+        quakeTerminalController.reloadBackgroundBlur()
         updateWorkspaceBarSettings()
         updateHiddenBarSettings()
         _ = syncMouseWarpPolicy()
@@ -631,6 +632,10 @@ final class WMController {
 
     func reloadQuakeTerminalOpacity() {
         quakeTerminalController.reloadOpacityConfig()
+    }
+
+    func reloadQuakeTerminalBackgroundBlur() {
+        quakeTerminalController.reloadBackgroundBlur()
     }
 
     func requestWorkspaceBarRefresh() {

--- a/Sources/OmniWM/Core/SkyLight/SkyLight.swift
+++ b/Sources/OmniWM/Core/SkyLight/SkyLight.swift
@@ -144,6 +144,7 @@ final class SkyLight {
     private typealias SetWindowShapeFunc = @convention(c) (Int32, UInt32, Float, Float, CFTypeRef) -> CGError
     private typealias SetWindowResolutionFunc = @convention(c) (Int32, UInt32, Float) -> CGError
     private typealias SetWindowOpacityFunc = @convention(c) (Int32, UInt32, Int32) -> CGError
+    private typealias SetWindowBackgroundBlurRadiusFunc = @convention(c) (Int32, UInt32, Int32) -> CGError
     private typealias SetWindowTagsFunc = @convention(c) (Int32, UInt32, UnsafePointer<UInt64>, Int32) -> CGError
     private typealias FlushWindowContentRegionFunc = @convention(c) (Int32, UInt32, CFTypeRef?) -> CGError
     private typealias NewRegionWithRectFunc = @convention(c) (UnsafePointer<CGRect>, UnsafeMutablePointer<CFTypeRef?>)
@@ -228,6 +229,7 @@ final class SkyLight {
     private let setWindowShape: SetWindowShapeFunc
     private let setWindowResolution: SetWindowResolutionFunc
     private let setWindowOpacity: SetWindowOpacityFunc
+    private let setWindowBackgroundBlurRadius: SetWindowBackgroundBlurRadiusFunc?
     private let setWindowTags: SetWindowTagsFunc
     private let flushWindowContentRegion: FlushWindowContentRegionFunc
     private let newRegionWithRect: NewRegionWithRectFunc
@@ -330,6 +332,10 @@ final class SkyLight {
         setWindowShape = resolve("SLSSetWindowShape", as: SetWindowShapeFunc.self)
         setWindowResolution = resolve("SLSSetWindowResolution", as: SetWindowResolutionFunc.self)
         setWindowOpacity = resolve("SLSSetWindowOpacity", as: SetWindowOpacityFunc.self)
+        setWindowBackgroundBlurRadius = resolveOptional(
+            "SLSSetWindowBackgroundBlurRadius",
+            as: SetWindowBackgroundBlurRadiusFunc.self
+        )
         setWindowTags = resolve("SLSSetWindowTags", as: SetWindowTagsFunc.self)
         flushWindowContentRegion = resolve("SLSFlushWindowContentRegion", as: FlushWindowContentRegionFunc.self)
         newRegionWithRect = resolve("CGSNewRegionWithRect", as: NewRegionWithRectFunc.self)
@@ -898,6 +904,21 @@ final class SkyLight {
         let opacityOk = setWindowOpacity(cid, wid, opaque ? 1 : 0) == .success
         if !opacityOk { FallbackFiringRecorder.shared.note(.skylight, "setWindowOpacityFailed") }
         return (resolutionOk, opacityOk)
+    }
+
+    var backgroundBlurAvailable: Bool {
+        setWindowBackgroundBlurRadius != nil
+    }
+
+    /// Blurs whatever is behind `wid`; only visible through the window's translucent pixels.
+    /// A radius of 0 removes the blur.
+    @discardableResult
+    func setWindowBackgroundBlurRadius(_ wid: UInt32, radius: Int) -> Bool {
+        let cid = getMainConnectionID()
+        guard cid != 0, let setWindowBackgroundBlurRadius else { return false }
+        let ok = setWindowBackgroundBlurRadius(cid, wid, Int32(radius)) == .success
+        if !ok { FallbackFiringRecorder.shared.note(.skylight, "setWindowBackgroundBlurRadiusFailed") }
+        return ok
     }
 
     @discardableResult

--- a/Sources/OmniWM/QuakeTerminal/QuakeTerminalAppearancePolicy.swift
+++ b/Sources/OmniWM/QuakeTerminal/QuakeTerminalAppearancePolicy.swift
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: GPL-2.0-only
+// Copyright (C) 2026 BarutSRB — https://github.com/BarutSRB/OmniWM
+
+import Foundation
+
+enum QuakeTerminalAppearancePolicy {
+    static let minimumBackgroundBlurRadius = 0
+    static let maximumBackgroundBlurRadius = 100
+    static let disabledBackgroundBlurRadius = 0
+
+    /// Radius Ghostty uses for `background-blur = true`; the value the UI offers as "on".
+    static let defaultEnabledBackgroundBlurRadius = 20
+
+    static func normalizedBackgroundBlurRadius(_ value: Int) -> Int {
+        min(max(value, minimumBackgroundBlurRadius), maximumBackgroundBlurRadius)
+    }
+
+    /// Blur only shows through translucent pixels, so a fully opaque terminal renders
+    /// identically with the blur on or off.
+    static func backgroundBlurIsHiddenByOpaqueBackground(radius: Int, opacity: Double) -> Bool {
+        normalizedBackgroundBlurRadius(radius) > disabledBackgroundBlurRadius && opacity >= 1.0
+    }
+}

--- a/Sources/OmniWM/QuakeTerminal/QuakeTerminalController.swift
+++ b/Sources/OmniWM/QuakeTerminal/QuakeTerminalController.swift
@@ -43,6 +43,7 @@ final class QuakeTerminalController: NSObject, NSWindowDelegate, QuakeTerminalTa
     private var animationGeneration: UInt64 = 0
     private var appearanceObserver: NSKeyValueObservation?
     private var appliedColorScheme: ghostty_color_scheme_e?
+    private var appliedBackgroundBlurRadius: Int?
 
     private let settings: SettingsStore
     private let motionPolicy: MotionPolicy
@@ -195,6 +196,7 @@ final class QuakeTerminalController: NSObject, NSWindowDelegate, QuakeTerminalTa
         surfaceCoordinator.unregister(id: surfaceID)
         window?.close()
         window = nil
+        appliedBackgroundBlurRadius = nil
         containerView = nil
         tabBar = nil
         restoreTarget = nil
@@ -215,6 +217,24 @@ final class QuakeTerminalController: NSObject, NSWindowDelegate, QuakeTerminalTa
         ghostty_app_update_config(ghosttyApp, newConfig)
         ghostty_config_free(newConfig)
         applyCurrentGhosttyColorScheme()
+    }
+
+    func reloadBackgroundBlur() {
+        applyBackgroundBlur()
+    }
+
+    /// The blur lives on the window-server window, so libghostty never sees it: it is applied
+    /// to our own panel and shows through wherever the terminal background is translucent.
+    private func applyBackgroundBlur() {
+        guard let window else { return }
+        let windowNumber = window.windowNumber
+        guard windowNumber > 0 else { return }
+
+        let radius = QuakeTerminalAppearancePolicy
+            .normalizedBackgroundBlurRadius(settings.quakeTerminalBackgroundBlurRadius)
+        guard appliedBackgroundBlurRadius != radius else { return }
+        guard SkyLight.shared.setWindowBackgroundBlurRadius(UInt32(windowNumber), radius: radius) else { return }
+        appliedBackgroundBlurRadius = radius
     }
 
     private func startGhosttyAppearanceSync() {
@@ -310,6 +330,8 @@ final class QuakeTerminalController: NSObject, NSWindowDelegate, QuakeTerminalTa
         )
         container.addSubview(bar)
         self.tabBar = bar
+
+        applyBackgroundBlur()
     }
 
     private var surfaceID: String {
@@ -518,6 +540,9 @@ final class QuakeTerminalController: NSObject, NSWindowDelegate, QuakeTerminalTa
         if tabs.isEmpty {
             createInitialSurface()
         }
+
+        // No-op once applied; covers a window whose device was not backed yet at creation.
+        applyBackgroundBlur()
 
         animateWindowIn(window: window)
     }

--- a/Sources/OmniWM/UI/QuakeTerminalSettingsTab.swift
+++ b/Sources/OmniWM/UI/QuakeTerminalSettingsTab.swift
@@ -7,6 +7,12 @@ struct QuakeTerminalSettingsTab: View {
     @Bindable var settings: SettingsStore
     @Bindable var controller: WMController
 
+    private var blurValueText: String {
+        settings.quakeTerminalBackgroundBlurRadius == QuakeTerminalAppearancePolicy.disabledBackgroundBlurRadius
+            ? "Off"
+            : "\(settings.quakeTerminalBackgroundBlurRadius)"
+    }
+
     var body: some View {
         Form {
             Section("Quake Terminal") {
@@ -63,6 +69,28 @@ struct QuakeTerminalSettingsTab: View {
                     )
                     .onChange(of: settings.quakeTerminalOpacity) { _, _ in
                         controller.reloadQuakeTerminalOpacity()
+                    }
+
+                    SettingsSliderRow(
+                        label: "Background Blur",
+                        value: Binding(
+                            get: { Double(settings.quakeTerminalBackgroundBlurRadius) },
+                            set: { settings.quakeTerminalBackgroundBlurRadius = Int($0.rounded()) }
+                        ),
+                        range: Double(QuakeTerminalAppearancePolicy.minimumBackgroundBlurRadius)
+                            ... Double(QuakeTerminalAppearancePolicy.maximumBackgroundBlurRadius),
+                        step: 5,
+                        valueText: blurValueText
+                    )
+                    .onChange(of: settings.quakeTerminalBackgroundBlurRadius) { _, _ in
+                        controller.reloadQuakeTerminalBackgroundBlur()
+                    }
+
+                    if QuakeTerminalAppearancePolicy.backgroundBlurIsHiddenByOpaqueBackground(
+                        radius: settings.quakeTerminalBackgroundBlurRadius,
+                        opacity: settings.quakeTerminalOpacity
+                    ) {
+                        SettingsCaption("Blur only shows through a translucent terminal - lower the opacity to see it.")
                     }
                 }
 

--- a/Tests/OmniWMTests/QuakeTerminalAppearanceSettingsTests.swift
+++ b/Tests/OmniWMTests/QuakeTerminalAppearanceSettingsTests.swift
@@ -1,0 +1,184 @@
+// SPDX-License-Identifier: GPL-2.0-only
+// Copyright (C) 2026 BarutSRB — https://github.com/BarutSRB/OmniWM
+
+import Foundation
+@testable import OmniWM
+import XCTest
+
+final class QuakeTerminalAppearanceSettingsTests: XCTestCase {
+    func testBackgroundBlurDefaultsToOff() {
+        let defaults = SettingsExport.defaults()
+
+        XCTAssertEqual(
+            defaults.quakeTerminalBackgroundBlurRadius,
+            QuakeTerminalAppearancePolicy.disabledBackgroundBlurRadius
+        )
+    }
+
+    func testNormalizedBackgroundBlurRadiusClampsToSupportedRange() {
+        XCTAssertEqual(QuakeTerminalAppearancePolicy.normalizedBackgroundBlurRadius(-30), 0)
+        XCTAssertEqual(QuakeTerminalAppearancePolicy.normalizedBackgroundBlurRadius(0), 0)
+        XCTAssertEqual(QuakeTerminalAppearancePolicy.normalizedBackgroundBlurRadius(20), 20)
+        XCTAssertEqual(QuakeTerminalAppearancePolicy.normalizedBackgroundBlurRadius(1000), 100)
+    }
+
+    func testBackgroundBlurIsOnlyVisibleThroughATranslucentTerminal() {
+        let policy = QuakeTerminalAppearancePolicy.self
+
+        XCTAssertFalse(policy.backgroundBlurIsHiddenByOpaqueBackground(radius: 0, opacity: 1.0))
+        XCTAssertFalse(policy.backgroundBlurIsHiddenByOpaqueBackground(radius: 20, opacity: 0.85))
+        XCTAssertTrue(policy.backgroundBlurIsHiddenByOpaqueBackground(radius: 20, opacity: 1.0))
+    }
+
+    func testRoundTripsBackgroundBlurRadiusInQuakeTerminalTable() throws {
+        var export = SettingsExport.defaults()
+        export.quakeTerminalBackgroundBlurRadius = 35
+
+        let data = try SettingsTOMLCodec.encode(export)
+        let toml = String(decoding: data, as: UTF8.self)
+        let decoded = try SettingsTOMLCodec.decode(data)
+
+        XCTAssertTrue(toml.contains("[quakeTerminal]"))
+        XCTAssertTrue(toml.contains("backgroundBlurRadius = 35"))
+        XCTAssertEqual(decoded.quakeTerminalBackgroundBlurRadius, 35)
+    }
+
+    @MainActor
+    func testConfigWithoutBackgroundBlurRadiusDecodesToOff() throws {
+        let defaults = SettingsExport.defaults()
+        let toml = String(decoding: try SettingsTOMLCodec.encode(defaults), as: UTF8.self)
+        let stripped = removingValue(in: toml, table: "quakeTerminal", key: "backgroundBlurRadius")
+
+        let decoded = try SettingsTOMLCodec.decode(Data(stripped.utf8))
+        XCTAssertNil(decoded.quakeTerminalBackgroundBlurRadius)
+
+        let settings = makeSettingsStore()
+        settings.applyExport(decoded)
+        XCTAssertEqual(
+            settings.quakeTerminalBackgroundBlurRadius,
+            QuakeTerminalAppearancePolicy.disabledBackgroundBlurRadius
+        )
+    }
+
+    func testMalformedBackgroundBlurRadiusRejectsDecode() throws {
+        let defaults = String(
+            decoding: try SettingsTOMLCodec.encode(SettingsExport.defaults()),
+            as: UTF8.self
+        )
+        let malformed = replacingValue(
+            in: defaults,
+            table: "quakeTerminal",
+            key: "backgroundBlurRadius",
+            with: "\"heavy\""
+        )
+
+        XCTAssertThrowsError(try SettingsTOMLCodec.decode(Data(malformed.utf8)))
+    }
+
+    @MainActor
+    func testApplyExportClampsBackgroundBlurRadius() {
+        let settings = makeSettingsStore()
+        var export = SettingsExport.defaults()
+
+        export.quakeTerminalBackgroundBlurRadius = -5
+        settings.applyExport(export)
+        XCTAssertEqual(settings.quakeTerminalBackgroundBlurRadius, 0)
+
+        export.quakeTerminalBackgroundBlurRadius = 400
+        settings.applyExport(export)
+        XCTAssertEqual(settings.quakeTerminalBackgroundBlurRadius, 100)
+        XCTAssertEqual(settings.toExport().quakeTerminalBackgroundBlurRadius, 100)
+    }
+
+    @MainActor
+    func testAssigningOutOfRangeBackgroundBlurRadiusNormalizesInPlace() {
+        let settings = makeSettingsStore()
+
+        settings.quakeTerminalBackgroundBlurRadius = 250
+        XCTAssertEqual(settings.quakeTerminalBackgroundBlurRadius, 100)
+
+        settings.quakeTerminalBackgroundBlurRadius = -1
+        XCTAssertEqual(settings.quakeTerminalBackgroundBlurRadius, 0)
+    }
+
+    @MainActor
+    func testAutosavePersistsBackgroundBlurRadius() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("OmniWMQuakeAppearanceAutosaveTests-\(UUID().uuidString)", isDirectory: true)
+        defer {
+            try? FileManager.default.removeItem(at: root)
+        }
+        let persistence = SettingsFilePersistence(
+            directory: root.appendingPathComponent("config", isDirectory: true),
+            startWatching: false,
+            deferSaves: false
+        )
+        let settings = SettingsStore(
+            persistence: persistence,
+            runtimeState: RuntimeStateStore(
+                directory: root.appendingPathComponent("state", isDirectory: true),
+                deferSaves: false
+            ),
+            autosaveEnabled: true
+        )
+
+        settings.quakeTerminalBackgroundBlurRadius = 40
+
+        let persisted = try SettingsTOMLCodec.decode(Data(contentsOf: persistence.fileURL))
+        XCTAssertEqual(persisted.quakeTerminalBackgroundBlurRadius, 40)
+    }
+
+    private func replacingValue(
+        in toml: String,
+        table: String,
+        key: String,
+        with replacement: String
+    ) -> String {
+        transform(toml) { currentTable, line in
+            guard currentTable == table, line.hasPrefix("\(key) = ") else { return line }
+            return "\(key) = \(replacement)"
+        }
+    }
+
+    private func removingValue(in toml: String, table: String, key: String) -> String {
+        transform(toml) { currentTable, line in
+            guard currentTable == table, line.hasPrefix("\(key) = ") else { return line }
+            return nil
+        }
+    }
+
+    private func transform(
+        _ toml: String,
+        _ operation: (_ table: String, _ line: String) -> String?
+    ) -> String {
+        var currentTable = ""
+        return toml
+            .split(separator: "\n", omittingEmptySubsequences: false)
+            .compactMap { substring -> String? in
+                let line = String(substring)
+                if line.hasPrefix("["), line.hasSuffix("]") {
+                    currentTable = String(line.dropFirst().dropLast())
+                }
+                return operation(currentTable, line)
+            }
+            .joined(separator: "\n")
+    }
+
+    @MainActor
+    private func makeSettingsStore() -> SettingsStore {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("OmniWMQuakeAppearanceSettingsTests-\(UUID().uuidString)", isDirectory: true)
+        return SettingsStore(
+            persistence: SettingsFilePersistence(
+                directory: root.appendingPathComponent("config", isDirectory: true),
+                startWatching: false,
+                deferSaves: false
+            ),
+            runtimeState: RuntimeStateStore(
+                directory: root.appendingPathComponent("state", isDirectory: true),
+                deferSaves: false
+            ),
+            autosaveEnabled: false
+        )
+    }
+}


### PR DESCRIPTION
## Problem

`quakeTerminal.opacity` already lets the terminal go translucent, but whatever sits behind it stays sharp. At any usable opacity the desktop competes with the terminal's own text, and the prompt is hard to read against a busy backdrop.

Ghostty solves this with `background-blur`, and that option does nothing here: libghostty only parses it. The embedder owns the window and has to apply the blur itself, so nothing in the config OmniWM hands to ghostty could ever have taken effect.

## Approach

Add `quakeTerminal.backgroundBlurRadius` and apply it to our own `NSPanel` through `SLSSetWindowBackgroundBlurRadius`. `0` disables it (the default), and the value is clamped to 0-100 on both the store and the `applyExport` path.

- The SkyLight symbol is resolved with `resolveOptional` rather than `resolve`. The blur is cosmetic, so a macOS release that drops the symbol should lose the effect, not abort at the `fatalError` every required symbol carries.
- The radius is applied at window creation, on show, and on change, caching the value that took so repeat shows don't re-enter the window server.
- `applyPersistedSettings` re-applies it alongside `reloadOpacityConfig`, so an editor save to `settings.toml` lands live the way opacity already did.
- The TOML key is optional, like `opacity` and `monitorMode` before it, so existing configs decode unchanged and recover to off.
- New `QuakeTerminalAppearancePolicy` holds the bounds, clamping, and the predicate behind the settings caption, mirroring the existing `QuakeTerminalGeometryPolicy`.

## Behavior change

- New setting `[quakeTerminal] backgroundBlurRadius` (integer, 0-100, default `0`), plus a "Background Blur" slider in Settings -> Quake Terminal -> Appearance that reads "Off" at 0.
- When the radius is above 0 but opacity is 1.0 the slider would look broken, since blur is invisible against a fully opaque background. The UI says so with a caption instead.
- Existing configs are unaffected: absent key decodes to off, and nothing changes unless the user opts in.

## Verification

- `make verify` passes (SwiftFormat 0.62.1, SwiftLint 0.65.0, build).
- `swift test --arch arm64`: 1510 tests, 1 failure - `NiriInitialColumnWidthTests.testHandlerSeedsAdmissionWidthBeforeFirstConstraintResolutionAndLeavesLiveStateUntouched`, which is display-geometry-dependent and fails identically on `main` without these changes.
- 9 new tests cover the clamping, the TOML round-trip, missing-key recovery, `applyExport` clamping, autosave, and the caption predicate.
- Checked end to end in the running app against an isolated config dir. At opacity 0.8: radius 0 renders the backdrop sharp; radius 40 blurs it with the terminal text crisp and no bleed past the window edge; back to 0 goes sharp again; radius 25 survives a hide/show cycle. All applied live from a `settings.toml` edit with no relaunch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configurable Quake Terminal background blur.
  - Adjust blur intensity using the new Background Blur setting, including an Off option.
  - Blur settings are saved and restored with the rest of the application configuration.
  - Blur updates are applied immediately to the Quake Terminal.

- **Improvements**
  - Blur values are automatically constrained to supported limits.
  - Added guidance when blur is not visible because the terminal background is opaque.
  - Blur gracefully remains unavailable on systems that do not support the feature.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->