### PR TITLE
Fix MenuAnywhere submenu popup rendering and item enablement

### DIFF
--- a/Sources/OmniWM/Core/Menu/MenuExtractor.swift
+++ b/Sources/OmniWM/Core/Menu/MenuExtractor.swift
@@ -288,6 +288,7 @@ final class MenuExtractor: @unchecked Sendable {
         }
 
         let submenu = NSMenu(title: item.title)
+        submenu.autoenablesItems = false
 
         submenu.delegate = target as? NSMenuDelegate
         submenu.axRootElement = firstSub

--- a/Sources/OmniWM/UI/MenuAnywhere/MenuAnywhereController.swift
+++ b/Sources/OmniWM/UI/MenuAnywhere/MenuAnywhereController.swift
@@ -99,8 +99,8 @@ final class MenuAnywhereController: NSObject, NSMenuDelegate {
 
     func menuNeedsUpdate(_ menu: NSMenu) {
         if menu === activeMenu { return }
-        guard let axRoot = menu.axRootElement else { return }
         menu.autoenablesItems = false
+        guard let axRoot = menu.axRootElement else { return }
 
         let isPlaceholderOnly = menu.items.count == 1 && menu.items.first?.title == "Loading..."
         guard menu.items.isEmpty || isPlaceholderOnly else { return }

--- a/Sources/OmniWM/UI/MenuAnywhere/MenuAnywhereController.swift
+++ b/Sources/OmniWM/UI/MenuAnywhere/MenuAnywhereController.swift
@@ -11,7 +11,6 @@ final class MenuAnywhereController: NSObject, NSMenuDelegate {
     private let menuExtractor = MenuExtractor()
     private weak var currentApp: NSRunningApplication?
     private var activeMenu: NSMenu?
-    private let axFetchQueue = DispatchQueue(label: "com.omniwm.menufetch", qos: .userInitiated)
     var onMenuTrackingChanged: ((Bool) -> Void)?
 
     private static let kAXPressAction = "AXPress" as CFString
@@ -95,74 +94,27 @@ final class MenuAnywhereController: NSObject, NSMenuDelegate {
 
     func menuWillOpen(_ menu: NSMenu) {
         if menu === activeMenu { return }
-
-        guard menu.items.isEmpty, let axRoot = menu.axRootElement else { return }
-        guard menu.isPopulatingAsynchronously == false else { return }
-
-        menu.isPopulatingAsynchronously = true
-
-        let placeholder = NSMenuItem(title: "Loading...", action: nil, keyEquivalent: "")
-        placeholder.isEnabled = false
-        menu.addItem(placeholder)
-        populateSubmenuAsync(menu: menu, axRoot: axRoot)
+        menu.autoenablesItems = false
     }
 
     func menuNeedsUpdate(_ menu: NSMenu) {
         if menu === activeMenu { return }
-        guard menu.items.isEmpty, let axRoot = menu.axRootElement else { return }
+        guard let axRoot = menu.axRootElement else { return }
+        menu.autoenablesItems = false
+
+        let isPlaceholderOnly = menu.items.count == 1 && menu.items.first?.title == "Loading..."
+        guard menu.items.isEmpty || isPlaceholderOnly else { return }
+
         let items = menuExtractor.buildSubmenu(
             from: axRoot, target: self, action: #selector(menuAction(_:))
         )
         menu.removeAllItems()
-        items.forEach(menu.addItem)
-    }
-
-    private func populateSubmenuAsync(menu: NSMenu, axRoot: AXUIElement) {
-        nonisolated(unsafe) let menu = menu
-        let extractor = menuExtractor
-        axFetchQueue.async { [weak self] in
-            guard let children = axRoot.getChildren() else {
-                DispatchQueue.main.async {
-                    menu.removeAllItems()
-                    let empty = NSMenuItem(title: "(No items)", action: nil, keyEquivalent: "")
-                    empty.isEnabled = false
-                    menu.addItem(empty)
-                    menu.isPopulatingAsynchronously = false
-                }
-                return
-            }
-
-            let attrs = [
-                "AXTitle", "AXRole", "AXRoleDescription", "AXEnabled",
-                "AXMenuItemMarkChar", "AXMenuItemCmdChar", "AXMenuItemCmdModifiers", "AXChildren"
-            ]
-            var itemsData: [[String: Any]] = []
-            itemsData.reserveCapacity(children.count)
-            for child in children {
-                if let values = child.getMultipleAttributes(attrs) {
-                    itemsData.append(values)
-                } else {
-                    itemsData.append([:])
-                }
-            }
-
-            DispatchQueue.main.async {
-                guard let self else { return }
-                let submenuItems = extractor.buildSubmenu(
-                    fromChildren: children, itemsData: itemsData, target: self,
-                    action: #selector(self.menuAction(_:))
-                )
-                menu.removeAllItems()
-                for item in submenuItems {
-                    menu.addItem(item)
-                }
-                if submenuItems.isEmpty {
-                    let empty = NSMenuItem(title: "(No items)", action: nil, keyEquivalent: "")
-                    empty.isEnabled = false
-                    menu.addItem(empty)
-                }
-                menu.isPopulatingAsynchronously = false
-            }
+        if items.isEmpty {
+            let empty = NSMenuItem(title: "(No items)", action: nil, keyEquivalent: "")
+            empty.isEnabled = false
+            menu.addItem(empty)
+        } else {
+            items.forEach(menu.addItem)
         }
     }
 }

--- a/Tests/OmniWMTests/MenuExtractorTests.swift
+++ b/Tests/OmniWMTests/MenuExtractorTests.swift
@@ -26,14 +26,16 @@ final class MenuExtractorTests: XCTestCase {
 
     func testMenuAnywhereControllerMenuWillOpenAndNeedsUpdateConfiguresSubmenu() {
         let controller = MenuAnywhereController.shared
-        let submenu = NSMenu(title: "Submenu Test")
-        XCTAssertTrue(submenu.autoenablesItems)
 
-        controller.menuWillOpen(submenu)
-        XCTAssertFalse(submenu.autoenablesItems, "menuWillOpen should set autoenablesItems = false")
+        let willOpenMenu = NSMenu(title: "WillOpen Test")
+        XCTAssertTrue(willOpenMenu.autoenablesItems)
+        controller.menuWillOpen(willOpenMenu)
+        XCTAssertFalse(willOpenMenu.autoenablesItems, "menuWillOpen should set autoenablesItems = false")
 
-        controller.menuNeedsUpdate(submenu)
-        XCTAssertFalse(submenu.autoenablesItems, "menuNeedsUpdate should set autoenablesItems = false")
+        let needsUpdateMenu = NSMenu(title: "NeedsUpdate Test")
+        XCTAssertTrue(needsUpdateMenu.autoenablesItems)
+        controller.menuNeedsUpdate(needsUpdateMenu)
+        XCTAssertFalse(needsUpdateMenu.autoenablesItems, "menuNeedsUpdate should set autoenablesItems = false even without axRoot")
     }
 
     @objc private func dummyAction() {}

--- a/Tests/OmniWMTests/MenuExtractorTests.swift
+++ b/Tests/OmniWMTests/MenuExtractorTests.swift
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: GPL-2.0-only
+// Copyright (C) 2026 BarutSRB — https://github.com/BarutSRB/OmniWM
+
+import AppKit
+@testable import OmniWM
+import XCTest
+
+@MainActor
+final class MenuExtractorTests: XCTestCase {
+    func testSubmenuAutoenablesItemsIsDisabled() {
+        let submenu = NSMenu(title: "Submenu")
+        XCTAssertTrue(submenu.autoenablesItems, "NSMenu defaults autoenablesItems to true")
+
+        // Set autoenablesItems = false as expected for extracted menus
+        submenu.autoenablesItems = false
+        XCTAssertFalse(submenu.autoenablesItems)
+
+        let disabledItem = NSMenuItem(title: "Disabled Item", action: #selector(dummyAction), keyEquivalent: "")
+        disabledItem.isEnabled = false
+        disabledItem.target = self
+        submenu.addItem(disabledItem)
+
+        // When autoenablesItems is false, item.isEnabled remains false despite having target/action
+        XCTAssertFalse(disabledItem.isEnabled)
+    }
+
+    func testMenuAnywhereControllerMenuWillOpenAndNeedsUpdateConfiguresSubmenu() {
+        let controller = MenuAnywhereController.shared
+        let submenu = NSMenu(title: "Submenu Test")
+        XCTAssertTrue(submenu.autoenablesItems)
+
+        controller.menuWillOpen(submenu)
+        XCTAssertFalse(submenu.autoenablesItems, "menuWillOpen should set autoenablesItems = false")
+
+        controller.menuNeedsUpdate(submenu)
+        XCTAssertFalse(submenu.autoenablesItems, "menuNeedsUpdate should set autoenablesItems = false")
+    }
+
+    @objc private func dummyAction() {}
+}


### PR DESCRIPTION
### Summary

This PR isolates and resubmits the MenuAnywhere submenu fixes requested in review on #552.

### Changes Made

1. **Submenu Item Enablement (`autoenablesItems = false`)**:
   - Explicitly set `autoenablesItems = false` on submenus created in `MenuExtractor.handleSubmenu` as well as in `MenuAnywhereController.menuWillOpen` and `menuNeedsUpdate`.
   - Prevents AppKit from overriding extracted `AXEnabled` states with its default auto-enablement algorithm.

2. **Scoped Population Path**:
   - Rescoped `menuNeedsUpdate` to populate items synchronously when the menu is empty or when the `"Loading..."` placeholder is present.
   - Removed the asynchronous `populateSubmenuAsync` background fetch, establishing a single deterministic population path. AppKit now correctly measures menu height against the complete item list before display, eliminating single-row truncation.
   - Re-hovers over already-populated menus return immediately without redundant AX fetches.

3. **Unit Tests**:
   - Added `Tests/OmniWMTests/MenuExtractorTests.swift` to verify `autoenablesItems` state and item enablement behavior. All tests pass cleanly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved submenu behavior so disabled items remain disabled when menus open or refresh.
  * Submenus now populate immediately, replacing loading indicators without delay.
  * Empty submenus display a disabled “(No items)” message.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->