### PR TITLE
Document all public CLI commands

### DIFF
--- a/docs/IPC-CLI.md
+++ b/docs/IPC-CLI.md
@@ -262,8 +262,13 @@ omniwmctl command <command-path> [arguments...]
 | Command | Arguments | Layout | Description |
 |---------|-----------|--------|-------------|
 | `command focus` | `<left\|right\|up\|down>` | shared | Focus spatially; Dwindle Up/Down traverse grouped tabs before edge fallback |
+| `command focus-window-in-column` | `<number>` | niri | Focus a window in the focused Niri column by one-based index |
+| `command focus-window top` | — | niri | Focus the top window in the focused Niri column |
+| `command focus-window bottom` | — | niri | Focus the bottom window in the focused Niri column |
 | `command focus-window down-or-top` | — | shared | Focus the next window in the active Niri column or Dwindle group, wrapping locally |
 | `command focus-window up-or-bottom` | — | shared | Focus the previous window in the active Niri column or Dwindle group, wrapping locally |
+| `command focus-window-or-workspace-down` | — | niri | Focus down in the focused Niri column, or switch to the workspace below at the column edge |
+| `command focus-window-or-workspace-up` | — | niri | Focus up in the focused Niri column, or switch to the workspace above at the column edge |
 | `command focus previous` | — | niri | Focus the previously focused window |
 | `command focus down-or-left` | — | niri | Traverse backward through the active Niri workspace |
 | `command focus up-or-right` | — | niri | Traverse forward through the active Niri workspace |
@@ -278,8 +283,12 @@ omniwmctl command <command-path> [arguments...]
 | `command move` | `<left\|right\|up\|down>` | shared | Move with layout-aware consume/expel or Dwindle join/extract behavior |
 | `command move-window-down` | — | shared | Reorder the focused window down by one without wrapping within its Niri column or Dwindle group |
 | `command move-window-up` | — | shared | Reorder the focused window up by one without wrapping within its Niri column or Dwindle group |
+| `command move-window-down-or-to-workspace-down` | — | niri | Move the focused Niri window down, or to the workspace below at the column edge |
+| `command move-window-up-or-to-workspace-up` | — | niri | Move the focused Niri window up, or to the workspace above at the column edge |
 | `command consume-or-expel-window-left` | — | niri | Consume or expel using the previous Niri column without wrapping or crossing monitors |
 | `command consume-or-expel-window-right` | — | niri | Consume or expel using the next Niri column without wrapping or crossing monitors |
+| `command consume-window-into-column` | — | niri | Consume the top window from the next Niri column into the focused column |
+| `command expel-window-from-column` | — | niri | Expel the bottom window from the focused Niri column into a new column to the right |
 
 `command move <direction>` follows the active layout's orientation and configured edge behavior, including optional monitor crossing. The explicit consume-or-expel commands use fixed Niri column order, never wrap or cross monitors, and cannot be assigned as shortcuts.
 
@@ -322,8 +331,13 @@ Workspace IDs are positive numeric strings. Direct hotkeys stay limited to `1-9`
 
 | Command | Arguments | Layout | Description |
 |---------|-----------|--------|-------------|
+| `command center-column` | — | niri | Center the focused Niri column without changing focus |
+| `command center-visible-columns` | — | niri | Center the fully visible Niri columns around the active column |
 | `command move-column` | `<left\|right\|up\|down>` | shared left/right; dwindle up/down | Move a Niri column horizontally or swap a complete Dwindle tile/group without monitor fallback |
-| `command move-column-to-workspace` | `<number>` | niri | Move focused column to workspace by index |
+| `command move-column-to-first` | — | niri | Move the focused Niri column to the first position |
+| `command move-column-to-last` | — | niri | Move the focused Niri column to the last position |
+| `command move-column-to-index` | `<number>` | niri | Move the focused Niri column to a one-based index |
+| `command move-column-to-workspace` | `<number>` | niri | Move the focused Niri column to a workspace by workspace ID |
 | `command move-column-to-workspace up` | — | niri | Move focused column to the adjacent workspace above |
 | `command move-column-to-workspace down` | — | niri | Move focused column to the adjacent workspace below |
 | `command toggle-column-tabbed` | — | niri | Toggle tabbed mode for the focused column |
@@ -384,6 +398,7 @@ Workspace IDs are positive numeric strings. Direct hotkeys stay limited to `1-9`
 | `command hidden-bar panel` | — | shared | Toggle the panel containing configured hidden menu-bar items |
 | `command toggle-quake-terminal` | — | shared | Toggle the configured Quake terminal |
 | `command toggle-overview` | — | shared | Open Overview when it is closed; see the modal-routing note below |
+| `command toggle-system-stats` | — | shared | Toggle the system stats popup |
 
 For example, run `omniwmctl command hidden-bar panel` to show or dismiss the Hidden Bar panel.
 


### PR DESCRIPTION
## Summary

- document the 15 public CLI command paths that were missing from the IPC and CLI reference
- cover focused-window navigation, column centering/reordering, explicit consume/expel actions, and the system stats toggle
- clarify that `move-column-to-workspace` targets a workspace ID

## Verification

- Ran: `git show --check HEAD`
- Checked: all 83 paths in `IPCAutomationManifest.commandDescriptors` are present in the CLI reference

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the CLI command reference with Niri focus, movement, column, centering, and system-stat commands.
  * Clarified workspace targeting for moving columns.
  * Documented commands for moving columns to the first, last, or a specific position.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->