### PR TITLE
fix: hidden window edge overflow

### DIFF
--- a/Sources/OmniWM/Core/Controller/LayoutRefreshController+WindowParking.swift
+++ b/Sources/OmniWM/Core/Controller/LayoutRefreshController+WindowParking.swift
@@ -1,10 +1,39 @@
 // SPDX-License-Identifier: GPL-2.0-only
 // Copyright (C) 2026 BarutSRB — https://github.com/BarutSRB/OmniWM
 
+import CoreGraphics
 import Foundation
 
 @MainActor
 extension LayoutRefreshController {
+    /// Only the corner park - inactive workspaces and the scratchpad - runs into the clamp macOS
+    /// puts on leaving the bottom of a display. Layout-transient hides stay on their own axis,
+    /// land exactly where they are told, and have to keep following the target so scrolling
+    /// animations stay in step.
+    func isSettledCornerPark(
+        for entry: WindowState,
+        frame: CGRect,
+        monitor: Monitor,
+        reason: HideReason
+    ) -> Bool {
+        guard let controller else { return false }
+        switch reason {
+        case .workspaceInactive,
+             .scratchpad:
+            break
+        case .layoutTransient:
+            return false
+        }
+
+        return HiddenWindowPlacementResolver.isParked(
+            frame: frame,
+            baseReveal: Self.hiddenEdgeReveal(isZoomApp: isZoomApp(entry.pid)),
+            scale: backingScale(for: monitor),
+            monitor: HiddenPlacementMonitorContext(monitor),
+            monitors: controller.workspaceManager.monitors.map(HiddenPlacementMonitorContext.init)
+        )
+    }
+
     func applyPositionPlans(_ plans: [WindowPositionPlan]) {
         guard let controller, !plans.isEmpty else { return }
 

--- a/Sources/OmniWM/Core/Controller/LayoutRefreshController+WindowParking.swift
+++ b/Sources/OmniWM/Core/Controller/LayoutRefreshController+WindowParking.swift
@@ -6,13 +6,12 @@ import Foundation
 
 @MainActor
 extension LayoutRefreshController {
-    /// Only the corner park - inactive workspaces and the scratchpad - runs into the clamp macOS
-    /// puts on leaving the bottom of a display. Layout-transient hides stay on their own axis,
-    /// land exactly where they are told, and have to keep following the target so scrolling
-    /// animations stay in step.
+    /// Layout-transient hides are excluded: they stay on their own axis, land exactly, and have to
+    /// keep following the target so scrolling animations stay in step.
     func isSettledCornerPark(
         for entry: WindowState,
         frame: CGRect,
+        target: CGPoint,
         monitor: Monitor,
         reason: HideReason
     ) -> Bool {
@@ -27,6 +26,7 @@ extension LayoutRefreshController {
 
         return HiddenWindowPlacementResolver.isParked(
             frame: frame,
+            target: target,
             baseReveal: Self.hiddenEdgeReveal(isZoomApp: isZoomApp(entry.pid)),
             scale: backingScale(for: monitor),
             monitor: HiddenPlacementMonitorContext(monitor),

--- a/Sources/OmniWM/Core/Controller/LayoutRefreshController.swift
+++ b/Sources/OmniWM/Core/Controller/LayoutRefreshController.swift
@@ -2903,10 +2903,9 @@ import QuartzCore
             )
         }
 
-        // A corner park asks to go deeper than macOS allows, so the window settles above the
-        // origin we asked for. Keep it where it settled instead of re-issuing an origin the
-        // window server will never grant, which no park write could ever verify.
-        if isSettledCornerPark(for: entry, frame: frame, monitor: monitor, reason: reason) {
+        // A corner park settles above the origin it asked for, and re-issuing an origin macOS will
+        // never grant leaves a park write that can never verify.
+        if isSettledCornerPark(for: entry, frame: frame, target: origin, monitor: monitor, reason: reason) {
             return .alreadyHidden(WindowPositionPlan(entry: entry, frame: frame), hiddenState: hiddenState)
         }
 

--- a/Sources/OmniWM/Core/Controller/LayoutRefreshController.swift
+++ b/Sources/OmniWM/Core/Controller/LayoutRefreshController.swift
@@ -2903,6 +2903,13 @@ import QuartzCore
             )
         }
 
+        // A corner park asks to go deeper than macOS allows, so the window settles above the
+        // origin we asked for. Keep it where it settled instead of re-issuing an origin the
+        // window server will never grant, which no park write could ever verify.
+        if isSettledCornerPark(for: entry, frame: frame, monitor: monitor, reason: reason) {
+            return .alreadyHidden(WindowPositionPlan(entry: entry, frame: frame), hiddenState: hiddenState)
+        }
+
         return .movable(
             WindowPositionPlan(
                 entry: entry,

--- a/Sources/OmniWM/Core/Layout/SideHiding.swift
+++ b/Sources/OmniWM/Core/Layout/SideHiding.swift
@@ -7,6 +7,15 @@ import Foundation
 enum HideSide {
     case left
     case right
+
+    var opposite: HideSide {
+        switch self {
+        case .left:
+            .right
+        case .right:
+            .left
+        }
+    }
 }
 
 enum AxisHideEdge {
@@ -77,6 +86,18 @@ enum HiddenWindowPlacementResolver {
         return max(baseReveal / max(1.0, scale), 1.0)
     }
 
+    /// Parks a window that belongs to an inactive workspace, or to the scratchpad.
+    ///
+    /// The window leaves the display diagonally, past one of its bottom corners, so both axes
+    /// run off the screen at once. macOS refuses a placement that is entirely off-screen and
+    /// snaps the window back, so a `reveal` of the window has to stay on the display: taking it
+    /// out through a corner makes that residue a `reveal`-sized square in the corner instead of
+    /// a `reveal`-wide line down the full height of the window.
+    ///
+    /// The corner has to have empty space behind it, otherwise the parked body lands on a
+    /// neighbouring display. When both corners are occupied - a display directly below catches
+    /// either of them - parking falls back to the side edges, which keep the window's own row
+    /// and never reach the display below.
     static func physicalScreenEdgeOrigin(
         for size: CGSize,
         requestedSide: HideSide,
@@ -87,40 +108,123 @@ enum HiddenWindowPlacementResolver {
         monitors: [HiddenPlacementMonitorContext]
     ) -> CGPoint {
         let reveal = effectiveReveal(baseReveal: baseReveal, scale: scale)
+        let candidates = [
+            bottomCornerOrigin(for: size, side: requestedSide, reveal: reveal, monitor: monitor),
+            bottomCornerOrigin(for: size, side: requestedSide.opposite, reveal: reveal, monitor: monitor),
+            sideEdgeOrigin(for: size, side: requestedSide, targetY: targetY, reveal: reveal, monitor: monitor),
+            sideEdgeOrigin(
+                for: size,
+                side: requestedSide.opposite,
+                targetY: targetY,
+                reveal: reveal,
+                monitor: monitor
+            )
+        ]
 
-        func origin(for side: HideSide) -> CGPoint {
-            switch side {
-            case .left:
-                CGPoint(
-                    x: monitor.visibleFrame.minX - size.width + reveal,
-                    y: targetY
-                )
-            case .right:
-                CGPoint(
-                    x: monitor.visibleFrame.maxX - reveal,
-                    y: targetY
-                )
+        return leastOverlappingOrigin(
+            among: candidates,
+            size: size,
+            monitor: monitor,
+            monitors: monitors
+        )
+    }
+
+    /// Origin that pushes the window past a bottom corner of the display itself.
+    ///
+    /// Both axes are measured against `frame` rather than `visibleFrame`: the placement macOS
+    /// constrains is the one against the physical display, and referencing the full frame keeps
+    /// the residue at the very edge, underneath a Dock that sits on that edge, rather than
+    /// stranding it in the strip the Dock reserves.
+    private static func bottomCornerOrigin(
+        for size: CGSize,
+        side: HideSide,
+        reveal: CGFloat,
+        monitor: HiddenPlacementMonitorContext
+    ) -> CGPoint {
+        CGPoint(
+            x: horizontalOrigin(for: size, side: side, reveal: reveal, bounds: monitor.frame),
+            // AppKit coordinates: y grows up, so minY is the bottom edge of the display.
+            y: monitor.frame.minY - size.height + reveal
+        )
+    }
+
+    /// Origin that pushes the window past a side edge, keeping the row it is already on.
+    private static func sideEdgeOrigin(
+        for size: CGSize,
+        side: HideSide,
+        targetY: CGFloat,
+        reveal: CGFloat,
+        monitor: HiddenPlacementMonitorContext
+    ) -> CGPoint {
+        CGPoint(
+            x: horizontalOrigin(for: size, side: side, reveal: reveal, bounds: monitor.visibleFrame),
+            y: targetY
+        )
+    }
+
+    private static func horizontalOrigin(
+        for size: CGSize,
+        side: HideSide,
+        reveal: CGFloat,
+        bounds: CGRect
+    ) -> CGFloat {
+        switch side {
+        case .left:
+            bounds.minX - size.width + reveal
+        case .right:
+            bounds.maxX - reveal
+        }
+    }
+
+    /// First candidate that spills onto no other display, else the one that spills the least.
+    private static func leastOverlappingOrigin(
+        among candidates: [CGPoint],
+        size: CGSize,
+        monitor: HiddenPlacementMonitorContext,
+        monitors: [HiddenPlacementMonitorContext]
+    ) -> CGPoint {
+        var bestOrigin = candidates[0]
+        var bestOverlap = CGFloat.greatestFiniteMagnitude
+
+        for candidate in candidates {
+            let overlap = overlapArea(
+                for: CGRect(origin: candidate, size: size),
+                monitor: monitor,
+                monitors: monitors
+            )
+            if overlap == 0 {
+                return candidate
+            }
+            if overlap < bestOverlap {
+                bestOrigin = candidate
+                bestOverlap = overlap
             }
         }
 
-        let primaryOrigin = origin(for: requestedSide)
-        let primaryOverlap = overlapArea(
-            for: CGRect(origin: primaryOrigin, size: size),
-            monitor: monitor,
-            monitors: monitors
-        )
-        if primaryOverlap == 0 {
-            return primaryOrigin
-        }
+        return bestOrigin
+    }
 
-        let alternateSide: HideSide = requestedSide == .left ? .right : .left
-        let alternateOrigin = origin(for: alternateSide)
-        let alternateOverlap = overlapArea(
-            for: CGRect(origin: alternateOrigin, size: size),
-            monitor: monitor,
-            monitors: monitors
-        )
-        return alternateOverlap < primaryOverlap ? alternateOrigin : primaryOrigin
+    /// Whether `frame` is already parked as deeply as it is going to get.
+    ///
+    /// macOS clamps how far a window may leave the bottom of a display - it keeps a strip of the
+    /// top edge on screen, and how deep that strip is differs per window - so a settled park
+    /// usually sits above the origin that was asked for. Comparing against that origin would
+    /// never match, and the park would be rewritten on every refresh, so a park counts as done
+    /// once only a hairline of the window is left on its own display and none of its body has
+    /// landed on another one.
+    static func isParked(
+        frame: CGRect,
+        baseReveal: CGFloat,
+        scale: CGFloat,
+        monitor: HiddenPlacementMonitorContext,
+        monitors: [HiddenPlacementMonitorContext]
+    ) -> Bool {
+        let tolerance: CGFloat = 0.01
+        let reveal = effectiveReveal(baseReveal: baseReveal, scale: scale) + tolerance
+        let onScreen = frame.intersection(monitor.frame)
+        let showsHairlineAtMost = onScreen.isNull || onScreen.width <= reveal || onScreen.height <= reveal
+
+        return showsHairlineAtMost && overlapArea(for: frame, monitor: monitor, monitors: monitors) == 0
     }
 
     static func placement(

--- a/Sources/OmniWM/Core/Layout/SideHiding.swift
+++ b/Sources/OmniWM/Core/Layout/SideHiding.swift
@@ -86,18 +86,15 @@ enum HiddenWindowPlacementResolver {
         return max(baseReveal / max(1.0, scale), 1.0)
     }
 
-    /// Parks a window that belongs to an inactive workspace, or to the scratchpad.
+    /// Parks a window of an inactive workspace, or of the scratchpad, past a bottom corner.
     ///
-    /// The window leaves the display diagonally, past one of its bottom corners, so both axes
-    /// run off the screen at once. macOS refuses a placement that is entirely off-screen and
-    /// snaps the window back, so a `reveal` of the window has to stay on the display: taking it
-    /// out through a corner makes that residue a `reveal`-sized square in the corner instead of
-    /// a `reveal`-wide line down the full height of the window.
+    /// macOS snaps back a placement that is entirely off-screen, so a `reveal` of the window has
+    /// to stay on the display. Leaving through a corner runs both axes off at once, which makes
+    /// that residue a square rather than a line down the window's full height.
     ///
-    /// The corner has to have empty space behind it, otherwise the parked body lands on a
-    /// neighbouring display. When both corners are occupied - a display directly below catches
-    /// either of them - parking falls back to the side edges, which keep the window's own row
-    /// and never reach the display below.
+    /// A corner needs empty space behind it or the parked body lands on a neighbouring display,
+    /// so candidates are tried in preference order. A display directly below occupies both
+    /// corners, and parking falls back to the side edges, which never reach it.
     static func physicalScreenEdgeOrigin(
         for size: CGSize,
         requestedSide: HideSide,
@@ -129,12 +126,8 @@ enum HiddenWindowPlacementResolver {
         )
     }
 
-    /// Origin that pushes the window past a bottom corner of the display itself.
-    ///
-    /// Both axes are measured against `frame` rather than `visibleFrame`: the placement macOS
-    /// constrains is the one against the physical display, and referencing the full frame keeps
-    /// the residue at the very edge, underneath a Dock that sits on that edge, rather than
-    /// stranding it in the strip the Dock reserves.
+    /// Measured against `frame` rather than `visibleFrame`, which keeps the residue at the very
+    /// edge - underneath a Dock sitting there - instead of in the strip the Dock reserves.
     private static func bottomCornerOrigin(
         for size: CGSize,
         side: HideSide,
@@ -204,27 +197,38 @@ enum HiddenWindowPlacementResolver {
         return bestOrigin
     }
 
-    /// Whether `frame` is already parked as deeply as it is going to get.
+    /// Strip of a corner-parked window macOS holds back on screen, refusing to take the top edge
+    /// past the bottom of a display. Measured at 32pt for Ghostty and 41pt for Chrome, so it
+    /// tracks the title bar; overshooting the bound costs a redundant park write, nothing visible.
+    static let maxClampedParkResidue: CGFloat = 120
+
+    /// Whether `frame` is already parked as deeply as `target` is going to get it.
     ///
-    /// macOS clamps how far a window may leave the bottom of a display - it keeps a strip of the
-    /// top edge on screen, and how deep that strip is differs per window - so a settled park
-    /// usually sits above the origin that was asked for. Comparing against that origin would
-    /// never match, and the park would be rewritten on every refresh, so a park counts as done
-    /// once only a hairline of the window is left on its own display and none of its body has
-    /// landed on another one.
+    /// Only a corner target settles short of its origin, and only it needs this: every other park
+    /// lands exactly and is caught by comparing origins. Anything not in the target's column or
+    /// not pushed past the bottom gets parked again - a side-edge park left over from when a
+    /// display blocked both corners, or a window an app has dragged back up.
     static func isParked(
         frame: CGRect,
+        target: CGPoint,
         baseReveal: CGFloat,
         scale: CGFloat,
         monitor: HiddenPlacementMonitorContext,
         monitors: [HiddenPlacementMonitorContext]
     ) -> Bool {
         let tolerance: CGFloat = 0.01
-        let reveal = effectiveReveal(baseReveal: baseReveal, scale: scale) + tolerance
-        let onScreen = frame.intersection(monitor.frame)
-        let showsHairlineAtMost = onScreen.isNull || onScreen.width <= reveal || onScreen.height <= reveal
+        let reveal = effectiveReveal(baseReveal: baseReveal, scale: scale)
+        let bottom = monitor.frame.minY
 
-        return showsHairlineAtMost && overlapArea(for: frame, monitor: monitor, monitors: monitors) == 0
+        guard abs(target.y - (bottom - frame.height + reveal)) <= tolerance else { return false }
+        // The sideways push is always granted, and which corner is free flips as displays come
+        // and go, so a window outside the target's column is parked against the wrong edge.
+        guard abs(frame.minX - target.x) <= tolerance else { return false }
+        guard frame.maxY >= bottom + reveal - tolerance,
+              frame.maxY <= bottom + maxClampedParkResidue
+        else { return false }
+
+        return overlapArea(for: frame, monitor: monitor, monitors: monitors) == 0
     }
 
     static func placement(

--- a/Sources/OmniWM/Core/Layout/SideHiding.swift
+++ b/Sources/OmniWM/Core/Layout/SideHiding.swift
@@ -72,6 +72,11 @@ struct HiddenWindowPlacement {
 }
 
 enum HiddenWindowPlacementResolver {
+    static func effectiveReveal(baseReveal: CGFloat, scale: CGFloat) -> CGFloat {
+        guard baseReveal > 0 else { return 0 }
+        return max(baseReveal / max(1.0, scale), 1.0)
+    }
+
     static func physicalScreenEdgeOrigin(
         for size: CGSize,
         requestedSide: HideSide,
@@ -81,7 +86,7 @@ enum HiddenWindowPlacementResolver {
         monitor: HiddenPlacementMonitorContext,
         monitors: [HiddenPlacementMonitorContext]
     ) -> CGPoint {
-        let reveal = baseReveal / max(1.0, scale)
+        let reveal = effectiveReveal(baseReveal: baseReveal, scale: scale)
 
         func origin(for side: HideSide) -> CGPoint {
             switch side {
@@ -128,7 +133,7 @@ enum HiddenWindowPlacementResolver {
         monitor: HiddenPlacementMonitorContext,
         monitors: [HiddenPlacementMonitorContext]
     ) -> HiddenWindowPlacement {
-        let reveal = baseReveal / max(1.0, scale)
+        let reveal = effectiveReveal(baseReveal: baseReveal, scale: scale)
 
         func origin(for edge: AxisHideEdge) -> CGPoint {
             switch orientation {

--- a/Tests/OmniWMTests/HiddenWindowCornerParkTests.swift
+++ b/Tests/OmniWMTests/HiddenWindowCornerParkTests.swift
@@ -1,0 +1,196 @@
+// SPDX-License-Identifier: GPL-2.0-only
+// Copyright (C) 2026 BarutSRB — https://github.com/BarutSRB/OmniWM
+
+import CoreGraphics
+import Foundation
+@testable import OmniWM
+import XCTest
+
+/// Windows belonging to an inactive workspace are parked past a bottom corner of their display,
+/// so the residue macOS insists on keeping on screen is a single square rather than a hairline
+/// running the whole height of the window.
+final class HiddenWindowCornerParkTests: XCTestCase {
+    private let reveal: CGFloat = 1.0
+
+    private let main = HiddenPlacementMonitorContext(
+        id: Monitor.ID(displayId: 900_200),
+        frame: CGRect(x: 0, y: 0, width: 3360, height: 1890),
+        visibleFrame: CGRect(x: 0, y: 0, width: 3360, height: 1860)
+    )
+
+    private func park(
+        size: CGSize,
+        side: HideSide,
+        targetY: CGFloat,
+        monitor: HiddenPlacementMonitorContext,
+        monitors: [HiddenPlacementMonitorContext]
+    ) -> CGPoint {
+        HiddenWindowPlacementResolver.physicalScreenEdgeOrigin(
+            for: size,
+            requestedSide: side,
+            targetY: targetY,
+            baseReveal: reveal,
+            scale: 2.0,
+            monitor: monitor,
+            monitors: monitors
+        )
+    }
+
+    func testParkLeavesOnlyARevealSquareOnScreen() {
+        let size = CGSize(width: 3360, height: 1860)
+        let origin = park(size: size, side: .right, targetY: 0, monitor: main, monitors: [main])
+
+        // Parking sideways would leave `reveal` x 1860 of the window showing down the edge.
+        XCTAssertEqual(
+            CGRect(origin: origin, size: size).intersection(main.frame),
+            CGRect(x: main.frame.maxX - reveal, y: main.frame.minY, width: reveal, height: reveal)
+        )
+    }
+
+    func testParkTakesTheWindowPastTheDisplayBottom() {
+        let size = CGSize(width: 3360, height: 1860)
+        let origin = park(size: size, side: .right, targetY: 0, monitor: main, monitors: [main])
+
+        XCTAssertEqual(origin.x, main.frame.maxX - reveal)
+        XCTAssertEqual(origin.y, main.frame.minY - size.height + reveal)
+    }
+
+    /// The residue belongs at the physical bottom edge, underneath a Dock parked on that edge,
+    /// not in the strip the Dock reserves - `visibleFrame` would leave it beside the Dock.
+    func testParkClearsTheDockStripInsteadOfStoppingAtIt() {
+        let docked = HiddenPlacementMonitorContext(
+            id: Monitor.ID(displayId: 900_300),
+            frame: CGRect(x: 0, y: 0, width: 1600, height: 1000),
+            visibleFrame: CGRect(x: 0, y: 70, width: 1600, height: 900)
+        )
+        let size = CGSize(width: 200, height: 300)
+        let origin = park(size: size, side: .right, targetY: 400, monitor: docked, monitors: [docked])
+
+        XCTAssertEqual(origin.y, docked.frame.minY - size.height + reveal)
+        XCTAssertEqual(
+            CGRect(origin: origin, size: size).intersection(docked.frame),
+            CGRect(x: docked.frame.maxX - reveal, y: docked.frame.minY, width: reveal, height: reveal)
+        )
+    }
+
+    /// Laptop display sitting to the left of, and lower than, an external one. Leaving through
+    /// the right corner would drop the whole body onto the external display.
+    func testParkAvoidsTheCornerThatSpillsOntoANeighbouringDisplay() {
+        let builtIn = HiddenPlacementMonitorContext(
+            id: Monitor.ID(displayId: 900_100),
+            frame: CGRect(x: -1800, y: 721, width: 1800, height: 1169),
+            visibleFrame: CGRect(x: -1800, y: 721, width: 1800, height: 1130)
+        )
+        let size = CGSize(width: 1800, height: 1130)
+        let origin = park(
+            size: size,
+            side: .right,
+            targetY: 721,
+            monitor: builtIn,
+            monitors: [builtIn, main]
+        )
+
+        XCTAssertEqual(origin.x, builtIn.frame.minX - size.width + reveal)
+        XCTAssertEqual(origin.y, builtIn.frame.minY - size.height + reveal)
+        XCTAssertTrue(CGRect(origin: origin, size: size).intersection(main.frame).isNull)
+    }
+
+    /// macOS keeps a strip of the window's top edge on screen - 32pt for one app, 41pt for the
+    /// next - so a settled park sits above the origin it was given. It still counts as parked,
+    /// otherwise the unreachable origin is re-requested on every refresh and never verifies.
+    func testClampedParkCountsAsParked() {
+        let size = CGSize(width: 3360, height: 1860)
+        let clamped = CGRect(
+            origin: CGPoint(x: main.frame.maxX - reveal, y: main.frame.minY - size.height + 32),
+            size: size
+        )
+
+        XCTAssertTrue(
+            HiddenWindowPlacementResolver.isParked(
+                frame: clamped,
+                baseReveal: reveal,
+                scale: 2.0,
+                monitor: main,
+                monitors: [main]
+            )
+        )
+    }
+
+    func testWindowStillOnScreenDoesNotCountAsParked() {
+        let onScreen = CGRect(x: 0, y: 0, width: 3360, height: 1860)
+
+        XCTAssertFalse(
+            HiddenWindowPlacementResolver.isParked(
+                frame: onScreen,
+                baseReveal: reveal,
+                scale: 2.0,
+                monitor: main,
+                monitors: [main]
+            )
+        )
+    }
+
+    /// Parked against an edge that a newly attached display now sits behind: the hairline is
+    /// still a hairline, but the body is on that display, so the park has to be redone.
+    func testParkSpillingOntoAnotherDisplayDoesNotCountAsParked() {
+        let toTheRight = HiddenPlacementMonitorContext(
+            id: Monitor.ID(displayId: 900_500),
+            frame: CGRect(x: 3360, y: 0, width: 1920, height: 1080),
+            visibleFrame: CGRect(x: 3360, y: 0, width: 1920, height: 1080)
+        )
+        let size = CGSize(width: 800, height: 600)
+        let parked = CGRect(
+            origin: CGPoint(x: main.frame.maxX - reveal, y: main.frame.minY - size.height + 32),
+            size: size
+        )
+
+        XCTAssertFalse(
+            HiddenWindowPlacementResolver.isParked(
+                frame: parked,
+                baseReveal: reveal,
+                scale: 2.0,
+                monitor: main,
+                monitors: [main, toTheRight]
+            )
+        )
+    }
+
+    /// Zoom is parked flush with the edge instead of keeping a reveal, and has to settle too.
+    func testFlushParkWithoutRevealCountsAsParked() {
+        let size = CGSize(width: 800, height: 600)
+        let flush = CGRect(
+            origin: CGPoint(x: main.frame.maxX, y: main.frame.minY - size.height + 32),
+            size: size
+        )
+
+        XCTAssertTrue(
+            HiddenWindowPlacementResolver.isParked(
+                frame: flush,
+                baseReveal: 0,
+                scale: 2.0,
+                monitor: main,
+                monitors: [main]
+            )
+        )
+    }
+
+    /// A display directly below catches both bottom corners. Side parking keeps the window's own
+    /// row, which that display never covers, so it beats leaking a column onto it.
+    func testParkFallsBackToTheSideEdgeWhenBothCornersSpill() {
+        let top = HiddenPlacementMonitorContext(
+            id: Monitor.ID(displayId: 900_400),
+            frame: CGRect(x: 0, y: 0, width: 1000, height: 1000),
+            visibleFrame: CGRect(x: 0, y: 0, width: 1000, height: 1000)
+        )
+        let below = HiddenPlacementMonitorContext(
+            id: Monitor.ID(displayId: 900_401),
+            frame: CGRect(x: 0, y: -1000, width: 1000, height: 1000),
+            visibleFrame: CGRect(x: 0, y: -1000, width: 1000, height: 1000)
+        )
+        let size = CGSize(width: 400, height: 300)
+        let origin = park(size: size, side: .right, targetY: 200, monitor: top, monitors: [top, below])
+
+        XCTAssertEqual(origin, CGPoint(x: top.visibleFrame.maxX - reveal, y: 200))
+        XCTAssertTrue(CGRect(origin: origin, size: size).intersection(below.frame).isNull)
+    }
+}

--- a/Tests/OmniWMTests/HiddenWindowCornerParkTests.swift
+++ b/Tests/OmniWMTests/HiddenWindowCornerParkTests.swift
@@ -6,9 +6,8 @@ import Foundation
 @testable import OmniWM
 import XCTest
 
-/// Windows belonging to an inactive workspace are parked past a bottom corner of their display,
-/// so the residue macOS insists on keeping on screen is a single square rather than a hairline
-/// running the whole height of the window.
+/// Inactive-workspace windows park past a bottom corner, so the residue macOS insists on keeping
+/// on screen is a square rather than a hairline down the whole height of the window.
 final class HiddenWindowCornerParkTests: XCTestCase {
     private let reveal: CGFloat = 1.0
 
@@ -55,8 +54,8 @@ final class HiddenWindowCornerParkTests: XCTestCase {
         XCTAssertEqual(origin.y, main.frame.minY - size.height + reveal)
     }
 
-    /// The residue belongs at the physical bottom edge, underneath a Dock parked on that edge,
-    /// not in the strip the Dock reserves - `visibleFrame` would leave it beside the Dock.
+    /// The residue belongs at the physical bottom edge, under a Dock parked there, not beside it
+    /// in the strip the Dock reserves.
     func testParkClearsTheDockStripInsteadOfStoppingAtIt() {
         let docked = HiddenPlacementMonitorContext(
             id: Monitor.ID(displayId: 900_300),
@@ -73,8 +72,8 @@ final class HiddenWindowCornerParkTests: XCTestCase {
         )
     }
 
-    /// Laptop display sitting to the left of, and lower than, an external one. Leaving through
-    /// the right corner would drop the whole body onto the external display.
+    /// Laptop display left of, and lower than, an external one: the right corner would drop the
+    /// whole body onto the external display.
     func testParkAvoidsTheCornerThatSpillsOntoANeighbouringDisplay() {
         let builtIn = HiddenPlacementMonitorContext(
             id: Monitor.ID(displayId: 900_100),
@@ -95,9 +94,8 @@ final class HiddenWindowCornerParkTests: XCTestCase {
         XCTAssertTrue(CGRect(origin: origin, size: size).intersection(main.frame).isNull)
     }
 
-    /// macOS keeps a strip of the window's top edge on screen - 32pt for one app, 41pt for the
-    /// next - so a settled park sits above the origin it was given. It still counts as parked,
-    /// otherwise the unreachable origin is re-requested on every refresh and never verifies.
+    /// macOS keeps a strip of the top edge on screen - 32pt for one app, 41pt for the next - so a
+    /// settled park sits above the origin it was given, and still counts as parked.
     func testClampedParkCountsAsParked() {
         let size = CGSize(width: 3360, height: 1860)
         let clamped = CGRect(
@@ -108,6 +106,7 @@ final class HiddenWindowCornerParkTests: XCTestCase {
         XCTAssertTrue(
             HiddenWindowPlacementResolver.isParked(
                 frame: clamped,
+                target: park(size: size, side: .right, targetY: 0, monitor: main, monitors: [main]),
                 baseReveal: reveal,
                 scale: 2.0,
                 monitor: main,
@@ -122,6 +121,13 @@ final class HiddenWindowCornerParkTests: XCTestCase {
         XCTAssertFalse(
             HiddenWindowPlacementResolver.isParked(
                 frame: onScreen,
+                target: park(
+                    size: onScreen.size,
+                    side: .right,
+                    targetY: 0,
+                    monitor: main,
+                    monitors: [main]
+                ),
                 baseReveal: reveal,
                 scale: 2.0,
                 monitor: main,
@@ -130,8 +136,7 @@ final class HiddenWindowCornerParkTests: XCTestCase {
         )
     }
 
-    /// Parked against an edge that a newly attached display now sits behind: the hairline is
-    /// still a hairline, but the body is on that display, so the park has to be redone.
+    /// A newly attached display now sits behind the parked edge, so the body is on it.
     func testParkSpillingOntoAnotherDisplayDoesNotCountAsParked() {
         let toTheRight = HiddenPlacementMonitorContext(
             id: Monitor.ID(displayId: 900_500),
@@ -147,10 +152,52 @@ final class HiddenWindowCornerParkTests: XCTestCase {
         XCTAssertFalse(
             HiddenWindowPlacementResolver.isParked(
                 frame: parked,
+                target: park(size: size, side: .right, targetY: 0, monitor: main, monitors: [main, toTheRight]),
                 baseReveal: reveal,
                 scale: 2.0,
                 monitor: main,
                 monitors: [main, toTheRight]
+            )
+        )
+    }
+
+    /// A side-edge park is only right while a display blocks both corners. Unplug it and the
+    /// leftover park - a hairline down the whole window - has to be redone, not counted as settled.
+    func testSideEdgeParkIsNotSettledOnceTheBlockingDisplayIsRemoved() {
+        let top = HiddenPlacementMonitorContext(
+            id: Monitor.ID(displayId: 900_400),
+            frame: CGRect(x: 0, y: 0, width: 1000, height: 1000),
+            visibleFrame: CGRect(x: 0, y: 0, width: 1000, height: 1000)
+        )
+        let size = CGSize(width: 400, height: 300)
+        let sideParked = CGRect(origin: CGPoint(x: top.visibleFrame.maxX - reveal, y: 200), size: size)
+        let cornerTarget = park(size: size, side: .right, targetY: 200, monitor: top, monitors: [top])
+
+        XCTAssertFalse(
+            HiddenWindowPlacementResolver.isParked(
+                frame: sideParked,
+                target: cornerTarget,
+                baseReveal: reveal,
+                scale: 2.0,
+                monitor: top,
+                monitors: [top]
+            )
+        )
+    }
+
+    func testFullyOffScreenFrameIsNotSettledWhenARevealIsRequired() {
+        let size = CGSize(width: 800, height: 600)
+        let target = park(size: size, side: .right, targetY: 0, monitor: main, monitors: [main])
+        let belowTheDisplay = CGRect(origin: CGPoint(x: target.x, y: main.frame.minY - size.height - 40), size: size)
+
+        XCTAssertFalse(
+            HiddenWindowPlacementResolver.isParked(
+                frame: belowTheDisplay,
+                target: target,
+                baseReveal: reveal,
+                scale: 2.0,
+                monitor: main,
+                monitors: [main]
             )
         )
     }
@@ -166,6 +213,15 @@ final class HiddenWindowCornerParkTests: XCTestCase {
         XCTAssertTrue(
             HiddenWindowPlacementResolver.isParked(
                 frame: flush,
+                target: HiddenWindowPlacementResolver.physicalScreenEdgeOrigin(
+                    for: size,
+                    requestedSide: .right,
+                    targetY: 0,
+                    baseReveal: 0,
+                    scale: 2.0,
+                    monitor: main,
+                    monitors: [main]
+                ),
                 baseReveal: 0,
                 scale: 2.0,
                 monitor: main,
@@ -174,8 +230,8 @@ final class HiddenWindowCornerParkTests: XCTestCase {
         )
     }
 
-    /// A display directly below catches both bottom corners. Side parking keeps the window's own
-    /// row, which that display never covers, so it beats leaking a column onto it.
+    /// A display directly below catches both corners; side parking keeps the window's own row,
+    /// which that display never covers.
     func testParkFallsBackToTheSideEdgeWhenBothCornersSpill() {
         let top = HiddenPlacementMonitorContext(
             id: Monitor.ID(displayId: 900_400),

--- a/Tests/OmniWMTests/HiddenWindowRevealTests.swift
+++ b/Tests/OmniWMTests/HiddenWindowRevealTests.swift
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: GPL-2.0-only
+// Copyright (C) 2026 BarutSRB — https://github.com/BarutSRB/OmniWM
+
+import CoreGraphics
+import Foundation
+@testable import OmniWM
+import XCTest
+
+final class HiddenWindowRevealTests: XCTestCase {
+    private let monitor = HiddenPlacementMonitorContext(
+        id: Monitor.ID(displayId: 900_100),
+        frame: CGRect(x: 0, y: 0, width: 1800, height: 1169),
+        visibleFrame: CGRect(x: 0, y: 0, width: 1800, height: 1130)
+    )
+
+    func testRevealSurvivesRetinaScale() {
+        XCTAssertEqual(
+            HiddenWindowPlacementResolver.effectiveReveal(baseReveal: 1.0, scale: 2.0),
+            1.0
+        )
+    }
+
+    func testZeroRevealStaysZero() {
+        XCTAssertEqual(
+            HiddenWindowPlacementResolver.effectiveReveal(baseReveal: 0, scale: 2.0),
+            0
+        )
+    }
+
+    func testHiddenWindowKeepsAtLeastOnePointOnScreenAtRetinaScale() {
+        let size = CGSize(width: 230, height: 408)
+        let origin = HiddenWindowPlacementResolver.physicalScreenEdgeOrigin(
+            for: size,
+            requestedSide: .left,
+            targetY: 268,
+            baseReveal: 1.0,
+            scale: 2.0,
+            monitor: monitor,
+            monitors: [monitor]
+        )
+
+        let onScreenWidth = (origin.x + size.width) - monitor.visibleFrame.minX
+        XCTAssertGreaterThanOrEqual(onScreenWidth, 1.0)
+        XCTAssertEqual(origin.x.rounded(), origin.x)
+    }
+
+    func testTransientPlacementKeepsAtLeastOnePointOnScreenAtRetinaScale() {
+        let size = CGSize(width: 893, height: 1130)
+        let placement = HiddenWindowPlacementResolver.placement(
+            for: size,
+            requestedEdge: .minimum,
+            orthogonalOrigin: 0,
+            baseReveal: 1.0,
+            scale: 2.0,
+            orientation: .horizontal,
+            monitor: monitor,
+            monitors: [monitor]
+        )
+
+        let onScreenWidth = (placement.origin.x + size.width) - monitor.visibleFrame.minX
+        XCTAssertGreaterThanOrEqual(onScreenWidth, 1.0)
+    }
+
+    func testMaximumEdgeKeepsAtLeastOnePointOnScreenAtRetinaScale() {
+        let size = CGSize(width: 893, height: 1130)
+        let placement = HiddenWindowPlacementResolver.placement(
+            for: size,
+            requestedEdge: .maximum,
+            orthogonalOrigin: 0,
+            baseReveal: 1.0,
+            scale: 2.0,
+            orientation: .horizontal,
+            monitor: monitor,
+            monitors: [monitor]
+        )
+
+        let onScreenWidth = monitor.visibleFrame.maxX - placement.origin.x
+        XCTAssertGreaterThanOrEqual(onScreenWidth, 1.0)
+    }
+}

--- a/Tests/OmniWMTests/SingleWindowFitTests.swift
+++ b/Tests/OmniWMTests/SingleWindowFitTests.swift
@@ -352,7 +352,7 @@ final class NiriSingleWindowFitEngineTests: XCTestCase {
         XCTAssertEqual(frame, CGRect(x: 274, y: 16, width: 700, height: 760))
     }
 
-    func testHiddenPlacementKeepsOnePhysicalPixelReveal() {
+    func testHiddenPlacementKeepsOnePointReveal() {
         let monitor = HiddenPlacementMonitorContext(
             id: Monitor.ID(displayId: 1),
             frame: CGRect(x: 0, y: 0, width: 1280, height: 800),
@@ -372,7 +372,7 @@ final class NiriSingleWindowFitEngineTests: XCTestCase {
         )
         let frame = placement.frame(for: size)
 
-        XCTAssertEqual(frame.minX, monitor.visibleFrame.maxX - 0.5)
+        XCTAssertEqual(frame.minX, monitor.visibleFrame.maxX - 1.0)
         XCTAssertEqual(frame.minY, 40)
         XCTAssertEqual(frame.width, size.width)
         XCTAssertEqual(frame.height, size.height)


### PR DESCRIPTION
## Problem

Switching away from a workspace leaves a sliver of every window from it stuck to the screen edge.

Two bugs, one after the other.

**1. A 40px overflow.** Windows are parked off-screen with a deliberate 1pt reveal so macOS does not
treat them as fully off-screen, but the reveal was computed as `baseReveal / max(1, scale)` — one
*physical* pixel, so 0.5pt on a 2x display. AX position writes quantise to whole points, so the
0.5pt is rounded away: a request for `x=-229.5` lands at `x=-230.0`, flush to the edge with nothing
on screen. macOS then refuses the fully off-screen placement and snaps the window back:

```
x=-230 (0px visible) -> macOS relocates it to -190   <- the 40px overflow
x=-229 (1px visible) -> stays at -229
```

**2. A 1pt hairline the height of the window.** With the reveal fixed, parking still pushes the
window out *sideways*, so the reveal that has to stay on screen is a 1pt column as tall as the
window — 1 x 1860 points of Ghostty running down the right edge of a 4K display. Measured
on-screen bounds of a parked window: `(3359, 30, 3360 x 1860)`.

Both affect tiled and floating windows, on any 2x display.

## Approach

**Reveal.** Take it as at least one point, which survives the write. A `baseReveal` of 0 still means
no reveal, preserving the Zoom workaround in `hiddenEdgeReveal(isZoomApp:)`. Both placement
functions route through the shared helper, so the Niri off-viewport hiding path is fixed too — it
had the same 0.5pt bug.

**Corner parking.** Take the window out through a *bottom corner* instead, so both axes leave the
display at once and the reveal is a corner tick rather than a line. Both axes measure against the
display frame rather than the visible frame, which keeps the tick at the very edge — underneath a
Dock sitting there — instead of stranding it in the strip the Dock reserves.

A corner is only usable when the space behind it is empty, otherwise the parked body shows up on a
neighbouring display. The two corners are tried in preference order and the first that spills onto
nothing wins. When a display directly below catches both, parking falls back to the side edges,
which keep the window's own row and never reach that display, so no particular monitor arrangement
is required.

**Settling.** macOS clamps how far a window may leave the bottom of a display: it keeps a strip of
the top edge on screen, and the depth is per-window — 32pt for Ghostty, 41pt for Chrome. So a park
settles above the origin it was given, and park writes only verify on an exact match. Re-requesting
the unreachable origin would leave every hidden window permanently unverified and rewritten on every
visibility refresh. `HiddenWindowPlacementResolver.isParked` treats a park as done once only a
hairline is left on its own display and none of the body has landed on another one, which also
re-parks correctly when a newly attached display moves in behind the old edge.

## Behavior change

Parked windows leave a 1pt-wide tick in a bottom corner instead of a 1pt column down the full height
of the screen edge — on the reporting setup, 1860 square points of visible residue down to 32.

`testHiddenPlacementKeepsOnePhysicalPixelReveal` asserted the 0.5pt value directly. Its intent — the
smallest reveal that works — is unchanged, but sub-point reveals cannot survive the write, so it now
pins one point and is renamed accordingly.

Before:

https://github.com/user-attachments/assets/b66b97a4-30ce-48c1-acfa-b797691f86dd

After:

https://github.com/user-attachments/assets/62638234-1ab4-4958-858c-a439a4ba211f



## Verification

- `HiddenWindowRevealTests` — reveal survives Retina scale, zero stays zero, and both the
  screen-edge and transient placement paths keep at least one point on screen. Four of the five fail
  against the previous computation, reporting the exact 0.5.
- `HiddenWindowCornerParkTests` — the park leaves only a reveal-sized square, clears the display
  bottom, prefers the corner that does not spill onto a neighbour, falls back to the side edge when
  a display below catches both corners, and settles once clamped. Four of the nine fail against
  side parking.
- `make verify` clean. Four test failures on this branch (`AXFullRescanBoundaryTests`,
  `FloatingCreatePlacementTests` x2, `NiriInitialContainerPrimarySpanTests`) reproduce on
  `upstream/main` at `dc85eab` — checked out and run there directly — so they are not from this
  change.
- Live on a two-display setup (built-in left of, and lower than, an external 3360x1890), measured
  with `CGWindowListCopyWindowInfo` for what the window server actually composites rather than what
  OmniWM requested:

  | | before | after |
  |---|---|---|
  | external display | `(3359, 30, 3360 x 1860)` — 1 x 1860 down the whole edge | `(3359, 1858, ...)` — 1 x 32 in the corner |
  | built-in | side park | `(-3599, 1137, ...)` — bottom **left**, nothing on the neighbour |

  Pixel readout of the right edge at mid-height goes from a uniform Ghostty grey column to ordinary
  Chrome content; the residue only appears in the bottom 44pt. Reveal round-trips cleanly, and the
  built-in picks the opposite corner from the external display, as the spill check intends.

Note for reviewers: 1pt of residue is not reachable through Accessibility. The clamp is the app-side
AX position setter, not macOS compositing — `SLSMoveWindow` places the same window with exactly 1pt
on screen and it holds, and disabling `AXEnhancedUserInterface` does not move the AX stop. Pinning
parked windows through the window server instead was considered and deliberately not taken: it means
a parked window's AX position permanently disagrees with where it actually is, for 31pt of residue
in a screen corner.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved hidden-window parking near screen corners and edges.
  * Prevented unnecessary repositioning when a window is already correctly parked.
  * Ensured hidden windows retain at least one point of visibility across display scales.
  * Improved handling of multiple monitors, neighboring displays, the Dock, and overlapping parking locations.

* **Tests**
  * Added coverage for corner parking, side-edge fallback, display scaling, visibility limits, and multi-monitor layouts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->