### PR TITLE
Make Hyper key modifier composition configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -458,7 +458,7 @@ Use the `Toggle Workspace Layout` shortcut below to switch layouts per workspace
 
 ### Keyboard Shortcuts
 
-All shortcuts are customizable in Settings > Hotkeys. `Hyper` is the literal `Control + Option + Shift + Command` chord. Optionally pick a **System Hyper Trigger** — a single key (Caps Lock, F13–F20, or a left- or right-side modifier) or an extra mouse button that acts as `Hyper` while held (this needs Input Monitoring permission). Leave the trigger as `None` if you already produce `Hyper` another way, such as a Karabiner Elements remap. The tables below list all the default hotkeys:
+All shortcuts are customizable in Settings > Hotkeys. `Hyper` is the literal `Control + Option + Shift + Command` chord by default; which modifiers make up `Hyper` is configurable in Settings > Hotkeys (for example, exclude `Shift` to keep `Hyper + Shift + …` free for extra bindings). Optionally pick a **System Hyper Trigger** — a single key (Caps Lock, F13–F20, or a left- or right-side modifier) or an extra mouse button that acts as `Hyper` while held (this needs Input Monitoring permission). Leave the trigger as `None` if you already produce `Hyper` another way, such as a Karabiner Elements remap. The tables below list all the default hotkeys:
 
 Layout legend:
 - `Shared` works in any active layout.

--- a/Sources/OmniWM/Core/Config/CanonicalTOMLConfig.swift
+++ b/Sources/OmniWM/Core/Config/CanonicalTOMLConfig.swift
@@ -37,6 +37,7 @@ struct CanonicalTOMLConfig: Codable, Equatable {
     struct General: Codable, Equatable {
         var hotkeysEnabled: Bool
         var systemHyperTrigger: SystemHyperTrigger
+        var hyperKeyModifiers: HyperKeyModifiers
         var defaultLayoutType: String
         var preventSleepEnabled: Bool
         var updateChecksEnabled: Bool
@@ -288,6 +289,22 @@ private extension KeyedDecodingContainer {
             return defaultValue
         }
     }
+
+    func decodeHyperKeyModifiers(
+        forKey key: Key,
+        default defaultValue: HyperKeyModifiers,
+        recovering: Bool
+    ) throws -> HyperKeyModifiers {
+        do {
+            return try decode(HyperKeyModifiers.self, forKey: key)
+        } catch DecodingError.dataCorrupted {
+            return defaultValue
+        } catch DecodingError.keyNotFound(_, _) where recovering {
+            return defaultValue
+        } catch DecodingError.valueNotFound(_, _) where recovering {
+            return defaultValue
+        }
+    }
 }
 
 private extension CanonicalTOMLConfig {
@@ -308,6 +325,9 @@ extension CanonicalTOMLConfig {
             default: defaults.general,
             recovering: recovering
         )
+        // "Hyper" aliases in the hotkeys table resolve against the configured composition,
+        // so it must be active before the hotkey bindings decode below.
+        KeySymbolMapper.setHyperKeyModifiers(general.hyperKeyModifiers)
         focus = try container.decode(Focus.self, forKey: .focus, default: defaults.focus, recovering: recovering)
         mouseWarp = try container.decode(
             MouseWarp.self,
@@ -456,6 +476,11 @@ extension CanonicalTOMLConfig.General {
         systemHyperTrigger = try container.decodeSystemHyperTrigger(
             forKey: .systemHyperTrigger,
             default: defaults.systemHyperTrigger,
+            recovering: recovering
+        )
+        hyperKeyModifiers = try container.decodeHyperKeyModifiers(
+            forKey: .hyperKeyModifiers,
+            default: defaults.hyperKeyModifiers,
             recovering: recovering
         )
         defaultLayoutType = try container.decode(
@@ -1130,6 +1155,7 @@ extension CanonicalTOMLConfig {
         general = General(
             hotkeysEnabled: export.hotkeysEnabled,
             systemHyperTrigger: export.systemHyperTrigger,
+            hyperKeyModifiers: export.hyperKeyModifiers,
             defaultLayoutType: export.defaultLayoutType,
             preventSleepEnabled: export.preventSleepEnabled,
             updateChecksEnabled: export.updateChecksEnabled,
@@ -1312,6 +1338,7 @@ extension CanonicalTOMLConfig {
             overviewSelectedBorderColor: overview.windowBorders.selected.settingsColor,
             hotkeyBindings: hotkeys,
             systemHyperTrigger: general.systemHyperTrigger,
+            hyperKeyModifiers: general.hyperKeyModifiers,
             workspaceBarEnabled: workspaceBar.enabled,
             workspaceBarShowLabels: workspaceBar.showLabels,
             workspaceBarShowFloatingWindows: workspaceBar.showFloatingWindows,

--- a/Sources/OmniWM/Core/Config/CanonicalTOMLConfig.swift
+++ b/Sources/OmniWM/Core/Config/CanonicalTOMLConfig.swift
@@ -274,29 +274,14 @@ private extension KeyedDecodingContainer {
         return try decode(superDecoder(forKey: key), defaultValue, recovering)
     }
 
-    func decodeSystemHyperTrigger(
+    func decodeRecoveringInvalidValue<T: Decodable>(
+        _ type: T.Type,
         forKey key: Key,
-        default defaultValue: SystemHyperTrigger,
+        default defaultValue: T,
         recovering: Bool
-    ) throws -> SystemHyperTrigger {
+    ) throws -> T {
         do {
-            return try decode(SystemHyperTrigger.self, forKey: key)
-        } catch DecodingError.dataCorrupted {
-            return defaultValue
-        } catch DecodingError.keyNotFound(_, _) where recovering {
-            return defaultValue
-        } catch DecodingError.valueNotFound(_, _) where recovering {
-            return defaultValue
-        }
-    }
-
-    func decodeHyperKeyModifiers(
-        forKey key: Key,
-        default defaultValue: HyperKeyModifiers,
-        recovering: Bool
-    ) throws -> HyperKeyModifiers {
-        do {
-            return try decode(HyperKeyModifiers.self, forKey: key)
+            return try decode(type, forKey: key)
         } catch DecodingError.dataCorrupted {
             return defaultValue
         } catch DecodingError.keyNotFound(_, _) where recovering {
@@ -473,12 +458,14 @@ extension CanonicalTOMLConfig.General {
             default: defaults.hotkeysEnabled,
             recovering: recovering
         )
-        systemHyperTrigger = try container.decodeSystemHyperTrigger(
+        systemHyperTrigger = try container.decodeRecoveringInvalidValue(
+            SystemHyperTrigger.self,
             forKey: .systemHyperTrigger,
             default: defaults.systemHyperTrigger,
             recovering: recovering
         )
-        hyperKeyModifiers = try container.decodeHyperKeyModifiers(
+        hyperKeyModifiers = try container.decodeRecoveringInvalidValue(
+            HyperKeyModifiers.self,
             forKey: .hyperKeyModifiers,
             default: defaults.hyperKeyModifiers,
             recovering: recovering

--- a/Sources/OmniWM/Core/Config/SettingsExport.swift
+++ b/Sources/OmniWM/Core/Config/SettingsExport.swift
@@ -58,6 +58,7 @@ struct SettingsExport: Equatable {
 
     var hotkeyBindings: [HotkeyBinding]
     var systemHyperTrigger: SystemHyperTrigger
+    var hyperKeyModifiers: HyperKeyModifiers
 
     var workspaceBarEnabled: Bool
     var workspaceBarShowLabels: Bool
@@ -181,6 +182,7 @@ extension SettingsExport {
             overviewSelectedBorderColor: SettingsColor(red: 0.3, green: 0.8, blue: 0.4, alpha: 1.0),
             hotkeyBindings: HotkeyBindingRegistry.defaults(),
             systemHyperTrigger: .default,
+            hyperKeyModifiers: .default,
             workspaceBarEnabled: true,
             workspaceBarShowLabels: true,
             workspaceBarShowFloatingWindows: false,

--- a/Sources/OmniWM/Core/Config/SettingsStore.swift
+++ b/Sources/OmniWM/Core/Config/SettingsStore.swift
@@ -210,6 +210,21 @@ final class SettingsStore {
         didSet { scheduleSave() }
     }
 
+    private var hyperKeyModifiersStorage = SettingsStore.defaultExport.hyperKeyModifiers
+
+    var hyperKeyModifiers: HyperKeyModifiers {
+        get { hyperKeyModifiersStorage }
+        set { applyHyperKeyModifiers(newValue) }
+    }
+
+    private func applyHyperKeyModifiers(_ newValue: HyperKeyModifiers) {
+        guard newValue != hyperKeyModifiersStorage else { return }
+        let retargeted = HotkeyBindingRegistry.retargetingHyperChords(hotkeyBindings, to: newValue)
+        hyperKeyModifiersStorage = newValue
+        hotkeyBindings = retargeted
+        scheduleSave()
+    }
+
     var workspaceBarEnabled = SettingsStore.defaultExport.workspaceBarEnabled {
         didSet { scheduleSave() }
     }
@@ -712,6 +727,7 @@ final class SettingsStore {
             overviewSelectedBorderColor: overviewSelectedBorderColor,
             hotkeyBindings: hotkeyBindings,
             systemHyperTrigger: systemHyperTrigger,
+            hyperKeyModifiers: hyperKeyModifiersStorage,
             workspaceBarEnabled: workspaceBarEnabled,
             workspaceBarShowLabels: workspaceBarShowLabels,
             workspaceBarShowFloatingWindows: workspaceBarShowFloatingWindows,
@@ -849,6 +865,8 @@ final class SettingsStore {
             default: baseline.overviewSelectedBorderColor
         )
 
+        hyperKeyModifiersStorage = export.hyperKeyModifiers
+        KeySymbolMapper.setHyperKeyModifiers(export.hyperKeyModifiers)
         hotkeyBindings = export.hotkeyBindings
         systemHyperTrigger = export.systemHyperTrigger
 
@@ -968,6 +986,7 @@ final class SettingsStore {
     }
 
     func resetHotkeysToDefaults() {
+        hyperKeyModifiers = SettingsStore.defaultExport.hyperKeyModifiers
         hotkeyBindings = HotkeyBindingRegistry.defaults()
         systemHyperTrigger = SettingsStore.defaultExport.systemHyperTrigger
     }

--- a/Sources/OmniWM/Core/Config/SettingsTOMLCodec.swift
+++ b/Sources/OmniWM/Core/Config/SettingsTOMLCodec.swift
@@ -45,6 +45,20 @@ enum SettingsTOMLCodec {
     }
 
     static func decode(_ data: Data) throws -> SettingsExport {
+        let previousHyperKeyModifiers = KeySymbolMapper.hyperModifiers
+        do {
+            return try decodeCanonical(from: data)
+        } catch {
+            // CanonicalTOMLConfig.init applies the decoded Hyper composition before the
+            // hotkeys table parses; a rejected decode must not leave it active.
+            KeySymbolMapper.setHyperKeyModifiers(
+                HyperKeyModifiers(carbonMask: previousHyperKeyModifiers) ?? .default
+            )
+            throw error
+        }
+    }
+
+    private static func decodeCanonical(from data: Data) throws -> SettingsExport {
         do {
             let canonical = try TOMLDecoder().decode(CanonicalTOMLConfig.self, from: data)
             return canonical.toSettingsExport()

--- a/Sources/OmniWM/Core/Input/HotkeyBinding.swift
+++ b/Sources/OmniWM/Core/Input/HotkeyBinding.swift
@@ -248,6 +248,84 @@ extension SystemHyperTrigger: Codable {
     }
 }
 
+struct HyperKeyModifiers: Equatable, Hashable, Sendable {
+    static let allModifierFlags: [UInt32] = [
+        UInt32(controlKey), UInt32(optionKey), UInt32(shiftKey), UInt32(cmdKey)
+    ]
+    static let minimumModifierCount = 2
+    static let `default` = HyperKeyModifiers(
+        uncheckedCarbonMask: UInt32(controlKey | optionKey | shiftKey | cmdKey)
+    )
+
+    let carbonMask: UInt32
+
+    private init(uncheckedCarbonMask: UInt32) {
+        carbonMask = uncheckedCarbonMask
+    }
+
+    init?(carbonMask: UInt32) {
+        let allowedMask = Self.allModifierFlags.reduce(UInt32(0)) { $0 | $1 }
+        guard carbonMask & ~allowedMask == 0,
+              Self.modifierCount(of: carbonMask) >= Self.minimumModifierCount
+        else { return nil }
+        self.carbonMask = carbonMask
+    }
+
+    var modifierCount: Int {
+        Self.modifierCount(of: carbonMask)
+    }
+
+    func contains(_ flag: UInt32) -> Bool {
+        carbonMask & flag != 0
+    }
+
+    func setting(_ flag: UInt32, included: Bool) -> HyperKeyModifiers? {
+        HyperKeyModifiers(carbonMask: included ? carbonMask | flag : carbonMask & ~flag)
+    }
+
+    var humanReadableString: String {
+        KeySymbolMapper.literalModifierNames(carbonMask).joined(separator: "+")
+    }
+
+    var symbolsString: String {
+        KeySymbolMapper.literalModifierSymbols(carbonMask)
+    }
+
+    static func fromHumanReadable(_ string: String) -> HyperKeyModifiers? {
+        var mask: UInt32 = 0
+        for part in string.components(separatedBy: "+") {
+            let name = part.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !name.isEmpty, let flag = KeySymbolMapper.baseModifierFlag(named: name) else { return nil }
+            mask |= flag
+        }
+        return HyperKeyModifiers(carbonMask: mask)
+    }
+
+    private static func modifierCount(of mask: UInt32) -> Int {
+        allModifierFlags.count { mask & $0 != 0 }
+    }
+}
+
+extension HyperKeyModifiers: Codable {
+    init(from decoder: Decoder) throws {
+        if let container = try? decoder.singleValueContainer(),
+           let string = try? container.decode(String.self),
+           let modifiers = HyperKeyModifiers.fromHumanReadable(string)
+        {
+            self = modifiers
+            return
+        }
+        throw DecodingError.dataCorrupted(
+            .init(codingPath: decoder.codingPath, debugDescription: "Invalid Hyper key modifiers")
+        )
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(humanReadableString)
+    }
+}
+
 enum HotkeyTrigger: Equatable, Hashable {
     case unassigned
     case chord(KeyBinding)
@@ -450,6 +528,23 @@ enum HotkeyBindingRegistry {
             return .unassigned
         case let .chord(binding):
             return binding.isUnassigned ? .unassigned : .chord(binding)
+        }
+    }
+
+    /// Re-resolves Hyper-aliased chords against a new composition and applies it as the
+    /// active composition. Encoding must happen before the switch so chords recorded as
+    /// "Hyper+..." under the outgoing composition retarget to the incoming one.
+    static func retargetingHyperChords(
+        _ bindings: [HotkeyBinding],
+        to composition: HyperKeyModifiers
+    ) -> [HotkeyBinding] {
+        let encoded = bindings.map { ($0, $0.binding.humanReadableString) }
+        KeySymbolMapper.setHyperKeyModifiers(composition)
+        return encoded.map { binding, string in
+            guard case .chord = binding.binding,
+                  let trigger = HotkeyTrigger.fromHumanReadable(string)
+            else { return binding }
+            return HotkeyBinding(id: binding.id, command: binding.command, trigger: trigger)
         }
     }
 }

--- a/Sources/OmniWM/Core/Input/Hotkeys.swift
+++ b/Sources/OmniWM/Core/Input/Hotkeys.swift
@@ -217,11 +217,12 @@ final class HotkeyCenter {
     private(set) var registrationFailures: [HotkeyCommand: HotkeyRegistrationFailureReason] = [:]
     private(set) var systemHyperTriggerFailure: SystemHyperTriggerFailure?
 
-    private static let hyperFlagMask: UInt64 =
-        CGEventFlags.maskCommand.rawValue |
-        CGEventFlags.maskControl.rawValue |
-        CGEventFlags.maskAlternate.rawValue |
-        CGEventFlags.maskShift.rawValue
+    private static var hyperFlagMask: UInt64 {
+        let hyper = KeySymbolMapper.hyperModifiers
+        return ModifierFlagMask.all.reduce(UInt64(0)) { mask, flag in
+            hyper & flag.carbon != 0 ? mask | flag.independent : mask
+        }
+    }
 
     var isHyperTriggerActive: Bool {
         hyperTrigger.isActive

--- a/Sources/OmniWM/Core/Input/KeySymbolMapper.swift
+++ b/Sources/OmniWM/Core/Input/KeySymbolMapper.swift
@@ -3,6 +3,7 @@
 
 import Carbon
 import Foundation
+import Synchronization
 
 enum KeySymbolMapper {
     private struct KeyDescriptor {
@@ -125,7 +126,17 @@ enum KeySymbolMapper {
         UInt32(kVK_ANSI_KeypadEquals): descriptor("KP=", "Keypad Equals")
     ]
 
-    static let hyperModifiers = UInt32(controlKey | optionKey | shiftKey | cmdKey)
+    private static let hyperModifiersStorage = Atomic<UInt32>(HyperKeyModifiers.default.carbonMask)
+
+    /// The carbon modifier mask the "Hyper" alias currently resolves to. Reads happen from
+    /// nonisolated contexts (Codable, display); writes go through `setHyperKeyModifiers`.
+    static var hyperModifiers: UInt32 {
+        hyperModifiersStorage.load(ordering: .relaxed)
+    }
+
+    static func setHyperKeyModifiers(_ modifiers: HyperKeyModifiers) {
+        hyperModifiersStorage.store(modifiers.carbonMask, ordering: .relaxed)
+    }
 
     private struct ModifierDescriptor {
         let carbon: UInt32
@@ -141,9 +152,10 @@ enum KeySymbolMapper {
     ]
 
     static func modifierSymbols(_ modifiers: UInt32, sides: SidedModifiers = .none) -> String {
-        if sides.isEmpty, modifiers == hyperModifiers { return "Hyper+" }
-        var symbols = ""
-        for modifier in orderedModifiers where modifiers & modifier.carbon != 0 {
+        let useHyperSugar = sides.isEmpty && modifiers & hyperModifiers == hyperModifiers
+        let plainModifiers = useHyperSugar ? modifiers & ~hyperModifiers : modifiers
+        var symbols = useHyperSugar ? "Hyper+" : ""
+        for modifier in orderedModifiers where plainModifiers & modifier.carbon != 0 {
             switch sides.side(for: modifier.carbon) {
             case .either: symbols += modifier.symbol
             case .left: symbols += "L" + modifier.symbol
@@ -174,9 +186,10 @@ enum KeySymbolMapper {
     }
 
     static func modifierNames(_ modifiers: UInt32, sides: SidedModifiers = .none) -> String {
-        if sides.isEmpty, modifiers == hyperModifiers { return "Hyper" }
-        var names: [String] = []
-        for modifier in orderedModifiers where modifiers & modifier.carbon != 0 {
+        let useHyperSugar = sides.isEmpty && modifiers & hyperModifiers == hyperModifiers
+        let plainModifiers = useHyperSugar ? modifiers & ~hyperModifiers : modifiers
+        var names: [String] = useHyperSugar ? ["Hyper"] : []
+        for modifier in orderedModifiers where plainModifiers & modifier.carbon != 0 {
             switch sides.side(for: modifier.carbon) {
             case .either: names.append(modifier.name)
             case .left: names.append("Left " + modifier.name)
@@ -216,8 +229,7 @@ enum KeySymbolMapper {
         "Control": UInt32(controlKey),
         "Option": UInt32(optionKey),
         "Shift": UInt32(shiftKey),
-        "Command": UInt32(cmdKey),
-        "Hyper": hyperModifiers
+        "Command": UInt32(cmdKey)
     ]
 
     private static let normalizedNameToModifier: [String: UInt32] = {
@@ -250,8 +262,23 @@ enum KeySymbolMapper {
         )
     }
 
+    static func baseModifierFlag(named name: String) -> UInt32? {
+        nameToModifier[name] ?? normalizedNameToModifier[normalizeName(name)]
+    }
+
+    static func literalModifierNames(_ modifiers: UInt32) -> [String] {
+        orderedModifiers.filter { modifiers & $0.carbon != 0 }.map(\.name)
+    }
+
+    static func literalModifierSymbols(_ modifiers: UInt32) -> String {
+        orderedModifiers.filter { modifiers & $0.carbon != 0 }.map(\.symbol).joined()
+    }
+
     static func modifierToken(named name: String) -> (flag: UInt32, side: ModifierSide)? {
-        if let flag = nameToModifier[name] ?? normalizedNameToModifier[normalizeName(name)] {
+        if normalizeName(name) == "hyper" {
+            return (hyperModifiers, .either)
+        }
+        if let flag = baseModifierFlag(named: name) {
             return (flag, .either)
         }
         let normalized = normalizeName(name)

--- a/Sources/OmniWM/UI/HotkeySettingsView.swift
+++ b/Sources/OmniWM/UI/HotkeySettingsView.swift
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0-only
 // Copyright (C) 2026 BarutSRB — https://github.com/BarutSRB/OmniWM
 
+import Carbon
 import SwiftUI
 
 enum HotkeyCaptureResult {
@@ -175,8 +176,25 @@ struct HotkeySettingsView: View {
                     SettingsCaption(systemHyperTriggerFailureMessage(triggerFailure))
                 }
                 SettingsCaption(
-                    "Hold this key or button to act as ⌃⌥⇧⌘ (Hyper). Needs Input Monitoring permission. "
+                    "Hold this key or button to act as \(settings.hyperKeyModifiers.symbolsString) (Hyper). "
+                        + "Needs Input Monitoring permission. "
                         + "Leave as None to use a Hyper key set up elsewhere, such as Karabiner."
+                )
+
+                LabeledContent("Hyper Key Modifiers") {
+                    HStack(spacing: 12) {
+                        hyperModifierToggle("⌃ Control", flag: UInt32(controlKey))
+                        hyperModifierToggle("⌥ Option", flag: UInt32(optionKey))
+                        hyperModifierToggle("⇧ Shift", flag: UInt32(shiftKey))
+                        hyperModifierToggle("⌘ Command", flag: UInt32(cmdKey))
+                    }
+                    .onChange(of: settings.hyperKeyModifiers) { _, _ in
+                        controller.updateHotkeyBindings(settings.hotkeyBindings, force: true)
+                    }
+                }
+                SettingsCaption(
+                    "Modifiers that make up the Hyper chord. Unchecked modifiers stay free to combine "
+                        + "with Hyper in shortcuts, such as Hyper+Shift when Shift is excluded."
                 )
 
                 LabeledContent("Input Monitoring") {
@@ -315,6 +333,21 @@ struct HotkeySettingsView: View {
 
     private func startChordRecording(for actionId: String) {
         recordingTarget = .chord(actionId)
+    }
+
+    private func hyperModifierToggle(_ title: String, flag: UInt32) -> some View {
+        Toggle(title, isOn: Binding(
+            get: { settings.hyperKeyModifiers.contains(flag) },
+            set: { included in
+                guard let updated = settings.hyperKeyModifiers.setting(flag, included: included) else { return }
+                settings.hyperKeyModifiers = updated
+            }
+        ))
+        .disabled(
+            settings.hyperKeyModifiers.contains(flag)
+                && settings.hyperKeyModifiers.modifierCount <= HyperKeyModifiers.minimumModifierCount
+        )
+        .accessibilityLabel("Hyper includes \(title)")
     }
 
     private func systemHyperTriggerFailureMessage(_ failure: SystemHyperTriggerFailure) -> String {

--- a/Tests/OmniWMTests/HotkeyChordTests.swift
+++ b/Tests/OmniWMTests/HotkeyChordTests.swift
@@ -161,6 +161,21 @@ final class HotkeyChordTests: XCTestCase {
         )
     }
 
+    func testFailedTOMLDecodeRestoresHyperComposition() {
+        defer { KeySymbolMapper.setHyperKeyModifiers(.default) }
+        let toml = """
+        [general]
+        hyperKeyModifiers = "Control+Option+Command"
+
+        [[hotkeys]]
+        binding = "NotAKey+1"
+        id = "focus.left"
+        """
+
+        XCTAssertThrowsError(try SettingsTOMLCodec.decode(Data(toml.utf8)))
+        XCTAssertEqual(KeySymbolMapper.hyperModifiers, HyperKeyModifiers.default.carbonMask)
+    }
+
     private func withHyperComposition(_ composition: String, _ body: () throws -> Void) throws {
         let modifiers = try XCTUnwrap(HyperKeyModifiers.fromHumanReadable(composition))
         KeySymbolMapper.setHyperKeyModifiers(modifiers)

--- a/Tests/OmniWMTests/HotkeyChordTests.swift
+++ b/Tests/OmniWMTests/HotkeyChordTests.swift
@@ -39,11 +39,133 @@ final class HotkeyChordTests: XCTestCase {
         XCTAssertEqual(KeySymbolMapper.fromHumanReadable("Hyper+1"), binding)
     }
 
-    func testHyperAliasEqualsLiteralFourModifiers() {
+    func testHyperAliasEqualsLiteralFourModifiersByDefault() {
         XCTAssertEqual(
             KeySymbolMapper.fromHumanReadable("Control+Option+Shift+Command+1"),
             KeySymbolMapper.fromHumanReadable("Hyper+1")
         )
+    }
+
+    func testConfiguredHyperAliasEqualsLiteralThreeModifiers() throws {
+        try withHyperComposition("Control+Option+Command") {
+            XCTAssertEqual(
+                KeySymbolMapper.fromHumanReadable("Control+Option+Command+1"),
+                KeySymbolMapper.fromHumanReadable("Hyper+1")
+            )
+        }
+    }
+
+    func testConfiguredHyperShiftAliasEqualsLiteralFourModifiers() throws {
+        try withHyperComposition("Control+Option+Command") {
+            XCTAssertEqual(
+                KeySymbolMapper.fromHumanReadable("Control+Option+Shift+Command+1"),
+                KeySymbolMapper.fromHumanReadable("Hyper+Shift+1")
+            )
+        }
+    }
+
+    func testConfiguredHyperShiftDisplaySugarRoundTrips() throws {
+        try withHyperComposition("Control+Option+Command") {
+            let binding = KeyBinding(
+                keyCode: UInt32(kVK_ANSI_1),
+                modifiers: KeySymbolMapper.hyperModifiers | UInt32(shiftKey)
+            )
+
+            XCTAssertEqual(binding.humanReadableString, "Hyper+Shift+1")
+            XCTAssertEqual(binding.displayString, "Hyper+⇧1")
+            XCTAssertEqual(KeySymbolMapper.fromHumanReadable("Hyper+Shift+1"), binding)
+        }
+    }
+
+    func testHyperKeyModifiersParsingAndValidation() {
+        XCTAssertEqual(
+            HyperKeyModifiers.fromHumanReadable("Control+Option+Command")?.carbonMask,
+            UInt32(controlKey | optionKey | cmdKey)
+        )
+        XCTAssertEqual(
+            HyperKeyModifiers.fromHumanReadable("command + shift")?.carbonMask,
+            UInt32(cmdKey | shiftKey)
+        )
+        XCTAssertNil(HyperKeyModifiers.fromHumanReadable("Control"))
+        XCTAssertNil(HyperKeyModifiers.fromHumanReadable(""))
+        XCTAssertNil(HyperKeyModifiers.fromHumanReadable("Hyper+Command"))
+        XCTAssertNil(HyperKeyModifiers.fromHumanReadable("Control+Q"))
+        XCTAssertNil(HyperKeyModifiers(carbonMask: UInt32(shiftKey)))
+    }
+
+    func testHyperKeyModifiersCodableRoundTrips() throws {
+        let modifiers = try XCTUnwrap(HyperKeyModifiers.fromHumanReadable("Control+Option+Command"))
+        let data = try JSONEncoder().encode(modifiers)
+
+        XCTAssertEqual(String(decoding: data, as: UTF8.self), "\"Control+Option+Command\"")
+        XCTAssertEqual(try JSONDecoder().decode(HyperKeyModifiers.self, from: data), modifiers)
+        XCTAssertThrowsError(try JSONDecoder().decode(HyperKeyModifiers.self, from: Data(#""Control""#.utf8)))
+    }
+
+    func testRetargetingHyperChordsFollowsComposition() throws {
+        defer { KeySymbolMapper.setHyperKeyModifiers(.default) }
+
+        let threeModifiers = try XCTUnwrap(HyperKeyModifiers.fromHumanReadable("Control+Option+Command"))
+        let hyperBound = try XCTUnwrap(HotkeyBindingRegistry.makeBinding(
+            id: "focus.left",
+            binding: KeyBinding(keyCode: UInt32(kVK_ANSI_H), modifiers: KeySymbolMapper.hyperModifiers)
+        ))
+        let literalBound = try XCTUnwrap(HotkeyBindingRegistry.makeBinding(
+            id: "focus.right",
+            binding: KeyBinding(keyCode: UInt32(kVK_ANSI_L), modifiers: UInt32(optionKey))
+        ))
+
+        let retargeted = HotkeyBindingRegistry.retargetingHyperChords([hyperBound, literalBound], to: threeModifiers)
+
+        XCTAssertEqual(
+            retargeted[0].binding,
+            .chord(KeyBinding(keyCode: UInt32(kVK_ANSI_H), modifiers: UInt32(controlKey | optionKey | cmdKey)))
+        )
+        XCTAssertEqual(retargeted[1].binding, literalBound.binding)
+
+        let restored = HotkeyBindingRegistry.retargetingHyperChords(retargeted, to: .default)
+        XCTAssertEqual(restored[0].binding, hyperBound.binding)
+        XCTAssertEqual(restored[1].binding, literalBound.binding)
+    }
+
+    func testTOMLDecodeAppliesHyperCompositionBeforeHotkeys() throws {
+        defer { KeySymbolMapper.setHyperKeyModifiers(.default) }
+        let toml = """
+        [general]
+        hyperKeyModifiers = "Control+Option+Command"
+
+        [[hotkeys]]
+        binding = "Hyper+H"
+        id = "focus.left"
+
+        [[hotkeys]]
+        binding = "Hyper+Shift+H"
+        id = "focus.right"
+        """
+
+        let export = try SettingsTOMLCodec.decode(Data(toml.utf8))
+
+        XCTAssertEqual(export.hyperKeyModifiers.humanReadableString, "Control+Option+Command")
+        let left = try XCTUnwrap(export.hotkeyBindings.first { $0.id == "focus.left" })
+        XCTAssertEqual(
+            left.binding,
+            .chord(KeyBinding(keyCode: UInt32(kVK_ANSI_H), modifiers: UInt32(controlKey | optionKey | cmdKey)))
+        )
+        let right = try XCTUnwrap(export.hotkeyBindings.first { $0.id == "focus.right" })
+        XCTAssertEqual(
+            right.binding,
+            .chord(KeyBinding(
+                keyCode: UInt32(kVK_ANSI_H),
+                modifiers: UInt32(controlKey | optionKey | shiftKey | cmdKey)
+            ))
+        )
+    }
+
+    private func withHyperComposition(_ composition: String, _ body: () throws -> Void) throws {
+        let modifiers = try XCTUnwrap(HyperKeyModifiers.fromHumanReadable(composition))
+        KeySymbolMapper.setHyperKeyModifiers(modifiers)
+        defer { KeySymbolMapper.setHyperKeyModifiers(.default) }
+        try body()
     }
 
     func testKeyBindingConflictRequiresIdenticalKeyAndModifiers() {


### PR DESCRIPTION
Closes #535

## Problem

Hyper is hardcoded as the full Control+Option+Shift+Command chord. Because all
four modifiers are consumed, Hyper cannot be combined with anything: binding
Hyper+Shift+1 is the same chord as Hyper+1. That blocks the classic niri/i3
workspace pattern (`Hyper+N` to switch, `Hyper+Shift+N` to move). Related: the
discussion in #382 about what "Hyper" should mean — this makes it explicit and
user-controlled.

## What changed

- **Settings > Hotkeys** gains a "Hyper Key Modifiers" row with four checkboxes
  (⌃ ⌥ ⇧ ⌘). At least two must stay checked. The trigger caption shows the
  live combination.
- **Config**: new `hyperKeyModifiers` key under `[general]`, stored
  human-readable (e.g. `"Control+Option+Command"`), same pattern as
  `systemHyperTrigger`. Absent key → default → existing configs are untouched.
- **Behavior**: the default composition is unchanged (⌃⌥⇧⌘), so nothing moves
  for current users. When a modifier is excluded, it becomes combinable:
  `Hyper+Shift+1` is then a distinct, bindable chord that displays as
  `Hyper+⇧1`.

## Design notes

- `"Hyper+…"` binding strings resolve against the composition at parse time,
  so `CanonicalTOMLConfig` applies the decoded composition immediately after
  the `[general]` section and before the hotkeys table decodes — a saved
  config with a custom composition resolves its bindings correctly on launch.
- Changing the setting live retargets existing Hyper chords
  (`HotkeyBindingRegistry.retargetingHyperChords`: encode under the outgoing
  composition, re-parse under the incoming one) and re-registers hotkeys.
- The system Hyper trigger's event tap injects exactly the configured
  modifiers (`hyperFlagMask` now derives from the composition).
- The active composition lives in an `Atomic<UInt32>` since it is read from
  nonisolated contexts (Codable, display) and written from the main actor.

## Verification

- `swift build` and `swift test` on macOS 26 (arm64): full suite passes.
- New tests in `HotkeyChordTests`: default alias still equals the literal
  four-modifier chord; configured alias equals its literal chord;
  `Hyper+Shift` alias/display round-trips; `HyperKeyModifiers`
  parsing/validation/Codable; live retargeting in both directions; and a TOML
  decode test proving composition applies before hotkey strings parse.
- Running as my daily driver with a `Control+Option+Command` composition and a
  Caps Lock system trigger: recorded `Hyper+1…9` (switch) and
  `Hyper+Shift+1…9` (move) bindings through the settings recorder, and they
  dispatch correctly.

README's hotkeys section is updated to describe the configurable composition.

## Screenshot

_(Settings > Hotkeys — Hyper Key Modifiers row; attached below)_
<img width="1012" height="824" alt="Screenshot 2026-08-05 at 4 53 33 PM" src="https://github.com/user-attachments/assets/cfdb9c4f-2d72-42d9-8813-52f9c1e046f7" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Hyper key modifiers are now configurable in **Settings > Hotkeys**.
  * Choose from Control, Option, Shift, and Command, with at least two modifiers required.
  * Existing hotkeys automatically adapt when the Hyper combination changes.
  * Hyper key settings are preserved in configuration exports and imports.

* **Documentation**
  * Updated keyboard shortcut documentation with configuration guidance and examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->