### PR TITLE
test(IPCRuleValidator): add characterization tests for bundle-id, regex, and min-size boundaries

### DIFF
--- a/Tests/OmniWMTests/IPCRuleValidatorTests.swift
+++ b/Tests/OmniWMTests/IPCRuleValidatorTests.swift
@@ -186,4 +186,54 @@ final class IPCRuleValidatorTests: XCTestCase {
         )
         XCTAssertEqual(roundTripped, snapshot)
     }
+
+    func testBundleIdTrimsSurroundingWhitespace() {
+        XCTAssertNil(IPCRuleValidator.bundleIdError(for: " com.example.app "))
+        XCTAssertNil(IPCRuleValidator.bundleIdError(for: "com.example.app\n"))
+    }
+
+    func testBundleIdRejectsLeadingAndTrailingDots() {
+        XCTAssertNotNil(IPCRuleValidator.bundleIdError(for: "com.app."))
+        XCTAssertNotNil(IPCRuleValidator.bundleIdError(for: ".com.app"))
+    }
+
+    func testBundleIdRegexBoundaries() {
+        XCTAssertNil(IPCRuleValidator.bundleIdError(for: "a"))
+        XCTAssertNil(IPCRuleValidator.bundleIdError(for: "1"))
+        XCTAssertNil(IPCRuleValidator.bundleIdError(for: "com.app-slot"))
+        XCTAssertNotNil(IPCRuleValidator.bundleIdError(for: "com.app-"))
+        XCTAssertNotNil(IPCRuleValidator.bundleIdError(for: "com.app slot"))
+    }
+
+    func testValidRegexReturnsNoMessage() {
+        XCTAssertNil(IPCRuleValidator.invalidRegexMessage(for: "^foo.*bar$"))
+        XCTAssertNil(IPCRuleValidator.invalidRegexMessage(for: nil))
+        XCTAssertNil(IPCRuleValidator.invalidRegexMessage(for: "   "))
+    }
+
+    func testMinSizeRejectsNonFiniteAndNegativeZero() {
+        for value in [Double.infinity, -Double.infinity, -0.0] {
+            let report = IPCRuleValidator.validate(
+                IPCRuleDefinition(bundleId: "com.test.app", minWidth: value)
+            )
+            XCTAssertNotNil(report.minSizeError, "min width \(value) should be rejected")
+        }
+
+        let height = IPCRuleValidator.validate(
+            IPCRuleDefinition(bundleId: "com.test.app", minHeight: .infinity)
+        )
+        XCTAssertNotNil(height.minSizeError)
+    }
+
+    func testMinSizeAcceptsSmallestPositiveFinite() {
+        let one = IPCRuleValidator.validate(
+            IPCRuleDefinition(bundleId: "com.test.app", minWidth: 1)
+        )
+        XCTAssertNil(one.minSizeError)
+
+        let ulp = IPCRuleValidator.validate(
+            IPCRuleDefinition(bundleId: "com.test.app", minWidth: Double.ulpOfOne)
+        )
+        XCTAssertNil(ulp.minSizeError)
+    }
 }


### PR DESCRIPTION
# IPCRuleValidator coverage gaps — worker report

**Repo:** `BarutSRB/OmniWM` (fork `YuriNachos/OmniWM`), branch `YuriNachos/w3-omniwm`, HEAD `9ebd441` ("Add move window to monitor actions"), `git describe v0.5.10-23-g9ebd441`, OmniWM **0.5.10** (build 70).
**Machine:** macOS **26.6** (Build 25G72), **arm64**, Xcode **26.4.1** (Build 17E202) → bundled Swift **6.3.1**.
**Scope:** test-only. One file touched: `Tests/OmniWMTests/IPCRuleValidatorTests.swift` (+50 lines, append-only, no existing assertion edited). No file under `Sources/` modified.

---

## 1. New test methods and the current behavior each pins

All expected values were re-derived from `Sources/OmniWMIPC/IPCRuleValidator.swift` (unchanged) before writing. Every new method is a **characterization test**: it documents existing correct behavior as a regression guard. None changed source.

| # | Method | Pins (current behavior) | Determining source line |
|---|---|---|---|
| 1 | `testBundleIdTrimsSurroundingWhitespace` | `bundleIdError(for:)` returns `nil` for `" com.example.app "` and `"com.example.app\n"` — input is trimmed of `.whitespacesAndNewlines` before the regex is applied, so padded-but-otherwise-valid IDs pass. | `IPCRuleValidator.swift:57` (`trimmingCharacters(in: .whitespacesAndNewlines)`) |
| 2 | `testBundleIdRejectsLeadingAndTrailingDots` | `bundleIdError` is non-nil for `"com.app."` and `".com.app"` — the pattern requires an alnum run after every `[.-]` and at the start, so a dangling dot on either side fails. | `IPCRuleValidator.swift:53` (`^[a-zA-Z0-9]+([.-][a-zA-Z0-9]+)*$`) |
| 3 | `testBundleIdRegexBoundaries` | `nil` for `"a"` (single alnum segment), `"1"` (single numeric segment), `"com.app-slot"` (hyphen as interior separator); non-nil for `"com.app-"` (trailing hyphen) and `"com.app slot"` (embedded space). | `IPCRuleValidator.swift:53` |
| 4 | `testValidRegexReturnsNoMessage` | `invalidRegexMessage(for:)` returns `nil` for a **valid** pattern `"^foo.*bar$"`, for `nil`, and for whitespace-only `"   "` (trims to empty → nil). The happy-path branch was previously untested (only the malformed case was covered). | `IPCRuleValidator.swift:115` (guard trim→empty→nil), `:120` (`try NSRegularExpression` → nil) |
| 5 | `testMinSizeRejectsNonFiniteAndNegativeZero` | `minSizeError` is non-nil for `minWidth` in `[.infinity, -.infinity, -0.0]` (non-finite; and `-0.0 > 0` is false), mirrored for `minHeight: .infinity`. Adds the non-finite + negative-zero cases to the existing negative/zer


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added validation coverage for bundle ID formatting and regular expression boundary rules.
  * Added tests for invalid, non-finite, negative-zero, and smallest positive size values.
  * Added coverage confirming valid regular expressions are accepted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->