### PR TITLE
Fix opaque window ID decode for delimiter-bearing session tokens

### DIFF
--- a/Sources/OmniWMIPC/IPCModels.swift
+++ b/Sources/OmniWMIPC/IPCModels.swift
@@ -2955,14 +2955,20 @@ public enum IPCWindowOpaqueID {
             return nil
         }
 
+        // The payload layout is `<session-token>:<pid>:<window-id>`. The session token is a
+        // free-form String (it defaults to a UUID, but the public API accepts any value), so it
+        // may itself contain the `:` delimiter. Anchor the well-formed integer fields from the
+        // right and treat everything before them as the token instead of requiring exactly three
+        // fields, which silently rejected tokens containing a colon.
         let parts = payload.split(separator: ":", omittingEmptySubsequences: false)
-        guard parts.count == 3,
-              let pid = Int32(parts[1]),
-              let windowId = Int(parts[2])
+        guard parts.count >= 3,
+              let pid = Int32(parts[parts.count - 2]),
+              let windowId = Int(parts[parts.count - 1])
         else {
             return nil
         }
-        return DecodedPayload(sessionToken: String(parts[0]), pid: pid, windowId: windowId)
+        let sessionToken = parts[0 ..< parts.count - 2].joined(separator: ":")
+        return DecodedPayload(sessionToken: sessionToken, pid: pid, windowId: windowId)
     }
 
     private static func base64URLEncoded(_ data: Data) -> String {

--- a/Tests/OmniWMTests/IPCWindowOpaqueIDTests.swift
+++ b/Tests/OmniWMTests/IPCWindowOpaqueIDTests.swift
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: GPL-2.0-only
+// Copyright (C) 2026 BarutSRB — https://github.com/BarutSRB/OmniWM
+
+import OmniWMIPC
+import XCTest
+
+final class IPCWindowOpaqueIDTests: XCTestCase {
+    func testRoundTripsUUIDSessionToken() {
+        let token = UUID().uuidString
+        let opaque = IPCWindowOpaqueID.encode(pid: 12_345, windowId: 67, sessionToken: token)
+
+        XCTAssertEqual(
+            IPCWindowOpaqueID.validate(opaque, expectingSessionToken: token),
+            .valid(pid: 12_345, windowId: 67)
+        )
+    }
+
+    func testRoundTripsSessionTokenContainingColonDelimiter() {
+        // The session token is a free-form String; a token that itself contains the `:` payload
+        // delimiter must still round-trip instead of being reported as invalid.
+        let token = "prefix:suffix"
+        let opaque = IPCWindowOpaqueID.encode(pid: 42, windowId: 7, sessionToken: token)
+
+        XCTAssertEqual(
+            IPCWindowOpaqueID.validate(opaque, expectingSessionToken: token),
+            .valid(pid: 42, windowId: 7)
+        )
+    }
+
+    func testRoundTripsSessionTokenWithMultipleColons() {
+        let token = "a:b:c:d"
+        let opaque = IPCWindowOpaqueID.encode(pid: -3, windowId: 999_999, sessionToken: token)
+
+        XCTAssertEqual(
+            IPCWindowOpaqueID.validate(opaque, expectingSessionToken: token),
+            .valid(pid: -3, windowId: 999_999)
+        )
+    }
+
+    func testMismatchedSessionTokenReportsStale() {
+        let opaque = IPCWindowOpaqueID.encode(pid: 5, windowId: 1, sessionToken: "session-a")
+
+        XCTAssertEqual(
+            IPCWindowOpaqueID.validate(opaque, expectingSessionToken: "session-b"),
+            .stale
+        )
+    }
+
+    func testMalformedOpaqueIDReportsInvalid() {
+        for malformed in ["", "ow_", "not-a-prefix", "ow_not-base64$$"] {
+            XCTAssertEqual(
+                IPCWindowOpaqueID.validate(malformed, expectingSessionToken: "session"),
+                .invalid
+            )
+        }
+    }
+
+    func testDecodeReturnsNilForStaleOrInvalid() {
+        let token = "session"
+        let valid = IPCWindowOpaqueID.encode(pid: 1, windowId: 2, sessionToken: token)
+
+        XCTAssertNotNil(IPCWindowOpaqueID.decode(valid, expectingSessionToken: token))
+        XCTAssertNil(IPCWindowOpaqueID.decode(valid, expectingSessionToken: "other"))
+        XCTAssertNil(IPCWindowOpaqueID.decode("ow_bogus", expectingSessionToken: token))
+    }
+}


### PR DESCRIPTION
## Problem

`IPCWindowOpaqueID` encodes a managed-window reference as `ow_<base64url(session-token:pid:window-id)>`. `decodePayload` split the decoded payload on `:` and required **exactly three** fields:

```swift
let parts = payload.split(separator: ":", omittingEmptySubsequences: false)
guard parts.count == 3, ...
```

The session token is a free-form `String` (it defaults to `UUID().uuidString`, but the public IPC API — `IPCServer(sessionToken:)` — accepts any value). A session token that itself contains `:` therefore produced an encode-then-validate round-trip that silently returned `.invalid`: encode succeeded, but decode saw more than three fields and bailed.

## Root cause

The `:` payload delimiter collides with characters the session-token component is permitted to contain, and the decoder anchored the token from the left instead of anchoring the well-formed integer fields.

## Changes

- `Sources/OmniWMIPC/IPCModels.swift` — `decodePayload` now anchors `pid`/`windowId` from the **right** (`parts[count-2]`, `parts[count-1]`) and rejoins everything before them as the session token. Normal UUID tokens (no `:`) decode byte-for-byte identically; delimiter-bearing tokens now round-trip.
- `Tests/OmniWMTests/IPCWindowOpaqueIDTests.swift` — new direct unit coverage for `IPCWindowOpaqueID` (previously only exercised indirectly through `@MainActor` controller tests). Covers UUID round-trip, single- and multi-colon tokens, stale/invalid rejection, and `decode`'s nil paths.

## Verification

Built and ran the `OmniWMIPC` target in isolation against the affected decode path. With the original code the two delimiter-bearing cases fail (`("invalid") is not equal to ("valid(...))"`); with this change all six cases pass. The four non-delimiter cases pass both before and after, confirming no regression.

Note: I could not run the full `make check` / `swift test` in my local environment because the toolchain available here resolves to Swift 6.3.1 while `Package.swift` pins `swift-tools-version` 6.4 (and the `GhosttyKit` binary target needs the Xcode build path). The changed target is pure Foundation and was verified in an isolated SwiftPM sandbox. CI / a macOS 26 + Swift 6.4 run will exercise the full suite.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved window identification when session tokens contain colons.
  * Continued rejecting malformed identifiers and correctly handling stale or mismatched tokens.

* **Tests**
  * Added coverage for valid identifiers, complex session tokens, malformed values, and stale window references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->