### PR TITLE
fix: Respect symlinked settings.toml

### DIFF
--- a/Sources/OmniWM/Core/Config/SettingsFilePersistence.swift
+++ b/Sources/OmniWM/Core/Config/SettingsFilePersistence.swift
@@ -128,7 +128,7 @@ final class SettingsFilePersistence {
 
         let previous = FileManager.default.fileExists(atPath: fileURL.path) ? try? Data(contentsOf: fileURL) : nil
         let data = try SettingsTOMLCodec.encode(export, preservingUnknownKeysFrom: previous)
-        try data.write(to: fileURL, options: .atomic)
+        try data.write(to: Self.resolvingSymlink(fileURL), options: .atomic)
 
         let fingerprint = currentFingerprint()
         lastWrittenFingerprint = fingerprint
@@ -333,6 +333,21 @@ final class SettingsFilePersistence {
 
     private static func nanoseconds(from timestamp: timespec) -> Int64 {
         Int64(timestamp.tv_sec) * nanosecondsPerSecond + Int64(timestamp.tv_nsec)
+    }
+
+    private static func resolvingSymlink(_ url: URL) throws -> URL {
+        var resolved = url.standardizedFileURL
+        var visitedPaths = Set<String>()
+        while let destination = try? FileManager.default.destinationOfSymbolicLink(atPath: resolved.path) {
+            guard visitedPaths.insert(resolved.path).inserted else {
+                throw POSIXError(.ELOOP)
+            }
+            resolved = (destination.hasPrefix("/")
+                ? URL(fileURLWithPath: destination)
+                : resolved.deletingLastPathComponent().appendingPathComponent(destination)
+            ).standardizedFileURL
+        }
+        return resolved
     }
 
     private func moveCorruptFileAsideIfPresent() {

--- a/Tests/OmniWMTests/SettingsFilePersistenceTests.swift
+++ b/Tests/OmniWMTests/SettingsFilePersistenceTests.swift
@@ -1,0 +1,129 @@
+// SPDX-License-Identifier: GPL-2.0-only
+// Copyright (C) 2026 BarutSRB — https://github.com/BarutSRB/OmniWM
+
+import Foundation
+@testable import OmniWM
+import XCTest
+
+final class SettingsFilePersistenceTests: XCTestCase {
+    @MainActor
+    func testSaveThroughSymlinkPreservesSymlink() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("OmniWMSettingsSymlinkTests-\(UUID().uuidString)", isDirectory: true)
+        let configDirectory = root.appendingPathComponent("config", isDirectory: true)
+        let dotfilesDirectory = root.appendingPathComponent("dotfiles", isDirectory: true)
+        try FileManager.default.createDirectory(at: configDirectory, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: dotfilesDirectory, withIntermediateDirectories: true)
+
+        let realFileURL = dotfilesDirectory.appendingPathComponent("omniwm.toml", isDirectory: false)
+        let initialExport = SettingsExport.defaults()
+        let initialData = try SettingsTOMLCodec.encode(initialExport)
+        try initialData.write(to: realFileURL)
+
+        let symlinkURL = configDirectory.appendingPathComponent(SettingsFilePersistence.fileName, isDirectory: false)
+        try FileManager.default.createSymbolicLink(at: symlinkURL, withDestinationURL: realFileURL)
+
+        let persistence = SettingsFilePersistence(directory: configDirectory, startWatching: false, deferSaves: false)
+        var export = persistence.load()
+        export.gapSize += 1
+        try persistence.saveImmediately(export)
+
+        let attributes = try FileManager.default.attributesOfItem(atPath: symlinkURL.path)
+        XCTAssertEqual(attributes[.type] as? FileAttributeType, .typeSymbolicLink)
+        XCTAssertEqual(
+            try FileManager.default.destinationOfSymbolicLink(atPath: symlinkURL.path),
+            realFileURL.path
+        )
+
+        let persisted = try SettingsTOMLCodec.decode(try Data(contentsOf: realFileURL))
+        XCTAssertEqual(persisted.gapSize, export.gapSize)
+    }
+
+    @MainActor
+    func testSaveThroughDanglingSymlinkPreservesSymlink() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("OmniWMSettingsDanglingSymlinkTests-\(UUID().uuidString)", isDirectory: true)
+        let configDirectory = root.appendingPathComponent("config", isDirectory: true)
+        let dotfilesDirectory = root.appendingPathComponent("dotfiles", isDirectory: true)
+        try FileManager.default.createDirectory(at: configDirectory, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: dotfilesDirectory, withIntermediateDirectories: true)
+
+        let realFileURL = dotfilesDirectory.appendingPathComponent("omniwm.toml", isDirectory: false)
+        let initialData = try SettingsTOMLCodec.encode(SettingsExport.defaults())
+        try initialData.write(to: realFileURL)
+
+        let symlinkURL = configDirectory.appendingPathComponent(SettingsFilePersistence.fileName, isDirectory: false)
+        try FileManager.default.createSymbolicLink(at: symlinkURL, withDestinationURL: realFileURL)
+
+        // Target removed after the symlink was created, but before the write: settings.toml
+        // is now a dangling symlink, which is what should still be preserved.
+        try FileManager.default.removeItem(at: realFileURL)
+
+        let persistence = SettingsFilePersistence(directory: configDirectory, startWatching: false, deferSaves: false)
+        var export = SettingsExport.defaults()
+        export.gapSize += 1
+        try persistence.saveImmediately(export)
+
+        let attributes = try FileManager.default.attributesOfItem(atPath: symlinkURL.path)
+        XCTAssertEqual(attributes[.type] as? FileAttributeType, .typeSymbolicLink)
+        XCTAssertEqual(
+            try FileManager.default.destinationOfSymbolicLink(atPath: symlinkURL.path),
+            realFileURL.path
+        )
+
+        let persisted = try SettingsTOMLCodec.decode(try Data(contentsOf: realFileURL))
+        XCTAssertEqual(persisted.gapSize, export.gapSize)
+    }
+
+    @MainActor
+    func testSaveThroughCyclicSymlinkThrowsAndPreservesSymlink() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("OmniWMSettingsCyclicSymlinkTests-\(UUID().uuidString)", isDirectory: true)
+        let configDirectory = root.appendingPathComponent("config", isDirectory: true)
+        try FileManager.default.createDirectory(at: configDirectory, withIntermediateDirectories: true)
+
+        let symlinkURL = configDirectory.appendingPathComponent(SettingsFilePersistence.fileName, isDirectory: false)
+        try FileManager.default.createSymbolicLink(at: symlinkURL, withDestinationURL: symlinkURL)
+
+        let persistence = SettingsFilePersistence(directory: configDirectory, startWatching: false, deferSaves: false)
+        XCTAssertThrowsError(try persistence.saveImmediately(SettingsExport.defaults()))
+
+        let attributes = try FileManager.default.attributesOfItem(atPath: symlinkURL.path)
+        XCTAssertEqual(attributes[.type] as? FileAttributeType, .typeSymbolicLink)
+        XCTAssertEqual(
+            try FileManager.default.destinationOfSymbolicLink(atPath: symlinkURL.path),
+            symlinkURL.path
+        )
+    }
+
+    @MainActor
+    func testSaveThroughCrossDirectoryCyclicSymlinkThrowsAndPreservesSymlink() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("OmniWMSettingsCrossDirCyclicSymlinkTests-\(UUID().uuidString)", isDirectory: true)
+        let configDirectory = root.appendingPathComponent("config", isDirectory: true)
+        let otherDirectory = root.appendingPathComponent("other", isDirectory: true)
+        try FileManager.default.createDirectory(at: configDirectory, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: otherDirectory, withIntermediateDirectories: true)
+
+        // Two relative symlinks pointing at each other across sibling directories: each hop's
+        // resolved path grows a fresh `../` segment, so this only trips the cycle guard if
+        // resolvingSymlink normalizes paths between hops instead of comparing them raw.
+        let symlinkURL = configDirectory.appendingPathComponent(SettingsFilePersistence.fileName, isDirectory: false)
+        let otherLinkURL = otherDirectory.appendingPathComponent("link2", isDirectory: false)
+        try FileManager.default.createSymbolicLink(atPath: symlinkURL.path, withDestinationPath: "../other/link2")
+        try FileManager.default.createSymbolicLink(
+            atPath: otherLinkURL.path,
+            withDestinationPath: "../config/\(SettingsFilePersistence.fileName)"
+        )
+
+        let persistence = SettingsFilePersistence(directory: configDirectory, startWatching: false, deferSaves: false)
+        XCTAssertThrowsError(try persistence.saveImmediately(SettingsExport.defaults()))
+
+        let attributes = try FileManager.default.attributesOfItem(atPath: symlinkURL.path)
+        XCTAssertEqual(attributes[.type] as? FileAttributeType, .typeSymbolicLink)
+        XCTAssertEqual(
+            try FileManager.default.destinationOfSymbolicLink(atPath: symlinkURL.path),
+            "../other/link2"
+        )
+    }
+}


### PR DESCRIPTION
Everytime we change a setting from the UI the settings are written in a temp file and then renamed in place of the previous one, overwriting it.

This means that if we have this setup:

```
➜  ~ ls -al ~/.config/omniwm
total 0
drwxr-xr-x@  3 crbelaus  staff   96 Aug 15 10:56 ./
drwx------  22 crbelaus  staff  704 Aug 14 11:51 ../
lrwxr-xr-x   1 crbelaus  staff   53 Aug 15 10:56 settings.toml@ -> /Users/crbelaus/Developer/dotfiles/config/omniwm.toml
```

Changing any setting in the UI will break the symlink:

```
➜  ~ ls -al ~/.config/omniwm
total 32
drwxr-xr-x@  3 crbelaus  staff     96 Aug 15 10:57 ./
drwx------  22 crbelaus  staff    704 Aug 14 11:51 ../
-rwxr-xr-x@  1 crbelaus  staff  15587 Aug 15 10:57 settings.toml*
```

This PR ensures that we [follow symlinks](https://developer.apple.com/documentation/foundation/url/resolvingsymlinksinpath()) (if any) when writing the updated settings so we just update the target without breaking symlinks. This also works the same way when there are no symlinks involved.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed immediate settings saves when the configured settings file is accessed through a symbolic link.
  * Preserved symbolic links while writing updated settings to valid or dangling targets.
  * Prevented saves from modifying files when symbolic links contain resolution cycles.

* **Tests**
  * Added coverage for valid, dangling, self-referential, and cross-directory cyclic symbolic links.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->