### PR TITLE
fix: rebind a floating window to the monitor it was dragged onto

### DIFF
--- a/Sources/OmniWM/Core/Controller/AXEventHandler+FloatingMonitorMembership.swift
+++ b/Sources/OmniWM/Core/Controller/AXEventHandler+FloatingMonitorMembership.swift
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: GPL-2.0-only
+// Copyright (C) 2026 BarutSRB — https://github.com/BarutSRB/OmniWM
+
+import CoreGraphics
+import Foundation
+
+@MainActor
+extension AXEventHandler {
+    func reassignFloatingWindowToContainingMonitor(
+        entry: WindowState,
+        frame: CGRect
+    ) {
+        guard let controller else { return }
+        let token = entry.token
+        guard controller.workspaceManager.hiddenState(for: token) == nil,
+              !controller.workspaceManager.isScratchpadToken(token),
+              let targetMonitor = frame.center.monitorApproximation(
+                  in: controller.workspaceManager.monitors
+              ),
+              controller.workspaceManager.monitorId(for: entry.workspaceId) != targetMonitor.id,
+              let targetWorkspace = controller.workspaceManager.activeWorkspaceOrFirst(
+                  on: targetMonitor.id
+              ),
+              targetWorkspace.id != entry.workspaceId
+        else {
+            return
+        }
+
+        controller.reassignManagedWindow(token, to: targetWorkspace.id)
+        controller.requestWorkspaceBarRefresh()
+    }
+}

--- a/Sources/OmniWM/Core/Controller/AXEventHandler.swift
+++ b/Sources/OmniWM/Core/Controller/AXEventHandler.swift
@@ -997,11 +997,11 @@ final class AXEventHandler {
         guard isWindowDisplayable(token: token) else { return }
 
         if entry.mode == .floating {
-            if let frame = focusedObservedFrame ?? observedFrame(for: entry) {
-                if shouldSuppressFrameChangedRelayout(for: entry, observedFrame: frame) {
-                    return
-                }
+            if let frame = focusedObservedFrame ?? observedFrame(for: entry),
+               !shouldSuppressFrameChangedRelayout(for: entry, observedFrame: frame)
+            {
                 controller.workspaceManager.updateFloatingGeometry(frame: frame, for: token)
+                reassignFloatingWindowToContainingMonitor(entry: entry, frame: frame)
             }
             return
         }


### PR DESCRIPTION
## Problem

A floating window's workspace is fixed at admission and never revisited when the window moves. Drag one to a second monitor and it stays owned by the workspace it came from, so it is hidden when you switch workspaces on the monitor it left, and ignores switches on the monitor it is actually sitting on.

## Approach

On each floating frame change, re-derive the monitor from the window's centre and rebind the window to that monitor's active workspace, as AeroSpace does in `moveFloatingWindow` (`mouse/moveWithMouse.swift`).

Skipped for hidden and scratchpad windows, and the existing frame-change suppression check still runs first so OmniWM's own writes do not trigger it.

The helper lives in a new `AXEventHandler+FloatingMonitorMembership.swift`: `AXEventHandler.swift` is at its `type_body_length` limit and any addition there fails the lint gate.

## Behavior change

A floating window dragged to another monitor becomes a member of that monitor's active workspace, so it hides and reveals with the workspace it now sits on.

## Verification

- `make verify` clean; no new test failures against `main`.
- Live on a two-monitor setup (built-in left of an external), driven through IPC:
  - A floating window moved onto the other monitor rebinds: `ws=1 / External-Display-1` -> `ws=4 / Built-in Retina Display`.
  - Switching workspaces on the monitor it *left* no longer hides it (`hidden=None`, `visible=True`) — the actual reported symptom.
  - Switching workspaces on the monitor it now sits on does hide it (`hidden=workspace-inactive`, parked with 1pt on screen).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Floating windows now automatically move to the workspace associated with the monitor containing them after their position or size changes.
  * Hidden and scratchpad windows are excluded from automatic workspace reassignment.
  * Workspace bars refresh to reflect the updated floating-window placement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->