### PR TITLE
fix: keep focus on a floating window across a workspace round trip

### DIFF
--- a/Sources/OmniWM/Core/Reconcile/ReconcileSnapshot.swift
+++ b/Sources/OmniWM/Core/Reconcile/ReconcileSnapshot.swift
@@ -165,6 +165,7 @@ struct FocusSessionSnapshot: Equatable {
     var pendingManagedFocus: PendingManagedFocusSnapshot = .empty
     var lastTiledFocusedByWorkspace: [WorkspaceDescriptor.ID: WindowToken] = [:]
     var lastFloatingFocusedByWorkspace: [WorkspaceDescriptor.ID: WindowToken] = [:]
+    var lastFocusedByWorkspace: [WorkspaceDescriptor.ID: WindowToken] = [:]
     var lastTiledFocusedToken: WindowToken? = nil
     var tiledFocusHistory: [WindowToken] = []
     var focusLease: FocusPolicyLease? = nil
@@ -195,16 +196,24 @@ extension FocusSessionSnapshot {
         in workspaceId: WorkspaceDescriptor.ID,
         mode: TrackedWindowMode
     ) -> Bool {
+        var changed = false
+        if lastFocusedByWorkspace[workspaceId] != token {
+            lastFocusedByWorkspace[workspaceId] = token
+            changed = true
+        }
         switch mode {
         case .tiling:
-            guard lastTiledFocusedByWorkspace[workspaceId] != token else { return false }
-            lastTiledFocusedByWorkspace[workspaceId] = token
-            return true
+            if lastTiledFocusedByWorkspace[workspaceId] != token {
+                lastTiledFocusedByWorkspace[workspaceId] = token
+                changed = true
+            }
         case .floating:
-            guard lastFloatingFocusedByWorkspace[workspaceId] != token else { return false }
-            lastFloatingFocusedByWorkspace[workspaceId] = token
-            return true
+            if lastFloatingFocusedByWorkspace[workspaceId] != token {
+                lastFloatingFocusedByWorkspace[workspaceId] = token
+                changed = true
+            }
         }
+        return changed
     }
 
     @discardableResult
@@ -232,6 +241,10 @@ extension FocusSessionSnapshot {
                 lastFloatingFocusedByWorkspace[workspaceId] = nil
                 changed = true
             }
+            if lastFocusedByWorkspace[workspaceId] == token {
+                lastFocusedByWorkspace[workspaceId] = nil
+                changed = true
+            }
             return changed
         }
 
@@ -241,6 +254,10 @@ extension FocusSessionSnapshot {
         }
         for (id, rememberedToken) in lastFloatingFocusedByWorkspace where rememberedToken == token {
             lastFloatingFocusedByWorkspace[id] = nil
+            changed = true
+        }
+        for (id, rememberedToken) in lastFocusedByWorkspace where rememberedToken == token {
+            lastFocusedByWorkspace[id] = nil
             changed = true
         }
 
@@ -266,6 +283,10 @@ extension FocusSessionSnapshot {
         }
         for (workspaceId, token) in lastFloatingFocusedByWorkspace where token == oldToken {
             lastFloatingFocusedByWorkspace[workspaceId] = newToken
+            changed = true
+        }
+        for (workspaceId, token) in lastFocusedByWorkspace where token == oldToken {
+            lastFocusedByWorkspace[workspaceId] = newToken
             changed = true
         }
 

--- a/Sources/OmniWM/Core/Reconcile/StateReducer.swift
+++ b/Sources/OmniWM/Core/Reconcile/StateReducer.swift
@@ -266,6 +266,7 @@ enum StateReducer {
             for workspaceId in workspaceIds {
                 focusSession.lastTiledFocusedByWorkspace.removeValue(forKey: workspaceId)
                 focusSession.lastFloatingFocusedByWorkspace.removeValue(forKey: workspaceId)
+                focusSession.lastFocusedByWorkspace.removeValue(forKey: workspaceId)
             }
             setFocusSession(focusSession, current: currentSnapshot.focusSession, plan: &plan)
 

--- a/Sources/OmniWM/Core/Workspace/WorkspaceManager.swift
+++ b/Sources/OmniWM/Core/Workspace/WorkspaceManager.swift
@@ -1344,12 +1344,14 @@ final class WorkspaceManager {
     @discardableResult
     func rememberFocus(_ token: WindowToken, in workspaceId: WorkspaceDescriptor.ID) -> Bool {
         let mode = windowMode(for: token) ?? .tiling
-        let changed = switch mode {
+        let modeSpecificChanged = switch mode {
         case .tiling:
             world.focus.lastTiledFocusedByWorkspace[workspaceId] != token
         case .floating:
             world.focus.lastFloatingFocusedByWorkspace[workspaceId] != token
         }
+        let changed = world.focus.lastFocusedByWorkspace[workspaceId] != token
+            || modeSpecificChanged
         guard changed else { return false }
         recordReconcileEvent(
             .focusRemembered(

--- a/Sources/OmniWM/Core/Workspace/WorkspaceManager.swift
+++ b/Sources/OmniWM/Core/Workspace/WorkspaceManager.swift
@@ -268,6 +268,7 @@ final class WorkspaceManager {
         let current = world.focus
         return current.lastTiledFocusedByWorkspace != previous.lastTiledFocusedByWorkspace
             || current.lastFloatingFocusedByWorkspace != previous.lastFloatingFocusedByWorkspace
+            || current.lastFocusedByWorkspace != previous.lastFocusedByWorkspace
             || current.lastTiledFocusedToken != previous.lastTiledFocusedToken
             || current.nonManagedFocusToken != previous.nonManagedFocusToken
             || current.suppressedFocusToken != previous.suppressedFocusToken
@@ -1482,6 +1483,13 @@ final class WorkspaceManager {
     }
 
     func resolveWorkspaceFocusToken(in workspaceId: WorkspaceDescriptor.ID) -> WindowToken? {
+        if let mostRecent = world.focus.lastFocusedByWorkspace[workspaceId],
+           let mode = windowMode(for: mostRecent),
+           let remembered = eligibleFocusCandidate(mostRecent, in: workspaceId, mode: mode)
+        {
+            return remembered
+        }
+
         if let remembered = eligibleFocusCandidate(
             world.focus.lastTiledFocusedByWorkspace[workspaceId],
             in: workspaceId,
@@ -3272,6 +3280,7 @@ final class WorkspaceManager {
         let rememberedIds = toRemove.filter {
             world.focus.lastTiledFocusedByWorkspace[$0] != nil
                 || world.focus.lastFloatingFocusedByWorkspace[$0] != nil
+                || world.focus.lastFocusedByWorkspace[$0] != nil
         }
         if !rememberedIds.isEmpty {
             recordReconcileEvent(.focusForgotten(workspaceIds: rememberedIds, source: .workspaceManager))

--- a/Tests/OmniWMTests/FloatingFocusMRUTests.swift
+++ b/Tests/OmniWMTests/FloatingFocusMRUTests.swift
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: GPL-2.0-only
+// Copyright (C) 2026 BarutSRB — https://github.com/BarutSRB/OmniWM
+
+import ApplicationServices
+import Foundation
+@testable import OmniWM
+import XCTest
+
+@MainActor
+final class FloatingFocusMRUTests: XCTestCase {
+    func testWorkspaceFocusReturnsToTheFloatingWindowFocusedLast() {
+        let manager = makeManager()
+        let workspaceId = manager.workspaces[0].id
+        let tiled = manager.addWindow(axRef(4001, 11), pid: 4001, windowId: 11, to: workspaceId)
+        let floating = manager.addWindow(
+            axRef(4001, 12),
+            pid: 4001,
+            windowId: 12,
+            to: workspaceId,
+            mode: .floating
+        )
+
+        _ = manager.rememberFocus(tiled, in: workspaceId)
+        _ = manager.rememberFocus(floating, in: workspaceId)
+
+        XCTAssertEqual(manager.resolveWorkspaceFocusToken(in: workspaceId), floating)
+    }
+
+    func testWorkspaceFocusReturnsToTheTiledWindowWhenItWasFocusedLast() {
+        let manager = makeManager()
+        let workspaceId = manager.workspaces[0].id
+        let tiled = manager.addWindow(axRef(4002, 21), pid: 4002, windowId: 21, to: workspaceId)
+        let floating = manager.addWindow(
+            axRef(4002, 22),
+            pid: 4002,
+            windowId: 22,
+            to: workspaceId,
+            mode: .floating
+        )
+
+        _ = manager.rememberFocus(floating, in: workspaceId)
+        _ = manager.rememberFocus(tiled, in: workspaceId)
+
+        XCTAssertEqual(manager.resolveWorkspaceFocusToken(in: workspaceId), tiled)
+    }
+
+    func testRemovingTheMostRecentFloatingWindowFallsBackToTheTiledWindow() {
+        let manager = makeManager()
+        let workspaceId = manager.workspaces[0].id
+        let tiled = manager.addWindow(axRef(4003, 31), pid: 4003, windowId: 31, to: workspaceId)
+        let floating = manager.addWindow(
+            axRef(4003, 32),
+            pid: 4003,
+            windowId: 32,
+            to: workspaceId,
+            mode: .floating
+        )
+
+        _ = manager.rememberFocus(tiled, in: workspaceId)
+        _ = manager.rememberFocus(floating, in: workspaceId)
+        _ = manager.removeWindow(pid: floating.pid, windowId: floating.windowId)
+
+        XCTAssertEqual(manager.resolveWorkspaceFocusToken(in: workspaceId), tiled)
+    }
+
+    func testUnifiedSlotSurvivesAModeChangeOfTheRememberedWindow() {
+        let manager = makeManager()
+        let workspaceId = manager.workspaces[0].id
+        let token = manager.addWindow(
+            axRef(4004, 41),
+            pid: 4004,
+            windowId: 41,
+            to: workspaceId,
+            mode: .floating
+        )
+
+        _ = manager.rememberFocus(token, in: workspaceId)
+        _ = manager.setWindowMode(.tiling, for: token)
+
+        XCTAssertEqual(manager.resolveWorkspaceFocusToken(in: workspaceId), token)
+    }
+
+    private func makeManager() -> WorkspaceManager {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("OmniWMFloatingFocusMRUTests-\(UUID().uuidString)", isDirectory: true)
+        let settings = SettingsStore(
+            persistence: SettingsFilePersistence(
+                directory: root.appendingPathComponent("config", isDirectory: true),
+                startWatching: false,
+                deferSaves: false
+            ),
+            runtimeState: RuntimeStateStore(
+                directory: root.appendingPathComponent("state", isDirectory: true),
+                deferSaves: false
+            ),
+            autosaveEnabled: false
+        )
+        return WorkspaceManager(settings: settings)
+    }
+
+    private func axRef(_ pid: pid_t, _ windowId: Int) -> AXWindowRef {
+        AXWindowRef(element: AXUIElementCreateApplication(pid), windowId: windowId)
+    }
+}

--- a/Tests/OmniWMTests/FloatingFocusMRUTests.swift
+++ b/Tests/OmniWMTests/FloatingFocusMRUTests.swift
@@ -44,6 +44,44 @@ final class FloatingFocusMRUTests: XCTestCase {
         XCTAssertEqual(manager.resolveWorkspaceFocusToken(in: workspaceId), tiled)
     }
 
+    func testRefocusingTheSameTiledWindowAfterAFloatingWindowWins() {
+        let manager = makeManager()
+        let workspaceId = manager.workspaces[0].id
+        let tiled = manager.addWindow(axRef(4005, 51), pid: 4005, windowId: 51, to: workspaceId)
+        let floating = manager.addWindow(
+            axRef(4005, 52),
+            pid: 4005,
+            windowId: 52,
+            to: workspaceId,
+            mode: .floating
+        )
+
+        _ = manager.rememberFocus(tiled, in: workspaceId)
+        _ = manager.rememberFocus(floating, in: workspaceId)
+        _ = manager.rememberFocus(tiled, in: workspaceId)
+
+        XCTAssertEqual(manager.resolveWorkspaceFocusToken(in: workspaceId), tiled)
+    }
+
+    func testRefocusingTheSameFloatingWindowAfterATiledWindowWins() {
+        let manager = makeManager()
+        let workspaceId = manager.workspaces[0].id
+        let tiled = manager.addWindow(axRef(4006, 61), pid: 4006, windowId: 61, to: workspaceId)
+        let floating = manager.addWindow(
+            axRef(4006, 62),
+            pid: 4006,
+            windowId: 62,
+            to: workspaceId,
+            mode: .floating
+        )
+
+        _ = manager.rememberFocus(floating, in: workspaceId)
+        _ = manager.rememberFocus(tiled, in: workspaceId)
+        _ = manager.rememberFocus(floating, in: workspaceId)
+
+        XCTAssertEqual(manager.resolveWorkspaceFocusToken(in: workspaceId), floating)
+    }
+
     func testRemovingTheMostRecentFloatingWindowFallsBackToTheTiledWindow() {
         let manager = makeManager()
         let workspaceId = manager.workspaces[0].id


### PR DESCRIPTION
## Problem

Focus is remembered per workspace in two separate slots, tiled and floating, and
`resolveWorkspaceFocusToken` consults the tiled slot first unconditionally. Focus a floating
window, switch to another workspace, switch back: focus lands on the last tiled window instead, and the floating window drops behind it.

## Approach

Add a mode-agnostic `lastFocusedByWorkspace` slot, maintained alongside the existing two at every mutation point (`rememberFocus`, `clearRememberedFocus`, `replaceRememberedFocus`, `reconcileRememberedFocus`, and `.focusForgotten`), and consult it first.

This mirrors AeroSpace, which keeps a single `mostRecentWindowRecursive` MRU per workspace that floating windows take part in (`Workspace.toLiveFocus`, `focus.swift`).

The two mode-specific slots stay as they are: `preferredFocusToken` feeds the Niri and Dwindle engines, which must never be handed a floating token.

## Behavior change

A workspace round trip restores whichever window was focused last, floating or tiled. Previously it always restored the last tiled window. No change when the workspace has no floating windows.

## Verification

- `FloatingFocusMRUTests` — floating-last and tiled-last both restore correctly; removal and mode change fall back correctly. The floating-last case fails against the previous behavior (returns the tiled token).
- Live on a two-monitor setup via IPC: focus floating -> switch workspace -> switch back restores the floating window; the tiled case still restores the tiled window.
- `make verify` clean; no new test failures against `main`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved workspace focus restoration by remembering the most recently focused window, regardless of whether it is tiled or floating.
  - Returning to a workspace now prioritizes its latest focused window before using fallback choices.
  - Focus memory is correctly cleared when windows or workspaces are removed.
  - Preserved remembered focus when windows change between tiled and floating modes.
- **Tests**
  - Added coverage for recent-focus behavior, fallback handling, and mode changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->