### PR TITLE
Stop control characters corrupting CLI table and TSV output

### DIFF
--- a/Sources/OmniWMCtl/CLIRenderer.swift
+++ b/Sources/OmniWMCtl/CLIRenderer.swift
@@ -532,7 +532,8 @@ enum CLIRenderer {
         case .json:
             return ""
         case .tsv:
-            return ([headers] + rows).map { $0.joined(separator: "\t") }.joined(separator: "\n")
+            let sanitizedRows = ([headers] + rows).map { $0.map(sanitizedCell) }
+            return sanitizedRows.map { $0.joined(separator: "\t") }.joined(separator: "\n")
         case .text,
              .table:
             return renderTable(headers: headers, rows: rows)
@@ -540,14 +541,16 @@ enum CLIRenderer {
     }
 
     private static func renderTable(headers: [String], rows: [[String]]) -> String {
-        let widths = headers.indices.map { column in
-            ([headers[column]] + rows.map { row in row.indices.contains(column) ? row[column] : "" })
+        let cleanHeaders = headers.map(sanitizedCell)
+        let cleanRows = rows.map { $0.map(sanitizedCell) }
+        let widths = cleanHeaders.indices.map { column in
+            ([cleanHeaders[column]] + cleanRows.map { row in row.indices.contains(column) ? row[column] : "" })
                 .map(\.count)
                 .max() ?? 0
         }
 
         func renderRow(_ row: [String]) -> String {
-            headers.indices.map { column in
+            cleanHeaders.indices.map { column in
                 let value = row.indices.contains(column) ? row[column] : ""
                 return value.padding(toLength: widths[column], withPad: " ", startingAt: 0)
             }
@@ -555,14 +558,21 @@ enum CLIRenderer {
             .trimmingCharacters(in: .whitespaces)
         }
 
-        var lines = [renderRow(headers)]
+        var lines = [renderRow(cleanHeaders)]
         lines.append(widths.map { String(repeating: "-", count: $0) }.joined(separator: "  "))
-        if rows.isEmpty {
+        if cleanRows.isEmpty {
             lines.append("(none)")
         } else {
-            lines.append(contentsOf: rows.map(renderRow))
+            lines.append(contentsOf: cleanRows.map(renderRow))
         }
         return lines.joined(separator: "\n")
+    }
+
+    private static func sanitizedCell(_ value: String) -> String {
+        value
+            .replacingOccurrences(of: "\t", with: " ")
+            .replacingOccurrences(of: "\n", with: " ")
+            .replacingOccurrences(of: "\r", with: " ")
     }
 
     private static func boolDescription(_ value: Bool?) -> String {

--- a/Tests/OmniWMTests/CLIRendererOutputTests.swift
+++ b/Tests/OmniWMTests/CLIRendererOutputTests.swift
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: GPL-2.0-only
+// Copyright (C) 2026 BarutSRB — https://github.com/BarutSRB/OmniWM
+
+@testable import OmniWMCtl
+import OmniWMIPC
+import XCTest
+
+final class CLIRendererOutputTests: XCTestCase {
+    private func windowResponse(title: String) -> IPCResponse {
+        IPCResponse.success(
+            id: "1",
+            kind: .query,
+            result: IPCResult(
+                windows: IPCWindowsQueryResult(
+                    windows: [IPCWindowQuerySnapshot(id: "w-1", title: title)]
+                )
+            )
+        )
+    }
+
+    func testTSVEscapesNewlineAndTabInWindowTitle() throws {
+        let response = windowResponse(title: "Progress\tbar\r\nsecond")
+        let output = try CLIRenderer.responseOutput(response, format: .tsv)
+        let text = try XCTUnwrap(String(data: output.data, encoding: .utf8))
+        let body = text.trimmingCharacters(in: .newlines)
+        let lines = body.components(separatedBy: "\n")
+
+        // A single window must occupy exactly one data row beneath the header.
+        XCTAssertEqual(lines.count, 2)
+
+        let dataFields = lines[1].components(separatedBy: "\t")
+        // The windows table has 10 columns; a tab inside the title must not add a column.
+        XCTAssertEqual(dataFields.count, 10)
+        XCTAssertFalse(dataFields.contains { $0.contains("\t") || $0.contains("\n") || $0.contains("\r") })
+    }
+
+    func testTableKeepsTitleOnSingleRow() throws {
+        let response = windowResponse(title: "Progress\tbar\r\nsecond")
+        let output = try CLIRenderer.responseOutput(response, format: .table)
+        let text = try XCTUnwrap(String(data: output.data, encoding: .utf8))
+        let body = text.trimmingCharacters(in: .newlines)
+        let lines = body.components(separatedBy: "\n")
+
+        // Header, separator, and exactly one data row — a newline in the title must not split it.
+        XCTAssertEqual(lines.count, 3)
+        XCTAssertFalse(lines.contains { $0.contains("\n") || $0.contains("\r") })
+    }
+
+    func testPlainTitleIsUnchanged() throws {
+        let response = windowResponse(title: "Clean title")
+        let output = try CLIRenderer.responseOutput(response, format: .tsv)
+        let text = try XCTUnwrap(String(data: output.data, encoding: .utf8))
+        XCTAssertTrue(text.contains("Clean title"))
+    }
+}


### PR DESCRIPTION
## Problem

`omniwmctl query windows` (and every other table/TSV rendering path) feeds free-form fields — window titles, app names — straight into the renderer without any escaping. A title that contains a control character corrupts the output structure:

- a **tab** in a title injects an extra TSV column (shifting every later field);
- a **newline** or **carriage return** splits a single row across multiple lines, breaking the table layout and any tool piping the TSV stream.

Window titles come straight from the Accessibility API and are not guaranteed to be control-character free (terminal titles with progress bars, multi-line document titles, etc.).

## Approach

Sanitize at the render boundary rather than at every call site that builds a row. A single `sanitizedCell(_:)` replaces tab/newline/carriage return with a space, applied:

- in `formatRows` for the **TSV** path (before tab-joining), and
- in `renderTable` for the **table/text** path (before width computation and padding, so column widths stay correct).

Sanitizing before width measurement also keeps the padding math honest.

## Changes

- `Sources/OmniWMCtl/CLIRenderer.swift` — add `sanitizedCell`; run headers/rows through it in both render paths.
- `Tests/OmniWMTests/CLIRendererOutputTests.swift` — render a windows query whose title contains a tab, carriage return, and newline in both `.tsv` and `.table` formats; assert the TSV stays one data row of 10 columns and the table stays header + separator + one row. Plus a plain-title regression guard.

## Verification

Built the `OmniWMCtl` + `OmniWMIPC` targets in an isolated sandbox and ran the new test class. Without the fix the control-character cases fail (TSV reports 3 lines / 5 fields instead of 2 / 10; the table reports 4 lines instead of 3); with it all three cases pass and a plain title is unchanged.

Note: as on the other open CLI/IPC change, I could not run the full `make check` / `swift test` locally because the toolchain available here resolves to Swift 6.3.1 while `Package.swift` pins `swift-tools-version` 6.4 (and the `GhosttyKit` binary target needs the Xcode build path). The changed targets are pure Foundation and were verified in an isolated SwiftPM sandbox; CI / a macOS 26 + Swift 6.4 run will exercise the full suite.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CLI output by replacing tabs, newlines, and carriage returns in headers and cell values with spaces.
  * Prevented multiline or special-character window titles from disrupting TSV and table formatting.
  * Preserved existing rendering for plain titles.

* **Tests**
  * Added coverage for escaped special characters and multiline window titles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->