### PR TITLE
Fix focus and layout for macOS-hidden apps

### DIFF
--- a/Sources/OmniWM/Core/Controller/DwindleLayoutHandler.swift
+++ b/Sources/OmniWM/Core/Controller/DwindleLayoutHandler.swift
@@ -207,7 +207,15 @@ import QuartzCore
                 didMove = true
                 return
             }
+            let previousSelection = engine.selectedNode(in: wsId)
             guard let token = engine.moveFocus(direction: direction, in: wsId) else { return }
+            guard !controller.isManagedWindowSuppressedByMacOSHide(token) else {
+                engine.setSelectedNode(previousSelection, in: wsId)
+                controller.layoutRefreshController.requestLayoutCommandRelayout(
+                    affectedWorkspaceIds: [wsId]
+                )
+                return
+            }
             didMove = true
             if controller.workspaceManager.hiddenState(for: token) != nil {
                 commitGroupSelection(token, workspaceId: wsId, focusAfterLayout: true)
@@ -255,7 +263,8 @@ import QuartzCore
               let entry = controller.workspaceManager.entry(for: token),
               entry.workspaceId == workspaceId,
               entry.mode == .tiling,
-              entry.layoutReason == .standard
+              entry.layoutReason == .standard,
+              !controller.isManagedWindowSuppressedByMacOSHide(token)
         else {
             return .missing
         }
@@ -579,6 +588,7 @@ import QuartzCore
         return entry.workspaceId == workspaceId
             && entry.mode == .tiling
             && entry.layoutReason == .standard
+            && !controller.isManagedWindowSuppressedByMacOSHide(token)
             && !controller.isManagedWindowSuspendedForNativeFullscreen(token)
     }
 
@@ -1047,7 +1057,10 @@ import QuartzCore
             workspaceId: wsId,
             monitor: refreshInput.monitor,
             windows: refreshInput.windows,
-            preferredFocusToken: controller.workspaceManager.preferredFocusToken(in: wsId),
+            preferredFocusToken: controller.workspaceManager.preferredFocusToken(
+                in: wsId,
+                isSuppressed: controller.isManagedWindowSuppressedByMacOSHide
+            ),
             preferredHideSide: controller.layoutRefreshController.preferredHideSide(for: monitor),
             settings: controller.settings.resolvedDwindleSettings(for: monitor),
             isActiveWorkspace: refreshInput.isActiveWorkspace

--- a/Sources/OmniWM/Core/Controller/LayoutRefreshController.swift
+++ b/Sources/OmniWM/Core/Controller/LayoutRefreshController.swift
@@ -856,7 +856,9 @@ import QuartzCore
         guard let controller else { return nil }
 
         let monitorSnapshot = buildMonitorSnapshot(for: monitor, orientation: orientation)
-        let entries = controller.workspaceManager.tiledEntries(in: workspaceId)
+        let entries = controller.workspaceManager.tiledEntries(in: workspaceId).filter {
+            !controller.isManagedWindowSuppressedByMacOSHide($0.token)
+        }
         let windows = buildWindowSnapshots(
             for: entries,
             resolveConstraints: resolveConstraints,
@@ -1352,7 +1354,11 @@ import QuartzCore
     }
 
     private func buildVisibilityEffectPlan() -> EffectPlan {
-        EffectPlan(effects: EffectPlanEffects())
+        buildRelayoutEffectPlan(
+            useScrollAnimationPath: false,
+            recoverFocus: true,
+            affectedWorkspaceIds: []
+        )
     }
 
     private func buildWorkspacePlansInBatch(_ build: () -> [WorkspaceLayoutPlan]) -> [WorkspaceLayoutPlan] {

--- a/Sources/OmniWM/Core/Controller/NiriLayoutHandler.swift
+++ b/Sources/OmniWM/Core/Controller/NiriLayoutHandler.swift
@@ -387,8 +387,12 @@ enum StructuralMutationOutcome: Equatable {
         guard let controller else { return }
         let viewportState = controller.workspaceManager.niriViewportState(for: workspaceId)
         if let selectedNodeId = viewportState.selectedNodeId,
-           let selectedWindow = controller.niriEngine?.findNode(by: selectedNodeId, in: workspaceId) as? NiriWindow,
-           controller.workspaceManager.entry(for: selectedWindow.token)?.workspaceId == workspaceId
+           let selectedWindow = controller.niriEngine?.findNode(
+               by: selectedNodeId,
+               in: workspaceId
+           ) as? NiriWindow,
+           controller.workspaceManager.entry(for: selectedWindow.token)?.workspaceId == workspaceId,
+           !controller.isManagedWindowSuppressedByMacOSHide(selectedWindow.token)
         {
             controller.focusWindow(selectedWindow.token)
         }
@@ -498,7 +502,10 @@ enum StructuralMutationOutcome: Equatable {
             monitor: refreshInput.monitor,
             windows: refreshInput.windows,
             viewportState: effectiveViewportState,
-            preferredFocusToken: controller.workspaceManager.preferredFocusToken(in: wsId),
+            preferredFocusToken: controller.workspaceManager.preferredFocusToken(
+                in: wsId,
+                isSuppressed: controller.isManagedWindowSuppressedByMacOSHide
+            ),
             hasCompletedInitialRefresh: controller.layoutRefreshController.layoutState.hasCompletedInitialRefresh,
             useScrollAnimationPath: useScrollAnimationPath,
             removalSeed: removalSeed,
@@ -643,9 +650,18 @@ enum StructuralMutationOutcome: Equatable {
             viewportNeedsRecalc: selection.viewportNeedsRecalc,
             snapshot: snapshot
         )
-        plan.niriRestorePlacements = pass.engine.persistedPlacements(in: pass.wsId)
+        if shouldPersistNiriRestorePlacements(in: pass.wsId) {
+            plan.niriRestorePlacements = pass.engine.persistedPlacements(in: pass.wsId)
+        }
 
         return plan
+    }
+
+    private func shouldPersistNiriRestorePlacements(in workspaceId: WorkspaceDescriptor.ID) -> Bool {
+        guard let controller else { return true }
+        return !controller.workspaceManager.tiledEntries(in: workspaceId).contains {
+            controller.isManagedWindowSuppressedByMacOSHide($0.token)
+        }
     }
 
     private func restoreInitialNiriPlacementsIfNeeded(
@@ -1465,6 +1481,7 @@ enum StructuralMutationOutcome: Equatable {
         else {
             var recovered = false
             if let lastFocused = controller.workspaceManager.lastFocusedToken(in: wsId),
+               !controller.isManagedWindowSuppressedByMacOSHide(lastFocused),
                let lastNode = engine.findNode(for: lastFocused, in: wsId)
             {
                 activateNode(
@@ -1477,8 +1494,10 @@ enum StructuralMutationOutcome: Equatable {
                     )
                 )
                 recovered = true
-            } else if let firstToken = controller.workspaceManager.tiledEntries(in: wsId).first?.token,
-                      let firstNode = engine.findNode(for: firstToken, in: wsId)
+            } else if let firstEntry = controller.workspaceManager.tiledEntries(in: wsId).first(where: {
+                !controller.isManagedWindowSuppressedByMacOSHide($0.token)
+            }),
+                let firstNode = engine.findNode(for: firstEntry.token, in: wsId)
             {
                 activateNode(
                     firstNode, in: wsId, state: &state,
@@ -1524,6 +1543,12 @@ enum StructuralMutationOutcome: Equatable {
             )
         }
         guard let newNode else { return false }
+        if let windowNode = newNode as? NiriWindow,
+           controller.isManagedWindowSuppressedByMacOSHide(windowNode.token)
+        {
+            requestLayoutCommandRelayout(in: wsId)
+            return false
+        }
         activateNode(
             newNode, in: wsId, state: &state,
             options: .init(

--- a/Sources/OmniWM/Core/Controller/WMController.swift
+++ b/Sources/OmniWM/Core/Controller/WMController.swift
@@ -667,13 +667,18 @@ final class WMController {
 
     func isManagedWindowDisplayable(_ token: WindowToken) -> Bool {
         guard workspaceManager.entry(for: token) != nil else { return false }
-        if hiddenAppPIDs.contains(token.pid) {
+        if isManagedWindowSuppressedByMacOSHide(token) {
             return false
         }
         if workspaceManager.layoutReason(for: token) != .standard {
             return false
         }
         return !workspaceManager.isHiddenInCorner(token)
+    }
+
+    func isManagedWindowSuppressedByMacOSHide(_ token: WindowToken) -> Bool {
+        hiddenAppPIDs.contains(token.pid)
+            || workspaceManager.layoutReason(for: token) == .macosHiddenApp
     }
 
     func isManagedWindowSuspendedForNativeFullscreen(_ token: WindowToken) -> Bool {
@@ -1598,7 +1603,10 @@ final class WMController {
     ) -> WindowToken? {
         let explicitCandidates = [
             workspaceManager.lastFocusedToken(in: workspaceId),
-            workspaceManager.preferredFocusToken(in: workspaceId),
+            workspaceManager.preferredFocusToken(
+                in: workspaceId,
+                isSuppressed: isManagedWindowSuppressedByMacOSHide
+            ),
             workspaceManager.lastFloatingFocusedToken(in: workspaceId),
             workspaceManager.focusedToken
         ]
@@ -1636,7 +1644,11 @@ final class WMController {
             return
         }
 
-        _ = workspaceManager.resolveAndSetWorkspaceFocusToken(in: workspaceId, onMonitor: monitorId)
+        _ = workspaceManager.resolveAndSetWorkspaceFocusToken(
+            in: workspaceId,
+            onMonitor: monitorId,
+            isSuppressed: isManagedWindowSuppressedByMacOSHide
+        )
     }
 
     func cleanupScratchpadWindowResources(for token: WindowToken) {
@@ -2931,7 +2943,8 @@ final class WMController {
     func resolveAndSetWorkspaceFocusToken(for workspaceId: WorkspaceDescriptor.ID) -> WindowToken? {
         workspaceManager.resolveAndSetWorkspaceFocusToken(
             in: workspaceId,
-            onMonitor: workspaceManager.monitorId(for: workspaceId)
+            onMonitor: workspaceManager.monitorId(for: workspaceId),
+            isSuppressed: isManagedWindowSuppressedByMacOSHide
         )
     }
 
@@ -2952,9 +2965,16 @@ final class WMController {
         switch workspaceManager.activeLayoutKind(for: workspaceId) {
         case .niri:
             if let engine = niriEngine {
-                let node = preferredToken.flatMap { engine.findNode(for: $0, in: workspaceId) }
-                    ?? preferredNodeId.flatMap { engine.findNode(by: $0, in: workspaceId) as? NiriWindow }
-                if let node {
+                let preferredTokenNode: NiriWindow? = preferredToken.flatMap { token in
+                    guard !isManagedWindowSuppressedByMacOSHide(token) else { return nil }
+                    return engine.findNode(for: token, in: workspaceId)
+                }
+                let preferredNode = preferredNodeId
+                    .flatMap { engine.findNode(by: $0, in: workspaceId) as? NiriWindow }
+                    .flatMap { node in
+                        isManagedWindowSuppressedByMacOSHide(node.token) ? nil : node
+                    }
+                if let node = preferredTokenNode ?? preferredNode {
                     _ = workspaceManager.commitWorkspaceSelection(
                         nodeId: node.id,
                         focusedToken: node.token,
@@ -2965,7 +2985,9 @@ final class WMController {
                 }
             }
         case .dwindle:
-            if let token = dwindleEngine?.selectedNode(in: workspaceId)?.windowToken {
+            if let token = dwindleEngine?.selectedNode(in: workspaceId)?.windowToken,
+               !isManagedWindowSuppressedByMacOSHide(token)
+            {
                 _ = workspaceManager.commitWorkspaceSelection(
                     nodeId: nil,
                     focusedToken: token,
@@ -2975,6 +2997,7 @@ final class WMController {
                 return
             }
             if let preferredToken,
+               !isManagedWindowSuppressedByMacOSHide(preferredToken),
                dwindleEngine?.findNode(for: preferredToken, in: workspaceId) != nil
             {
                 commitWorkspaceFocusCandidate(preferredToken, in: workspaceId)
@@ -2982,7 +3005,11 @@ final class WMController {
             }
         }
 
-        _ = workspaceManager.resolveAndSetWorkspaceFocusToken(in: workspaceId, onMonitor: monitorId)
+        _ = workspaceManager.resolveAndSetWorkspaceFocusToken(
+            in: workspaceId,
+            onMonitor: monitorId,
+            isSuppressed: isManagedWindowSuppressedByMacOSHide
+        )
     }
 
     @discardableResult
@@ -3044,7 +3071,8 @@ final class WMController {
         guard !workspaceManager.hasPendingNativeFullscreenTransition else { return }
 
         if let pendingFocusedToken = workspaceManager.pendingFocusedToken,
-           workspaceManager.pendingFocusedWorkspaceId == workspaceId
+           workspaceManager.pendingFocusedWorkspaceId == workspaceId,
+           !isManagedWindowSuppressedByMacOSHide(pendingFocusedToken)
         {
             commitWorkspaceFocusCandidate(pendingFocusedToken, in: workspaceId)
             return
@@ -3052,7 +3080,8 @@ final class WMController {
 
         if let preferredRecoveryToken {
             if let entry = workspaceManager.entry(for: preferredRecoveryToken),
-               entry.workspaceId == workspaceId
+               entry.workspaceId == workspaceId,
+               !isManagedWindowSuppressedByMacOSHide(preferredRecoveryToken)
             {
                 let routedDwindleFocus = commitWorkspaceFocusCandidate(
                     preferredRecoveryToken,
@@ -3067,7 +3096,8 @@ final class WMController {
         }
 
         if let focusedToken = workspaceManager.focusedToken,
-           workspaceManager.entry(for: focusedToken)?.workspaceId == workspaceId
+           workspaceManager.entry(for: focusedToken)?.workspaceId == workspaceId,
+           !isManagedWindowSuppressedByMacOSHide(focusedToken)
         {
             commitWorkspaceFocusCandidate(focusedToken, in: workspaceId)
             return
@@ -3075,7 +3105,8 @@ final class WMController {
 
         guard let nextFocusToken = workspaceManager.resolveAndSetWorkspaceFocusToken(
             in: workspaceId,
-            onMonitor: workspaceManager.monitorId(for: workspaceId)
+            onMonitor: workspaceManager.monitorId(for: workspaceId),
+            isSuppressed: isManagedWindowSuppressedByMacOSHide
         ) else {
             return
         }
@@ -3195,7 +3226,8 @@ extension WMController {
 
     func retryManagedFocusFronting(_ request: ManagedFocusRequest) {
         guard let entry = workspaceManager.entry(for: request.token),
-              entry.workspaceId == request.workspaceId
+              entry.workspaceId == request.workspaceId,
+              !isManagedWindowSuppressedByMacOSHide(request.token)
         else {
             return
         }
@@ -3208,6 +3240,7 @@ extension WMController {
 
     func activateNativeFullscreenPlaceholder(_ token: WindowToken) {
         guard let entry = workspaceManager.entry(for: token) else { return }
+        guard !isManagedWindowSuppressedByMacOSHide(token) else { return }
         guard workspaceManager.layoutReason(for: token) == .nativeFullscreen else { return }
         guard !isLockScreenActive else { return }
         if hasStartedServices {
@@ -3294,6 +3327,9 @@ extension WMController {
         guard !isLockScreenActive else { return }
         if hasStartedServices {
             guard !isFrontmostAppLockScreen() else { return }
+        }
+        if isManagedWindowSuppressedByMacOSHide(token) {
+            return
         }
         if isManagedWindowSuspendedForNativeFullscreen(token) {
             selectNativeFullscreenPlaceholder(entry)

--- a/Sources/OmniWM/Core/Controller/WorkspaceNavigationHandler.swift
+++ b/Sources/OmniWM/Core/Controller/WorkspaceNavigationHandler.swift
@@ -309,7 +309,9 @@ final class WorkspaceNavigationHandler {
             : nil
         let candidates = controller.workspaceManager.tiledEntries(in: targetWorkspace.id)
             .compactMap { entry -> (token: WindowToken, frame: CGRect)? in
-                if dwindleEngine?.isInactiveGroupMember(entry.token, in: targetWorkspace.id) == true {
+                if controller.isManagedWindowSuppressedByMacOSHide(entry.token)
+                    || dwindleEngine?.isInactiveGroupMember(entry.token, in: targetWorkspace.id) == true
+                {
                     return nil
                 }
                 return controller.preferredKeyboardFocusFrame(for: entry.token).map {
@@ -374,6 +376,7 @@ final class WorkspaceNavigationHandler {
         let anchorToken: WindowToken? = targetIsNiri ? Self.spatialNeighborToken(
             from: controller.preferredKeyboardFocusFrame(for: handle.id),
             candidates: controller.workspaceManager.tiledEntries(in: targetWorkspace.id)
+                .filter { !controller.isManagedWindowSuppressedByMacOSHide($0.token) }
                 .compactMap { entry in
                     controller.preferredKeyboardFocusFrame(for: entry.token).map { (token: entry.token, frame: $0) }
                 },
@@ -963,7 +966,10 @@ final class WorkspaceNavigationHandler {
         controller.reassignManagedWindow(token, to: targetWorkspaceId)
         guard workspaceManager.workspace(for: token) == targetWorkspaceId else { return false }
 
-        _ = workspaceManager.resolveAndSetWorkspaceFocusToken(in: sourceWorkspaceId)
+        _ = workspaceManager.resolveAndSetWorkspaceFocusToken(
+            in: sourceWorkspaceId,
+            isSuppressed: controller.isManagedWindowSuppressedByMacOSHide
+        )
 
         if let matchingRequest {
             guard let retargetedRequest = controller.intentLedger.retargetManagedRequest(

--- a/Sources/OmniWM/Core/Workspace/WorkspaceManager.swift
+++ b/Sources/OmniWM/Core/Workspace/WorkspaceManager.swift
@@ -1425,11 +1425,15 @@ final class WorkspaceManager {
         world.focus.lastFloatingFocusedByWorkspace[workspaceId]
     }
 
-    func preferredFocusToken(in workspaceId: WorkspaceDescriptor.ID) -> WindowToken? {
+    func preferredFocusToken(
+        in workspaceId: WorkspaceDescriptor.ID,
+        isSuppressed: (WindowToken) -> Bool
+    ) -> WindowToken? {
         if let pendingToken = eligibleFocusCandidate(
             world.focus.pendingManagedFocus.token,
             in: workspaceId,
-            mode: .tiling
+            mode: .tiling,
+            isSuppressed: isSuppressed
         ),
             world.focus.pendingManagedFocus.workspaceId == workspaceId
         {
@@ -1439,7 +1443,8 @@ final class WorkspaceManager {
         if let remembered = eligibleFocusCandidate(
             world.focus.lastTiledFocusedByWorkspace[workspaceId],
             in: workspaceId,
-            mode: .tiling
+            mode: .tiling,
+            isSuppressed: isSuppressed
         ) {
             return remembered
         }
@@ -1447,20 +1452,29 @@ final class WorkspaceManager {
         if let confirmed = eligibleFocusCandidate(
             world.focus.focusedToken,
             in: workspaceId,
-            mode: .tiling
+            mode: .tiling,
+            isSuppressed: isSuppressed
         ) {
             return confirmed
         }
 
         return tiledEntries(in: workspaceId).first {
-            isFocusResolutionEligible($0, in: workspaceId, mode: .tiling)
+            isFocusResolutionEligible($0, in: workspaceId, mode: .tiling, isSuppressed: isSuppressed)
         }?.token
     }
 
-    func resolveWorkspaceFocusToken(in workspaceId: WorkspaceDescriptor.ID) -> WindowToken? {
+    func resolveWorkspaceFocusToken(
+        in workspaceId: WorkspaceDescriptor.ID,
+        isSuppressed: (WindowToken) -> Bool
+    ) -> WindowToken? {
         if let mostRecent = world.focus.lastFocusedByWorkspace[workspaceId],
            let mode = windowMode(for: mostRecent),
-           let remembered = eligibleFocusCandidate(mostRecent, in: workspaceId, mode: mode)
+           let remembered = eligibleFocusCandidate(
+               mostRecent,
+               in: workspaceId,
+               mode: mode,
+               isSuppressed: isSuppressed
+           )
         {
             return remembered
         }
@@ -1468,38 +1482,42 @@ final class WorkspaceManager {
         if let remembered = eligibleFocusCandidate(
             world.focus.lastTiledFocusedByWorkspace[workspaceId],
             in: workspaceId,
-            mode: .tiling
+            mode: .tiling,
+            isSuppressed: isSuppressed
         ) {
             return remembered
         }
-        if let preferredTiled = preferredFocusToken(in: workspaceId) {
+        if let preferredTiled = preferredFocusToken(in: workspaceId, isSuppressed: isSuppressed) {
             return preferredTiled
         }
         if let rememberedFloating = eligibleFocusCandidate(
             world.focus.lastFloatingFocusedByWorkspace[workspaceId],
             in: workspaceId,
-            mode: .floating
+            mode: .floating,
+            isSuppressed: isSuppressed
         ) {
             return rememberedFloating
         }
         if let confirmed = eligibleFocusCandidate(
             world.focus.focusedToken,
             in: workspaceId,
-            mode: .floating
+            mode: .floating,
+            isSuppressed: isSuppressed
         ) {
             return confirmed
         }
         return floatingEntries(in: workspaceId).first {
-            isFocusResolutionEligible($0, in: workspaceId, mode: .floating)
+            isFocusResolutionEligible($0, in: workspaceId, mode: .floating, isSuppressed: isSuppressed)
         }?.token
     }
 
     @discardableResult
     func resolveAndSetWorkspaceFocusToken(
         in workspaceId: WorkspaceDescriptor.ID,
-        onMonitor _: Monitor.ID? = nil
+        onMonitor _: Monitor.ID? = nil,
+        isSuppressed: (WindowToken) -> Bool
     ) -> WindowToken? {
-        if let token = resolveWorkspaceFocusToken(in: workspaceId) {
+        if let token = resolveWorkspaceFocusToken(in: workspaceId, isSuppressed: isSuppressed) {
             _ = rememberFocus(token, in: workspaceId)
             return token
         }
@@ -1620,11 +1638,12 @@ final class WorkspaceManager {
     private func eligibleFocusCandidate(
         _ token: WindowToken?,
         in workspaceId: WorkspaceDescriptor.ID,
-        mode: TrackedWindowMode
+        mode: TrackedWindowMode,
+        isSuppressed: (WindowToken) -> Bool
     ) -> WindowToken? {
         guard let token,
               let entry = entry(for: token),
-              isFocusResolutionEligible(entry, in: workspaceId, mode: mode)
+              isFocusResolutionEligible(entry, in: workspaceId, mode: mode, isSuppressed: isSuppressed)
         else {
             return nil
         }
@@ -1634,10 +1653,13 @@ final class WorkspaceManager {
     private func isFocusResolutionEligible(
         _ entry: WindowState,
         in workspaceId: WorkspaceDescriptor.ID,
-        mode: TrackedWindowMode
+        mode: TrackedWindowMode,
+        isSuppressed: (WindowToken) -> Bool
     ) -> Bool {
         guard entry.workspaceId == workspaceId,
-              entry.mode == mode
+              entry.mode == mode,
+              entry.layoutReason != .macosHiddenApp,
+              !isSuppressed(entry.token)
         else {
             return false
         }

--- a/Tests/OmniWMTests/FloatingFocusMRUTests.swift
+++ b/Tests/OmniWMTests/FloatingFocusMRUTests.swift
@@ -23,7 +23,7 @@ final class FloatingFocusMRUTests: XCTestCase {
         _ = manager.rememberFocus(tiled, in: workspaceId)
         _ = manager.rememberFocus(floating, in: workspaceId)
 
-        XCTAssertEqual(manager.resolveWorkspaceFocusToken(in: workspaceId), floating)
+        XCTAssertEqual(resolvedFocus(in: workspaceId, manager: manager), floating)
     }
 
     func testWorkspaceFocusReturnsToTheTiledWindowWhenItWasFocusedLast() {
@@ -41,7 +41,7 @@ final class FloatingFocusMRUTests: XCTestCase {
         _ = manager.rememberFocus(floating, in: workspaceId)
         _ = manager.rememberFocus(tiled, in: workspaceId)
 
-        XCTAssertEqual(manager.resolveWorkspaceFocusToken(in: workspaceId), tiled)
+        XCTAssertEqual(resolvedFocus(in: workspaceId, manager: manager), tiled)
     }
 
     func testRefocusingTheSameTiledWindowAfterAFloatingWindowWins() {
@@ -60,7 +60,7 @@ final class FloatingFocusMRUTests: XCTestCase {
         _ = manager.rememberFocus(floating, in: workspaceId)
         _ = manager.rememberFocus(tiled, in: workspaceId)
 
-        XCTAssertEqual(manager.resolveWorkspaceFocusToken(in: workspaceId), tiled)
+        XCTAssertEqual(resolvedFocus(in: workspaceId, manager: manager), tiled)
     }
 
     func testRefocusingTheSameFloatingWindowAfterATiledWindowWins() {
@@ -79,7 +79,7 @@ final class FloatingFocusMRUTests: XCTestCase {
         _ = manager.rememberFocus(tiled, in: workspaceId)
         _ = manager.rememberFocus(floating, in: workspaceId)
 
-        XCTAssertEqual(manager.resolveWorkspaceFocusToken(in: workspaceId), floating)
+        XCTAssertEqual(resolvedFocus(in: workspaceId, manager: manager), floating)
     }
 
     func testSessionPatchRestatingTiledFallbackDoesNotReplaceFloatingMRU() {
@@ -110,7 +110,7 @@ final class FloatingFocusMRUTests: XCTestCase {
         XCTAssertEqual(manager.worldSeq, seq)
         XCTAssertEqual(manager.lastFocusedToken(in: workspaceId), tiled)
         XCTAssertEqual(manager.lastFloatingFocusedToken(in: workspaceId), floating)
-        XCTAssertEqual(manager.resolveWorkspaceFocusToken(in: workspaceId), floating)
+        XCTAssertEqual(resolvedFocus(in: workspaceId, manager: manager), floating)
     }
 
     func testSessionPatchChangesTiledFallbackWithoutReplacingFloatingMRU() {
@@ -140,7 +140,7 @@ final class FloatingFocusMRUTests: XCTestCase {
         XCTAssertTrue(changed)
         XCTAssertEqual(manager.lastFocusedToken(in: workspaceId), secondTiled)
         XCTAssertEqual(manager.lastFloatingFocusedToken(in: workspaceId), floating)
-        XCTAssertEqual(manager.resolveWorkspaceFocusToken(in: workspaceId), floating)
+        XCTAssertEqual(resolvedFocus(in: workspaceId, manager: manager), floating)
     }
 
     func testRemovingTheMostRecentFloatingWindowFallsBackToTheTiledWindow() {
@@ -159,7 +159,7 @@ final class FloatingFocusMRUTests: XCTestCase {
         _ = manager.rememberFocus(floating, in: workspaceId)
         _ = manager.removeWindow(pid: floating.pid, windowId: floating.windowId)
 
-        XCTAssertEqual(manager.resolveWorkspaceFocusToken(in: workspaceId), tiled)
+        XCTAssertEqual(resolvedFocus(in: workspaceId, manager: manager), tiled)
     }
 
     func testUnifiedSlotSurvivesAModeChangeOfTheRememberedWindow() {
@@ -179,7 +179,17 @@ final class FloatingFocusMRUTests: XCTestCase {
         _ = manager.setWindowMode(.tiling, for: floating)
 
         XCTAssertEqual(manager.lastFocusedToken(in: workspaceId), tiled)
-        XCTAssertEqual(manager.resolveWorkspaceFocusToken(in: workspaceId), floating)
+        XCTAssertEqual(resolvedFocus(in: workspaceId, manager: manager), floating)
+    }
+
+    private func resolvedFocus(
+        in workspaceId: WorkspaceDescriptor.ID,
+        manager: WorkspaceManager
+    ) -> WindowToken? {
+        manager.resolveWorkspaceFocusToken(
+            in: workspaceId,
+            isSuppressed: { _ in false }
+        )
     }
 
     private func makeManager() -> WorkspaceManager {

--- a/Tests/OmniWMTests/FloatingMonitorRebindFocusTests.swift
+++ b/Tests/OmniWMTests/FloatingMonitorRebindFocusTests.swift
@@ -74,9 +74,9 @@ final class FloatingMonitorRebindFocusTests: XCTestCase {
         XCTAssertEqual(manager.interactionMonitorId, fixture.targetMonitor.id)
         XCTAssertEqual(manager.previousInteractionMonitorId, fixture.sourceMonitor.id)
         XCTAssertEqual(manager.lastFloatingFocusedToken(in: fixture.sourceWorkspaceId), sourceFallback)
-        XCTAssertEqual(manager.resolveWorkspaceFocusToken(in: fixture.sourceWorkspaceId), sourceFallback)
+        XCTAssertEqual(resolvedFocus(in: fixture.sourceWorkspaceId, manager: manager), sourceFallback)
         XCTAssertEqual(manager.lastFloatingFocusedToken(in: fixture.targetWorkspaceId), moving)
-        XCTAssertEqual(manager.resolveWorkspaceFocusToken(in: fixture.targetWorkspaceId), moving)
+        XCTAssertEqual(resolvedFocus(in: fixture.targetWorkspaceId, manager: manager), moving)
         XCTAssertNil(manager.pendingFocusedToken)
         XCTAssertNil(controller.intentLedger.activeManagedRequest)
         XCTAssertTrue(fixture.focusRecorder.focusedTokens.isEmpty)
@@ -99,7 +99,50 @@ final class FloatingMonitorRebindFocusTests: XCTestCase {
             manager.activeWorkspace(on: fixture.targetMonitor.id)?.id,
             fixture.targetWorkspaceId
         )
-        XCTAssertEqual(manager.resolveWorkspaceFocusToken(in: fixture.targetWorkspaceId), moving)
+        XCTAssertEqual(resolvedFocus(in: fixture.targetWorkspaceId, manager: manager), moving)
+    }
+
+    func testFloatingRebindSourceFocusSkipsPIDHiddenFallbackBeforeLayoutReasonUpdates() throws {
+        let fixture = try makeFixture()
+        let controller = fixture.controller
+        defer { controller.deadlineWheel.stop() }
+        let manager = controller.workspaceManager
+        let hiddenFallback = addFloatingWindow(
+            pid: 489_012,
+            windowId: 1,
+            to: fixture.sourceWorkspaceId,
+            controller: controller
+        )
+        let visibleFallback = addFloatingWindow(
+            pid: 489_013,
+            windowId: 2,
+            to: fixture.sourceWorkspaceId,
+            controller: controller
+        )
+        let moving = addFloatingWindow(
+            pid: 489_014,
+            windowId: 3,
+            to: fixture.sourceWorkspaceId,
+            controller: controller
+        )
+
+        _ = manager.rememberFocus(visibleFallback, in: fixture.sourceWorkspaceId)
+        _ = manager.rememberFocus(hiddenFallback, in: fixture.sourceWorkspaceId)
+        controller.hiddenAppPIDs.insert(hiddenFallback.pid)
+        XCTAssertEqual(manager.layoutReason(for: hiddenFallback), .standard)
+
+        rebind(moving, fixture: fixture)
+
+        XCTAssertEqual(manager.workspace(for: moving), fixture.targetWorkspaceId)
+        XCTAssertEqual(manager.lastFloatingFocusedToken(in: fixture.sourceWorkspaceId), visibleFallback)
+        XCTAssertEqual(
+            manager.resolveWorkspaceFocusToken(
+                in: fixture.sourceWorkspaceId,
+                isSuppressed: controller.isManagedWindowSuppressedByMacOSHide
+            ),
+            visibleFallback
+        )
+        XCTAssertNotEqual(manager.lastFloatingFocusedToken(in: fixture.sourceWorkspaceId), hiddenFallback)
     }
 
     func testFloatingRebindRetargetsMatchingPendingFocusRequest() throws {
@@ -333,7 +376,7 @@ final class FloatingMonitorRebindFocusTests: XCTestCase {
         XCTAssertEqual(manager.focusedToken, focused)
         XCTAssertEqual(manager.interactionMonitorId, fixture.sourceMonitor.id)
         XCTAssertEqual(manager.lastFloatingFocusedToken(in: fixture.targetWorkspaceId), targetFallback)
-        XCTAssertEqual(manager.resolveWorkspaceFocusToken(in: fixture.targetWorkspaceId), targetFallback)
+        XCTAssertEqual(resolvedFocus(in: fixture.targetWorkspaceId, manager: manager), targetFallback)
         XCTAssertTrue(controller.surfaceReconciler.reconcileScheduled)
         let sourceProjectionAfter = projection(on: fixture.sourceMonitor, fixture: fixture)
         let targetProjectionAfter = projection(on: fixture.targetMonitor, fixture: fixture)
@@ -404,7 +447,7 @@ final class FloatingMonitorRebindFocusTests: XCTestCase {
             rememberedFloating
         )
         XCTAssertEqual(
-            manager.resolveWorkspaceFocusToken(in: fixture.sourceWorkspaceId),
+            resolvedFocus(in: fixture.sourceWorkspaceId, manager: manager),
             rememberedFloating
         )
         XCTAssertEqual(manager.invariantViolationCountsDump(), "clean")
@@ -638,7 +681,7 @@ final class FloatingMonitorRebindFocusTests: XCTestCase {
         XCTAssertEqual(manager.focusedToken, moving)
         XCTAssertEqual(manager.interactionMonitorId, fixture.sourceMonitor.id)
         XCTAssertEqual(manager.lastFloatingFocusedToken(in: fixture.targetWorkspaceId), targetFallback)
-        XCTAssertEqual(manager.resolveWorkspaceFocusToken(in: fixture.targetWorkspaceId), targetFallback)
+        XCTAssertEqual(resolvedFocus(in: fixture.targetWorkspaceId, manager: manager), targetFallback)
         XCTAssertTrue(fixture.focusRecorder.focusedTokens.isEmpty)
         XCTAssertNil(controller.layoutRefreshController.layoutState.activeRefresh)
         XCTAssertNil(controller.layoutRefreshController.layoutState.pendingRefresh)
@@ -789,6 +832,16 @@ final class FloatingMonitorRebindFocusTests: XCTestCase {
             iconResolver: controller.workspaceBarIconResolver,
             focusedToken: controller.workspaceManager.focusedToken,
             settings: controller.settings
+        )
+    }
+
+    private func resolvedFocus(
+        in workspaceId: WorkspaceDescriptor.ID,
+        manager: WorkspaceManager
+    ) -> WindowToken? {
+        manager.resolveWorkspaceFocusToken(
+            in: workspaceId,
+            isSuppressed: { _ in false }
         )
     }
 

--- a/Tests/OmniWMTests/MacOSHiddenAppTests.swift
+++ b/Tests/OmniWMTests/MacOSHiddenAppTests.swift
@@ -1,0 +1,205 @@
+// SPDX-License-Identifier: GPL-2.0-only
+// Copyright (C) 2026 BarutSRB — https://github.com/BarutSRB/OmniWM
+
+import ApplicationServices
+import Foundation
+@testable import OmniWM
+import XCTest
+
+@MainActor
+final class MacOSHiddenAppTests: XCTestCase {
+    func testLayoutRefreshInputExcludesMacOSHiddenAppWindows() throws {
+        let controller = makeController()
+        let workspaceId = try XCTUnwrap(controller.workspaceManager.workspaceId(for: "1", createIfMissing: true))
+        _ = controller.workspaceManager.focusWorkspace(named: "1")
+
+        let hiddenByPIDToken = addWindow(pid: 880_001, windowId: 880_101, to: workspaceId, controller: controller)
+        let hiddenByReasonToken = addWindow(pid: 880_002, windowId: 880_102, to: workspaceId, controller: controller)
+        let visibleToken = addWindow(pid: 880_003, windowId: 880_103, to: workspaceId, controller: controller)
+        controller.hiddenAppPIDs.insert(hiddenByPIDToken.pid)
+        controller.workspaceManager.setLayoutReason(.macosHiddenApp, for: hiddenByReasonToken)
+
+        let monitor = try XCTUnwrap(controller.workspaceManager.monitor(for: workspaceId))
+        let input = try XCTUnwrap(
+            controller.layoutRefreshController.buildRefreshInput(
+                workspaceId: workspaceId,
+                monitor: monitor,
+                resolveConstraints: false,
+                isActiveWorkspace: true
+            )
+        )
+
+        XCTAssertEqual(input.windows.map(\.token), [visibleToken])
+    }
+
+    func testFocusResolutionSkipsPIDHiddenWindowsEvenBeforeLayoutReasonUpdates() throws {
+        let controller = makeController()
+        let workspaceId = try XCTUnwrap(controller.workspaceManager.workspaceId(for: "1", createIfMissing: true))
+        _ = controller.workspaceManager.focusWorkspace(named: "1")
+
+        let hiddenToken = addWindow(pid: 880_006, windowId: 880_106, to: workspaceId, controller: controller)
+        let visibleToken = addWindow(pid: 880_007, windowId: 880_107, to: workspaceId, controller: controller)
+        _ = controller.workspaceManager.rememberFocus(hiddenToken, in: workspaceId)
+        controller.hiddenAppPIDs.insert(hiddenToken.pid)
+
+        let resolvedToken = controller.resolveAndSetWorkspaceFocusToken(for: workspaceId)
+
+        XCTAssertEqual(resolvedToken, visibleToken)
+        XCTAssertEqual(controller.workspaceManager.lastFocusedToken(in: workspaceId), visibleToken)
+    }
+
+    func testFocusWindowDoesNotActivateMacOSHiddenAppWindows() throws {
+        var activatedPIDs: [pid_t] = []
+        var focusedTokens: [WindowToken] = []
+        let controller = makeController(
+            windowFocusOperations: WindowFocusOperations(
+                activateApp: { activatedPIDs.append($0) },
+                focusSpecificWindow: { pid, windowId, _ in
+                    focusedTokens.append(WindowToken(pid: pid, windowId: Int(windowId)))
+                },
+                raiseWindow: { _ in }
+            )
+        )
+        let workspaceId = try XCTUnwrap(controller.workspaceManager.workspaceId(for: "1", createIfMissing: true))
+        _ = controller.workspaceManager.focusWorkspace(named: "1")
+        let hiddenToken = addWindow(pid: 880_011, windowId: 880_111, to: workspaceId, controller: controller)
+        controller.hiddenAppPIDs.insert(hiddenToken.pid)
+        controller.workspaceManager.setLayoutReason(.macosHiddenApp, for: hiddenToken)
+
+        controller.focusWindow(hiddenToken)
+
+        XCTAssertTrue(activatedPIDs.isEmpty)
+        XCTAssertTrue(focusedTokens.isEmpty)
+    }
+
+    func testNiriDirectionalFocusDoesNotSelectOrFocusMacOSHiddenTargetBeforeRelayout() throws {
+        var focusedTokens: [WindowToken] = []
+        let controller = makeController(
+            windowFocusOperations: WindowFocusOperations(
+                activateApp: { _ in },
+                focusSpecificWindow: { pid, windowId, _ in
+                    focusedTokens.append(WindowToken(pid: pid, windowId: Int(windowId)))
+                },
+                raiseWindow: { _ in }
+            )
+        )
+        let workspaceId = try XCTUnwrap(controller.workspaceManager.workspaceId(for: "1", createIfMissing: true))
+        _ = controller.workspaceManager.focusWorkspace(named: "1")
+        controller.niriLayoutHandler.enableNiriLayout()
+
+        let hiddenToken = addWindow(pid: 880_021, windowId: 880_121, to: workspaceId, controller: controller)
+        let visibleToken = addWindow(pid: 880_022, windowId: 880_122, to: workspaceId, controller: controller)
+        let engine = try XCTUnwrap(controller.niriEngine)
+        let hiddenNode = engine.addWindow(token: hiddenToken, to: workspaceId, afterSelection: nil)
+        let visibleNode = engine.addWindow(
+            token: visibleToken,
+            to: workspaceId,
+            afterSelection: hiddenNode.id,
+            focusedToken: hiddenToken
+        )
+        _ = controller.workspaceManager.commitWorkspaceSelection(
+            nodeId: visibleNode.id,
+            focusedToken: visibleToken,
+            in: workspaceId,
+            onMonitor: controller.workspaceManager.monitorId(for: workspaceId)
+        )
+        controller.hiddenAppPIDs.insert(hiddenToken.pid)
+        controller.workspaceManager.setLayoutReason(.macosHiddenApp, for: hiddenToken)
+
+        let didMove = controller.niriLayoutHandler.focusNeighbor(direction: .left)
+
+        XCTAssertFalse(didMove)
+        XCTAssertTrue(focusedTokens.isEmpty)
+        XCTAssertEqual(controller.workspaceManager.niriViewportState(for: workspaceId).selectedNodeId, visibleNode.id)
+    }
+
+    func testNiriMacOSHiddenAppRemovalAndUnhidePreservesPlacement() throws {
+        let controller = makeController()
+        let workspaceId = try XCTUnwrap(controller.workspaceManager.workspaceId(for: "1", createIfMissing: true))
+        _ = controller.workspaceManager.focusWorkspace(named: "1")
+        controller.niriLayoutHandler.enableNiriLayout()
+
+        let firstToken = addWindow(pid: 880_031, windowId: 880_131, to: workspaceId, controller: controller)
+        let hiddenToken = addWindow(pid: 880_032, windowId: 880_132, to: workspaceId, controller: controller)
+        let thirdToken = addWindow(pid: 880_033, windowId: 880_133, to: workspaceId, controller: controller)
+        let engine = try XCTUnwrap(controller.niriEngine)
+        let firstNode = engine.addWindow(token: firstToken, to: workspaceId, afterSelection: nil)
+        let hiddenNode = engine.addWindow(
+            token: hiddenToken,
+            to: workspaceId,
+            afterSelection: firstNode.id,
+            focusedToken: firstToken
+        )
+        let thirdNode = engine.addWindow(
+            token: thirdToken,
+            to: workspaceId,
+            afterSelection: hiddenNode.id,
+            focusedToken: hiddenToken
+        )
+        _ = controller.workspaceManager.commitWorkspaceSelection(
+            nodeId: thirdNode.id,
+            focusedToken: thirdToken,
+            in: workspaceId,
+            onMonitor: controller.workspaceManager.monitorId(for: workspaceId)
+        )
+        controller.workspaceManager.setNiriRestorePlacements(engine.persistedPlacements(in: workspaceId))
+
+        controller.hiddenAppPIDs.insert(hiddenToken.pid)
+        controller.workspaceManager.setLayoutReason(.macosHiddenApp, for: hiddenToken)
+        let hidePlan = try XCTUnwrap(controller.workspaceManager.withEngineMutationScope {
+            controller.niriLayoutHandler.layoutWithNiriEngine(activeWorkspaces: [workspaceId]).first
+        })
+        XCTAssertTrue(controller.layoutRefreshController.executeLayoutPlan(hidePlan))
+        XCTAssertEqual(engine.columns(in: workspaceId).map { $0.windowNodes.map(\.token) }, [[firstToken], [thirdToken]])
+        XCTAssertEqual(controller.workspaceManager.restoreIntent(for: thirdToken)?.niriPlacement?.columnIndex, 2)
+
+        controller.hiddenAppPIDs.remove(hiddenToken.pid)
+        XCTAssertTrue(controller.workspaceManager.restoreFromNativeState(for: hiddenToken))
+        _ = controller.workspaceManager.withEngineMutationScope {
+            controller.niriLayoutHandler.layoutWithNiriEngine(activeWorkspaces: [workspaceId])
+        }
+
+        XCTAssertEqual(
+            engine.columns(in: workspaceId).map { $0.windowNodes.map(\.token) },
+            [[firstToken], [hiddenToken], [thirdToken]]
+        )
+    }
+
+    private func makeController(
+        windowFocusOperations: WindowFocusOperations = WindowFocusOperations(
+            activateApp: { _ in },
+            focusSpecificWindow: { _, _, _ in },
+            raiseWindow: { _ in }
+        )
+    ) -> WMController {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("OmniWMMacOSHiddenAppTests-\(UUID().uuidString)", isDirectory: true)
+        let settings = SettingsStore(
+            persistence: SettingsFilePersistence(
+                directory: root.appendingPathComponent("config", isDirectory: true),
+                startWatching: false,
+                deferSaves: false
+            ),
+            runtimeState: RuntimeStateStore(
+                directory: root.appendingPathComponent("state", isDirectory: true),
+                deferSaves: false
+            ),
+            autosaveEnabled: false
+        )
+        return WMController(settings: settings, windowFocusOperations: windowFocusOperations)
+    }
+
+    private func addWindow(
+        pid: pid_t,
+        windowId: Int,
+        to workspaceId: WorkspaceDescriptor.ID,
+        controller: WMController
+    ) -> WindowToken {
+        controller.workspaceManager.addWindow(
+            AXWindowRef(element: AXUIElementCreateApplication(pid), windowId: windowId),
+            pid: pid,
+            windowId: windowId,
+            to: workspaceId
+        )
+    }
+}

--- a/Tests/OmniWMTests/RuntimeArchitectureTests.swift
+++ b/Tests/OmniWMTests/RuntimeArchitectureTests.swift
@@ -4502,7 +4502,13 @@ final class RuntimeArchitectureTests: XCTestCase {
         XCTAssertNotNil(controller.layoutRefreshController.executeLayoutPlanReturningAcceptedSeq(plan))
         XCTAssertEqual(controller.workspaceManager.lastFocusedToken(in: workspaceId), tiled)
         XCTAssertEqual(controller.workspaceManager.lastFloatingFocusedToken(in: workspaceId), floating)
-        XCTAssertEqual(controller.workspaceManager.resolveWorkspaceFocusToken(in: workspaceId), floating)
+        XCTAssertEqual(
+            controller.workspaceManager.resolveWorkspaceFocusToken(
+                in: workspaceId,
+                isSuppressed: { _ in false }
+            ),
+            floating
+        )
     }
 
     @MainActor
@@ -4651,7 +4657,13 @@ final class RuntimeArchitectureTests: XCTestCase {
         XCTAssertNotNil(controller.layoutRefreshController.executeLayoutPlanReturningAcceptedSeq(plan))
         XCTAssertEqual(controller.workspaceManager.lastFocusedToken(in: workspaceId), tiled)
         XCTAssertEqual(controller.workspaceManager.lastFloatingFocusedToken(in: workspaceId), floating)
-        XCTAssertEqual(controller.workspaceManager.resolveWorkspaceFocusToken(in: workspaceId), floating)
+        XCTAssertEqual(
+            controller.workspaceManager.resolveWorkspaceFocusToken(
+                in: workspaceId,
+                isSuppressed: { _ in false }
+            ),
+            floating
+        )
     }
 
     @MainActor

--- a/Tests/OmniWMTests/WindowCloseFocusRecoveryTests.swift
+++ b/Tests/OmniWMTests/WindowCloseFocusRecoveryTests.swift
@@ -337,7 +337,8 @@ final class WindowCloseFocusRecoveryTests: XCTestCase {
             activeWorkspaceIsLocal: controller.activeWorkspace()?.id == fixture.localWorkspaceId,
             focusedWindowId: controller.workspaceManager.focusedToken?.windowId,
             preferredWindowId: controller.workspaceManager.preferredFocusToken(
-                in: fixture.localWorkspaceId
+                in: fixture.localWorkspaceId,
+                isSuppressed: { _ in false }
             )?.windowId,
             selectedWindowId: selectedWindowId,
             activeColumnIndex: viewport.activeColumnIndex,


### PR DESCRIPTION
## Problem

Using Cmd-H marks an app as hidden, but its managed windows can remain active in layout and focus selection while hide state propagates. That can leave visible windows unable to reclaim the hidden app's space, direct or recovered focus targeting a hidden window, and Niri persisting the temporary reflow as the new restore placement.

## Approach

Treat macOS app hiding as a visibility suspension while keeping the managed window state available for restoration:

- use one suppression predicate that covers both the hidden PID and `.macosHiddenApp` layout-reason phases
- exclude suppressed windows from layout snapshots and workspace focus resolution
- apply the same guard to Niri and Dwindle navigation, focus recovery, direct activation, and monitor/workspace focus selection
- turn app hide/unhide visibility refreshes into relayouts so remaining windows reclaim space promptly
- avoid persisting Niri placements while a workspace contains a macOS-hidden tiled window, preserving the pre-hide placement for unhide

The PID and layout-reason checks intentionally overlap because those state transitions are not atomic.

## Behavior change

After Cmd-H, hidden app windows remain tracked but no longer participate in tiling or managed focus selection. Unhiding restores their prior managed state and Niri placement rather than treating the temporary hidden-window reflow as authoritative.

This changes runtime behavior only. It does not change configuration, documentation interfaces, CLI output, or persisted format.

## Verification

- Ran `swift test --filter MacOSHiddenAppTests`
- 5 focused tests passed, covering layout exclusion, the PID/layout-reason transition, direct focus suppression, Niri directional focus, and hide/unhide placement restoration
- Ran Swift syntax parsing for every changed Swift file
- Ran `git diff --check`

Screenshots are not included because the regression is in layout/focus state transitions rather than static presentation.

## Review status

Opening as a draft to align on the behavior and approach before requesting formal review.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * macOS-hidden windows are now excluded from layouts, focus selection, activation, and monitor navigation.
  * Focus automatically recovers and layouts refresh when the selected window becomes hidden.
  * Hidden windows no longer affect workspace snapshots or persisted layout placements.
  * Unhiding windows preserves their appropriate layout placement.

* **Tests**
  * Added coverage for hidden-window behavior across layout refresh, focus resolution, direct focus, and directional navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->