### PR TITLE
Clone Ghostty config during appearance changes

### DIFF
--- a/Sources/OmniWM/QuakeTerminal/QuakeGhosttyConfig.swift
+++ b/Sources/OmniWM/QuakeTerminal/QuakeGhosttyConfig.swift
@@ -43,6 +43,12 @@ struct QuakeGhosttyAppearance: Sendable, Equatable {
         self.opacity = min(max(opacity, 0), 1)
     }
 
+    init?(cloning config: ghostty_config_t) {
+        guard let ownedConfig = ghostty_config_clone(config) else { return nil }
+        defer { ghostty_config_free(ownedConfig) }
+        self.init(config: ownedConfig)
+    }
+
     init(config: ghostty_config_t) {
         var background = ghostty_config_color_s()
         let backgroundKey = "background"

--- a/Sources/OmniWM/QuakeTerminal/QuakeTerminalController.swift
+++ b/Sources/OmniWM/QuakeTerminal/QuakeTerminalController.swift
@@ -119,8 +119,9 @@ final class QuakeTerminalController: NSObject, NSWindowDelegate, QuakeTerminalTa
             switch action.tag {
             case GHOSTTY_ACTION_CONFIG_CHANGE:
                 guard target.tag == GHOSTTY_TARGET_APP,
-                      let config = action.action.config_change.config else { return false }
-                let appearance = QuakeGhosttyAppearance(config: config)
+                      let config = action.action.config_change.config,
+                      let appearance = QuakeGhosttyAppearance(cloning: config)
+                else { return false }
                 return MainActor.assumeIsolated {
                     let controller = Unmanaged<QuakeTerminalController>.fromOpaque(userdata).takeUnretainedValue()
                     controller.receiveGhosttyAppearance(appearance)

--- a/Tests/OmniWMTests/QuakeGhosttyAppearanceTests.swift
+++ b/Tests/OmniWMTests/QuakeGhosttyAppearanceTests.swift
@@ -2,6 +2,7 @@
 // Copyright (C) 2026 BarutSRB — https://github.com/BarutSRB/OmniWM
 
 import AppKit
+import GhosttyKit
 @testable import OmniWM
 import XCTest
 
@@ -55,6 +56,22 @@ final class QuakeGhosttyAppearanceTests: XCTestCase {
         XCTAssertEqual(makeAppearance(opacity: -0.25).opacity, 0)
         XCTAssertEqual(makeAppearance(opacity: 0.42).opacity, 0.42)
         XCTAssertEqual(makeAppearance(opacity: 1.25).opacity, 1)
+    }
+
+    func testSnapshotsAppearanceFromOwnedConfigClone() throws {
+        XCTAssertEqual(ghostty_init(0, nil), GHOSTTY_SUCCESS)
+        let temporaryDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("omniwm-quake-ghostty-test-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: temporaryDirectory) }
+        let config = try XCTUnwrap(QuakeGhosttyConfigBuilder(
+            temporaryDirectory: temporaryDirectory
+        ).build(opacity: 0.42, backgroundEffect: .glassClear))
+        defer { ghostty_config_free(config) }
+
+        let appearance = try XCTUnwrap(QuakeGhosttyAppearance(cloning: config))
+
+        XCTAssertEqual(appearance.opacity, 0.42, accuracy: 0.001)
+        XCTAssertEqual(appearance.glassStyle, .clear)
     }
 
     func testQuakeOverrideOwnsEveryBackgroundEffectMode() {


### PR DESCRIPTION
## Problem

The Ghostty `GHOSTTY_ACTION_CONFIG_CHANGE` callback exposes a config handle owned by Ghostty. Quake Terminal currently reads appearance values directly from that callback-provided handle. That couples the appearance snapshot to the callback object's ownership and lifetime instead of taking an owned snapshot before inspecting it.

## Approach

Add a failable `QuakeGhosttyAppearance.init(cloning:)` initializer that:

1. clones the callback config with `ghostty_config_clone`
2. reads the appearance fields from the owned clone
3. frees the clone immediately after constructing the Swift value

The config-change callback now uses this initializer and declines the action if cloning fails. Initial setup is unchanged because OmniWM already owns that config.

A regression test builds a real Ghostty config, snapshots its appearance through the clone path, and verifies the resulting opacity and glass style.

## Behavior change

Quake Terminal appearance updates now derive from an owned Ghostty config snapshot during config-change callbacks. This is an internal lifetime/ownership hardening change; it does not change configuration, documentation interfaces, CLI output, or persisted formats.

## Verification

- Ran `swift test --filter QuakeGhosttyAppearanceTests/testSnapshotsAppearanceFromOwnedConfigClone`
- The focused regression test passed
- Ran Swift syntax parsing for every changed Swift file
- Ran `git diff --check`

Screenshots are not included because this change preserves the existing appearance and only changes how callback configuration is owned while being read.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminal appearance updates by reliably capturing opacity and glass style from Ghostty configuration changes.
  * Added safer handling for configuration snapshots and cleanup.

* **Tests**
  * Added coverage verifying that terminal appearance settings are correctly captured from Ghostty configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->