### PR TITLE
Keep overview horizontal navigation inside the current workspace row

### DIFF
--- a/Sources/OmniWM/Core/Overview/OverviewLayoutCalculator.swift
+++ b/Sources/OmniWM/Core/Overview/OverviewLayoutCalculator.swift
@@ -747,17 +747,21 @@ struct OverviewLayoutCalculator {
         switch direction {
         case .left:
             let leftWindows = visibleWindows.filter {
-                $0.overviewFrame.midX < currentWindow.overviewFrame.midX &&
+                $0.workspaceId == currentWindow.workspaceId &&
+                    $0.overviewFrame.midX < currentWindow.overviewFrame.midX &&
                     abs($0.overviewFrame.midY - currentWindow.overviewFrame.midY) < currentWindow.overviewFrame.height
             }.sorted { $0.overviewFrame.midX > $1.overviewFrame.midX }
-            return leftWindows.first?.handle ?? findWrappedPrevious(in: visibleWindows, from: currentIndex)
+            return leftWindows.first?.handle
+                ?? findRowWrappedWindow(in: visibleWindows, of: currentWindow, movingLeft: true)
 
         case .right:
             let rightWindows = visibleWindows.filter {
-                $0.overviewFrame.midX > currentWindow.overviewFrame.midX &&
+                $0.workspaceId == currentWindow.workspaceId &&
+                    $0.overviewFrame.midX > currentWindow.overviewFrame.midX &&
                     abs($0.overviewFrame.midY - currentWindow.overviewFrame.midY) < currentWindow.overviewFrame.height
             }.sorted { $0.overviewFrame.midX < $1.overviewFrame.midX }
-            return rightWindows.first?.handle ?? findWrappedNext(in: visibleWindows, from: currentIndex)
+            return rightWindows.first?.handle
+                ?? findRowWrappedWindow(in: visibleWindows, of: currentWindow, movingLeft: false)
 
         case .up:
             let upWindows = visibleWindows.filter {
@@ -799,6 +803,24 @@ struct OverviewLayoutCalculator {
             }
             return downWindows.first?.handle
         }
+    }
+
+    /// Wraps Left/Right navigation inside the current window's workspace row so
+    /// edge navigation never escapes into another workspace's row. A row with a
+    /// single visible window keeps the current selection. The geometric neighbor
+    /// search in `findNextWindow` is scoped to the same row.
+    private static func findRowWrappedWindow(
+        in windows: [OverviewWindowItem],
+        of currentWindow: OverviewWindowItem,
+        movingLeft: Bool
+    ) -> WindowHandle? {
+        let rowWindows = windows.filter { $0.workspaceId == currentWindow.workspaceId }
+        guard let rowIndex = rowWindows.firstIndex(where: { $0.handle == currentWindow.handle }) else {
+            return currentWindow.handle
+        }
+        return movingLeft
+            ? findWrappedPrevious(in: rowWindows, from: rowIndex)
+            : findWrappedNext(in: rowWindows, from: rowIndex)
     }
 
     private static func findWrappedNext(in windows: [OverviewWindowItem], from index: Int) -> WindowHandle? {

--- a/Tests/OmniWMTests/OverviewBehaviorTests.swift
+++ b/Tests/OmniWMTests/OverviewBehaviorTests.swift
@@ -133,7 +133,7 @@ final class OverviewBehaviorTests: XCTestCase {
         }
     }
 
-    func testNavigationRevealsThirdWorkspaceAndWrapsHorizontally() throws {
+    func testNavigationRevealsThirdWorkspaceAndKeepsSingleWindowRowSelection() throws {
         let fixture = makeProjectionFixture()
         var layout = projectedLayout(fixture: fixture, scale: 1, query: "")
         let first = try XCTUnwrap(layout.allWindows.first?.handle)
@@ -157,14 +157,149 @@ final class OverviewBehaviorTests: XCTestCase {
 
         assertVisible(thirdWindow.overviewFrame, in: layout, offset: layout.scrollOffset)
         XCTAssertTrue(layout.scrollOffset < 0)
+        // Each workspace row holds a single window, so horizontal navigation at
+        // either edge must keep the selection inside that row instead of
+        // wrapping into another workspace's row.
         XCTAssertEqual(
             OverviewLayoutCalculator.findNextWindow(in: layout, from: third, direction: .right),
-            first
+            third
         )
         XCTAssertEqual(
             OverviewLayoutCalculator.findNextWindow(in: layout, from: first, direction: .left),
-            third
+            first
         )
+    }
+
+    func testHorizontalWrapStaysInsideCurrentWorkspaceRow() throws {
+        let fixture = makeProjectionFixture(windowCountsPerWorkspace: [3, 3, 3])
+        let layout = projectedLayout(fixture: fixture, scale: 1, query: "")
+
+        for (rowIndex, row) in fixture.rowHandles.enumerated() {
+            let leftEdge = try XCTUnwrap(row.first)
+            let rightEdge = try XCTUnwrap(row.last)
+
+            XCTAssertEqual(
+                OverviewLayoutCalculator.findNextWindow(in: layout, from: leftEdge, direction: .left),
+                rightEdge,
+                "left edge of workspace row \(rowIndex) must wrap to the row's right-most window"
+            )
+            XCTAssertEqual(
+                OverviewLayoutCalculator.findNextWindow(in: layout, from: rightEdge, direction: .right),
+                leftEdge,
+                "right edge of workspace row \(rowIndex) must wrap to the row's left-most window"
+            )
+        }
+
+        let firstRow = fixture.rowHandles[0]
+        XCTAssertEqual(
+            OverviewLayoutCalculator.findNextWindow(in: layout, from: firstRow[0], direction: .right),
+            firstRow[1]
+        )
+        XCTAssertEqual(
+            OverviewLayoutCalculator.findNextWindow(in: layout, from: firstRow[2], direction: .left),
+            firstRow[1]
+        )
+    }
+
+    func testHorizontalNavigationKeepsLoneWindowRowSelectionInPlace() throws {
+        let fixture = makeProjectionFixture(windowCountsPerWorkspace: [3, 1, 2])
+        let layout = projectedLayout(fixture: fixture, scale: 1, query: "")
+        let loneWindow = try XCTUnwrap(fixture.rowHandles[1].first)
+
+        XCTAssertEqual(
+            OverviewLayoutCalculator.findNextWindow(in: layout, from: loneWindow, direction: .right),
+            loneWindow
+        )
+        XCTAssertEqual(
+            OverviewLayoutCalculator.findNextWindow(in: layout, from: loneWindow, direction: .left),
+            loneWindow
+        )
+
+        let multiWindowRow = fixture.rowHandles[0]
+        XCTAssertEqual(
+            OverviewLayoutCalculator.findNextWindow(in: layout, from: multiWindowRow.first, direction: .left),
+            multiWindowRow.last
+        )
+        XCTAssertEqual(
+            OverviewLayoutCalculator.findNextWindow(in: layout, from: multiWindowRow.last, direction: .right),
+            multiWindowRow.first
+        )
+    }
+
+    func testHorizontalNavigationStaysInRowAcrossDifferingRowHeights() throws {
+        let tallDescriptor = WorkspaceDescriptor(name: "Tall")
+        let shortDescriptor = WorkspaceDescriptor(name: "Short")
+        let workspaces: [OverviewWorkspaceLayoutItem] = [
+            (id: tallDescriptor.id, name: tallDescriptor.name, isActive: true),
+            (id: shortDescriptor.id, name: shortDescriptor.name, isActive: false)
+        ]
+        var windows: [WindowHandle: OverviewWindowLayoutData] = [:]
+        let tallToken = WindowToken(pid: 1, windowId: 1)
+        let tallHandle = WindowHandle(id: tallToken)
+        windows[tallHandle] = (
+            token: tallToken,
+            workspaceId: tallDescriptor.id,
+            title: "Tall 1",
+            appName: "App 1",
+            appIcon: nil,
+            frame: CGRect(x: 0, y: 0, width: 1000, height: 700)
+        )
+        var shortHandles: [WindowHandle] = []
+        for slot in 0 ..< 2 {
+            let token = WindowToken(pid: pid_t(2 + slot), windowId: 2 + slot)
+            let handle = WindowHandle(id: token)
+            windows[handle] = (
+                token: token,
+                workspaceId: shortDescriptor.id,
+                title: "Short \(slot + 1)",
+                appName: "App \(2 + slot)",
+                appIcon: nil,
+                frame: CGRect(x: CGFloat(slot) * 500, y: 0, width: 500, height: 233)
+            )
+            shortHandles.append(handle)
+        }
+        let layout = projectedLayout(
+            fixture: ProjectionFixture(workspaces: workspaces, windows: windows),
+            scale: 1,
+            query: ""
+        )
+
+        // The tall row's window vertically overlaps the shorter row's band, so
+        // an unscoped geometric neighbor search would treat the short row's
+        // windows as same-row candidates.
+        XCTAssertEqual(
+            OverviewLayoutCalculator.findNextWindow(in: layout, from: tallHandle, direction: .left),
+            tallHandle
+        )
+        XCTAssertEqual(
+            OverviewLayoutCalculator.findNextWindow(in: layout, from: tallHandle, direction: .right),
+            tallHandle
+        )
+        XCTAssertEqual(
+            OverviewLayoutCalculator.findNextWindow(in: layout, from: shortHandles[0], direction: .right),
+            shortHandles[1]
+        )
+    }
+
+    func testHorizontalNavigationKeepsLoneRowMatchSelectionWhileSearching() throws {
+        let fixture = makeProjectionFixture(windowCountsPerWorkspace: [3, 3, 3])
+        let layout = projectedLayout(fixture: fixture, scale: 1, query: "2")
+
+        for (rowIndex, row) in fixture.rowHandles.enumerated() {
+            // Only the row's middle window ("… 2") survives the search filter.
+            let loneMatch = row[1]
+
+            XCTAssertEqual(
+                OverviewLayoutCalculator.findNextWindow(in: layout, from: loneMatch, direction: .right),
+                loneMatch,
+                "workspace row \(rowIndex)"
+            )
+            XCTAssertEqual(
+                OverviewLayoutCalculator.findNextWindow(in: layout, from: loneMatch, direction: .left),
+                loneMatch,
+                "workspace row \(rowIndex)"
+            )
+        }
     }
 
     func testZoomPreservesSelectedMidpointsIndependentlyUntilClamped() throws {
@@ -733,6 +868,7 @@ final class OverviewBehaviorTests: XCTestCase {
     private struct ProjectionFixture {
         var workspaces: [OverviewWorkspaceLayoutItem]
         var windows: [WindowHandle: OverviewWindowLayoutData]
+        var rowHandles: [[WindowHandle]] = []
     }
 
     private struct RuntimeOverviewFixture {
@@ -804,24 +940,38 @@ final class OverviewBehaviorTests: XCTestCase {
     }
 
     private func makeProjectionFixture() -> ProjectionFixture {
+        makeProjectionFixture(windowCountsPerWorkspace: [1, 1, 1])
+    }
+
+    private func makeProjectionFixture(windowCountsPerWorkspace: [Int]) -> ProjectionFixture {
         let descriptors = ["First", "Second", "Third"].map { WorkspaceDescriptor(name: $0) }
         let workspaces = descriptors.enumerated().map { index, descriptor in
             (id: descriptor.id, name: descriptor.name, isActive: index == 0)
         }
         var windows: [WindowHandle: OverviewWindowLayoutData] = [:]
+        var rowHandles: [[WindowHandle]] = []
+        var tokenSeed = 0
         for (index, descriptor) in descriptors.enumerated() {
-            let token = WindowToken(pid: pid_t(index + 1), windowId: index + 1)
-            let handle = WindowHandle(id: token)
-            windows[handle] = (
-                token: token,
-                workspaceId: descriptor.id,
-                title: descriptor.name.lowercased(),
-                appName: "App \(index + 1)",
-                appIcon: nil,
-                frame: CGRect(x: 0, y: 0, width: 1000, height: 700)
-            )
+            let windowCount = windowCountsPerWorkspace[index]
+            let columnWidth = 1000.0 / CGFloat(windowCount)
+            var row: [WindowHandle] = []
+            for slot in 0 ..< windowCount {
+                tokenSeed += 1
+                let token = WindowToken(pid: pid_t(tokenSeed), windowId: tokenSeed)
+                let handle = WindowHandle(id: token)
+                windows[handle] = (
+                    token: token,
+                    workspaceId: descriptor.id,
+                    title: "\(descriptor.name) \(slot + 1)",
+                    appName: "App \(tokenSeed)",
+                    appIcon: nil,
+                    frame: CGRect(x: columnWidth * CGFloat(slot), y: 0, width: columnWidth, height: 700)
+                )
+                row.append(handle)
+            }
+            rowHandles.append(row)
         }
-        return ProjectionFixture(workspaces: workspaces, windows: windows)
+        return ProjectionFixture(workspaces: workspaces, windows: windows, rowHandles: rowHandles)
     }
 
     private func projectedLayout(


### PR DESCRIPTION
## Problem

In Overview mode, pressing Left/Right to navigate through a workspace's row jumps the selection into a **different workspace's row**. Up/Down navigate between workspaces correctly; only Left/Right misbehave (#578).

## Root cause

`OverviewLayoutCalculator.findNextWindow` resolves `.left`/`.right` through a same-row geometric filter first, but when no same-row candidate exists (row edge, or a single-window row) it falls back to `findWrappedPrevious`/`findWrappedNext` — a blind `(index ± 1) % count` over the **flat** `allWindows` list, which is every workspace's rows concatenated. Wrapping from a row edge therefore lands in whichever workspace happens to be adjacent in that array. `.up`/`.down` never leave the geometric domain even in their fallbacks, which is why only horizontal navigation jumps.

## Approach

Scope the horizontal wrap fallback to the current window's own workspace row: when no same-row candidate exists, wrap within the visible windows sharing `currentWindow.workspaceId`, keeping the existing left/right ordering semantics. A row whose only visible window is the current one keeps the selection in place — wrapping to a foreign row was precisely the bug. `.up`/`.down` and the primary geometric filter are untouched.

The single-window-row wrap is a deliberate behavior change: the existing test `testNavigationRevealsThirdWorkspaceAndWrapsHorizontally` codified the old cross-row jump and is updated to assert the new stay-in-row behavior (its reveal/scroll assertions are unchanged).

## Changes

- `Sources/OmniWM/Core/Overview/OverviewLayoutCalculator.swift` — `.left`/`.right` fallbacks now call a new private `findRowWrappedWindow(in:of:movingLeft:)` that wraps within the current workspace's visible windows instead of the flat array.
- `Tests/OmniWMTests/OverviewBehaviorTests.swift`:
  - `makeProjectionFixture(windowCountsPerWorkspace:)` parameterization (default `[1, 1, 1]` keeps every existing fixture identical);
  - new `testHorizontalWrapStaysInsideCurrentWorkspaceRow` — 3 workspaces × 3 windows: Left at a row's left edge wraps to that row's right-most window, Right at the right edge to the row's left-most, plain steps stay inside the row;
  - new `testHorizontalNavigationKeepsLoneWindowRowSelectionInPlace` — rows of [3, 1, 2]: the lone middle row keeps its selection under Left/Right while its multi-window neighbours wrap within themselves;
  - updated `testNavigationRevealsThirdWorkspaceAndKeepsSingleWindowRowSelection` (was `…WrapsHorizontally`) — single-window rows now keep the selection instead of jumping across workspaces.

## Verification

All three new/updated tests were run against the **unpatched** calculator first: `Executed 3 tests, with 12 failures` (Left/Right from a row edge resolved to another workspace's window); with the fix: `Executed 3 tests, with 0 failures`.

Full suite: `swift test --parallel` executes 2417 test items; the only failure is `testRadiusFormattingPreservesVisibleFractionPrecision`, a pre-existing locale failure (`"12,25 pt"` vs `"12.25 pt"` on a comma-decimal system) that fails identically on a pristine tree. `swiftformat --lint` (0.62.1): `0/2 files require formatting`. `swiftlint` (0.65.0): no new warnings vs the pristine baseline.

Closes #578.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Horizontal window navigation now stays within the current workspace.
  * Navigation wraps to the opposite edge of the workspace when no adjacent window is available.
  * Improved behavior for workspaces with different row sizes, filtered windows, or only one window.

* **Tests**
  * Expanded coverage for workspace-scoped navigation, edge wrapping, and varied workspace layouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->