### PR TITLE
fix: inverted vertical window placement in Dwindle moves

### DIFF
--- a/Sources/OmniWM/Core/Layout/Dwindle/DwindleLayoutEngine.swift
+++ b/Sources/OmniWM/Core/Layout/Dwindle/DwindleLayoutEngine.swift
@@ -318,7 +318,9 @@ final class DwindleLayoutEngine {
         let (orientation, newFirst): (DwindleOrientation, Bool)
         if let dir = preselectedDirection {
             orientation = dir.dwindleOrientation
-            newFirst = dir == .left || dir == .up
+            // First child of a vertical split is the bottom half (frames are AppKit
+            // y-up), so an upward placement targets the second child.
+            newFirst = dir == .left || dir == .down
         } else {
             (orientation, newFirst) = planSplit(
                 targetRect: targetRect,

--- a/Tests/OmniWMTests/DwindleCommandRoutingTests.swift
+++ b/Tests/OmniWMTests/DwindleCommandRoutingTests.swift
@@ -75,7 +75,7 @@ final class DwindleCommandRoutingTests: XCTestCase {
             controller: fixture.controller
         )
         fixture.controller.workspaceManager.withEngineMutationScope(in: fixture.sourceWorkspaceId) {
-            XCTAssertTrue(fixture.engine.setPreselection(.up, in: fixture.sourceWorkspaceId))
+            XCTAssertTrue(fixture.engine.setPreselection(.down, in: fixture.sourceWorkspaceId))
             _ = fixture.engine.addWindow(
                 token: localNeighbor,
                 to: fixture.sourceWorkspaceId,

--- a/Tests/OmniWMTests/DwindleGroupFocusIntegrationTests.swift
+++ b/Tests/OmniWMTests/DwindleGroupFocusIntegrationTests.swift
@@ -1105,7 +1105,7 @@ final class DwindleGroupFocusIntegrationTests: XCTestCase {
         let screen = fixture.controller.workspaceManager.monitor(for: fixture.workspaceId)?.visibleFrame
             ?? CGRect(x: 0, y: 0, width: 1200, height: 800)
         fixture.controller.workspaceManager.withEngineMutationScope {
-            XCTAssertTrue(fixture.engine.setPreselection(.up, in: fixture.workspaceId))
+            XCTAssertTrue(fixture.engine.setPreselection(.down, in: fixture.workspaceId))
             _ = fixture.engine.addWindow(
                 token: token,
                 to: fixture.workspaceId,
@@ -1131,7 +1131,7 @@ final class DwindleGroupFocusIntegrationTests: XCTestCase {
         let screen = fixture.controller.workspaceManager.monitor(for: fixture.workspaceId)?.visibleFrame
             ?? CGRect(x: 0, y: 0, width: 1200, height: 800)
         fixture.controller.workspaceManager.withEngineMutationScope {
-            XCTAssertTrue(fixture.engine.setPreselection(.down, in: fixture.workspaceId))
+            XCTAssertTrue(fixture.engine.setPreselection(.up, in: fixture.workspaceId))
             _ = fixture.engine.addWindow(
                 token: token,
                 to: fixture.workspaceId,

--- a/Tests/OmniWMTests/DwindleGroupingEngineTests.swift
+++ b/Tests/OmniWMTests/DwindleGroupingEngineTests.swift
@@ -117,7 +117,7 @@ final class DwindleGroupingEngineTests: XCTestCase {
                 direction.dwindleOrientation,
                 direction.rawValue
             )
-            let extractedFirst = direction == .left || direction == .up
+            let extractedFirst = direction == .left || direction == .down
             XCTAssertEqual(
                 extractedFirst
                     ? engine.root(for: workspace)?.firstChild()?.windowToken
@@ -127,6 +127,40 @@ final class DwindleGroupingEngineTests: XCTestCase {
             )
             XCTAssertTrue(engine.isWindowFullscreen(second, in: workspace), direction.rawValue)
             XCTAssertEqual(engine.activeToken(in: workspace), second, direction.rawValue)
+        }
+    }
+
+    func testUngroupPlacesWindowOnRequestedSideOfFormerGroup() throws {
+        for direction in [Direction.left, .right, .up, .down] {
+            let (engine, workspace, first, second) = makeTwoWindowEngine()
+
+            XCTAssertTrue(engine.groupWindow(direction: .left, in: workspace), direction.rawValue)
+            XCTAssertTrue(engine.ungroupWindow(direction: direction, in: workspace), direction.rawValue)
+
+            let frames = engine.calculateLayout(for: workspace, screen: screen)
+            let firstFrame = try XCTUnwrap(frames[first], direction.rawValue)
+            let secondFrame = try XCTUnwrap(frames[second], direction.rawValue)
+
+            switch direction {
+            case .left:
+                XCTAssertLessThan(secondFrame.midX, firstFrame.midX, direction.rawValue)
+            case .right:
+                XCTAssertGreaterThan(secondFrame.midX, firstFrame.midX, direction.rawValue)
+            case .up:
+                XCTAssertGreaterThan(secondFrame.midY, firstFrame.midY, direction.rawValue)
+            case .down:
+                XCTAssertLessThan(secondFrame.midY, firstFrame.midY, direction.rawValue)
+            }
+
+            XCTAssertNil(
+                engine.findGeometricNeighbor(from: second, direction: direction, in: workspace),
+                direction.rawValue
+            )
+            XCTAssertEqual(
+                engine.findGeometricNeighbor(from: second, direction: opposite(direction), in: workspace),
+                first,
+                direction.rawValue
+            )
         }
     }
 
@@ -222,7 +256,7 @@ final class DwindleGroupingEngineTests: XCTestCase {
             _ = engine.addWindow(token: second, to: workspace, activeWindowFrame: nil)
             _ = engine.calculateLayout(for: workspace, screen: screen)
             XCTAssertTrue(engine.groupWindow(direction: .left, in: workspace))
-            XCTAssertTrue(engine.setPreselection(containerNeighborPreselection(for: direction), in: workspace))
+            XCTAssertTrue(engine.setPreselection(direction, in: workspace))
             _ = engine.addWindow(token: third, to: workspace, activeWindowFrame: nil)
             _ = engine.calculateLayout(for: workspace, screen: screen)
 
@@ -514,29 +548,16 @@ final class DwindleGroupingEngineTests: XCTestCase {
         lhs.windowId < rhs.windowId
     }
 
-    private func preselection(for neighborDirection: Direction) -> Direction {
-        switch neighborDirection {
-        case .left:
-            .right
-        case .right:
-            .left
-        case .up:
-            .up
-        case .down:
-            .down
+    private func opposite(_ direction: Direction) -> Direction {
+        switch direction {
+        case .left: .right
+        case .right: .left
+        case .up: .down
+        case .down: .up
         }
     }
 
-    private func containerNeighborPreselection(for direction: Direction) -> Direction {
-        switch direction {
-        case .left:
-            .left
-        case .right:
-            .right
-        case .up:
-            .down
-        case .down:
-            .up
-        }
+    private func preselection(for neighborDirection: Direction) -> Direction {
+        opposite(neighborDirection)
     }
 }

--- a/Tests/OmniWMTests/DwindleInteractiveResizeTests.swift
+++ b/Tests/OmniWMTests/DwindleInteractiveResizeTests.swift
@@ -64,7 +64,7 @@ final class DwindleInteractiveResizeTests: XCTestCase {
         let bottom = WindowToken(pid: 1, windowId: 1)
         let top = WindowToken(pid: 2, windowId: 2)
         _ = engine.addWindow(token: bottom, to: ws, activeWindowFrame: nil)
-        engine.setPreselection(.down, in: ws)
+        engine.setPreselection(.up, in: ws)
         _ = engine.addWindow(token: top, to: ws, activeWindowFrame: nil)
         _ = engine.calculateLayout(for: ws, screen: screen)
         XCTAssertEqual(engine.root(for: ws)?.splitOrientation, .vertical)
@@ -91,7 +91,7 @@ final class DwindleInteractiveResizeTests: XCTestCase {
         _ = engine.addWindow(token: leaf1, to: ws, activeWindowFrame: nil)
         _ = engine.addWindow(token: other, to: ws, activeWindowFrame: nil)
         engine.setSelectedNode(engine.findNode(for: leaf1, in: ws), in: ws)
-        engine.setPreselection(.down, in: ws)
+        engine.setPreselection(.up, in: ws)
         _ = engine.addWindow(token: leaf3, to: ws, activeWindowFrame: nil)
         _ = engine.calculateLayout(for: ws, screen: screen)
 


### PR DESCRIPTION
Fixes #515 

## Problem

In the Dwindle layout, the vertical half of the two-step window move is inverted: after stacking onto a neighbor, splitting out with move-down places the window *above* it, and move-up places it *below*. With w2 above w1, pressing move-down twice leaves w2 still on top. Horizontal moves are correct, and focus navigation is correct in all four directions, so the move gesture visibly disagrees with focus on the same layout. Split preselection shares the fault: preselecting up opens the new window below, and vice versa.

## Approach

The world model uses AppKit y-up frames, and the Dwindle geometry code is consistent about it: `splitRect` gives the first child of a vertical split the bottom half, and `findGeometricNeighbor` treats larger Y as up (which is why focus and the grouping step behave correctly). The one dissenter was `splitLeaf`'s preselected placement, which mapped `.up` to the first child - i.e. it assumed the first child is the top. The fix maps `.down` to the first child instead (one line in `DwindleLayoutEngine`). `ungroupWindow` and preselection both flow through this path, so both are fixed together.

Several test fixtures had compensated for the inversion - visibly so: a helper named `addSpatialNeighborBelowGroup` preselected `.up`, and the `preselection(for:)` helper mirrored left/right but passed up/down through unchanged. Those fixtures now use the geometrically true direction, and the now-identity `containerNeighborPreselection` helper is removed.

## Behavior change

- Move-down out of a stacked pair now lands the window below its neighbor; move-up lands it above. Horizontal moves are unchanged.
- Vertical split preselection now opens the new window on the preselected side.

## Verification

- New regression test `testUngroupPlacesWindowOnRequestedSideOfFormerGroup` drives the same engine seam as the move hotkey (group into neighbor, then ungroup in a direction) and asserts the resulting frames land on the requested side, cross-checked against `findGeometricNeighbor` - the oracle focus navigation uses. It fails against the old code on up/down and passes on left/right.
- Full suite passes (1597 tests, 0 failures); `make verify` (format-check, lint, build with the real GhosttyKit archive) is green.
- Manually confirmed end to end in the running app: two-window vertical move sequence now places the window on the pressed side.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected directional window placement when creating preselected splits.
  * Fixed grouping and ungrouping behavior so windows remain on the requested side.
  * Improved spatial navigation and interactive resizing consistency across directions.

* **Tests**
  * Expanded coverage for directional placement, grouping, focus movement, and resize behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->