### PR TITLE
Add a Start at Login option in Settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -501,8 +501,9 @@ For setup, installation options, commands, queries, rules, subscriptions, and se
 6. Keep one macOS Space per display and navigate with OmniWM workspaces; extra native Spaces are tolerated (their windows are left to macOS, not tiled)
 7. Use the default shortcuts in `Keyboard Shortcuts` to navigate between windows
 8. Click the menu bar icon to access Settings, including `Settings > General > Updates`
-9. Use `Check for Updates...` from the status bar menu whenever you want to run a manual update check
-10. In case you freak out and don't see all your status bar icons, relax, OmniWM hides the menu-bar icons you selected in `Settings > Hidden Bar`. Right-click OmniWM's status bar icon to open the Hidden Icons Bar and click any icon to use it.
+9. Enable `Start at Login` under `Settings > General > Startup` to launch OmniWM automatically when you log in
+10. Use `Check for Updates...` from the status bar menu whenever you want to run a manual update check
+11. In case you freak out and don't see all your status bar icons, relax, OmniWM hides the menu-bar icons you selected in `Settings > Hidden Bar`. Right-click OmniWM's status bar icon to open the Hidden Icons Bar and click any icon to use it.
 
 
 ## User Guide

--- a/Sources/OmniWM/App/LoginItemManager.swift
+++ b/Sources/OmniWM/App/LoginItemManager.swift
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: GPL-2.0-only
+// Copyright (C) 2026 BarutSRB — https://github.com/BarutSRB/OmniWM
+
+import Foundation
+import Observation
+import ServiceManagement
+
+@MainActor
+protocol LoginItemService: AnyObject {
+    var status: SMAppService.Status { get }
+    func register() throws
+    func unregister() throws
+}
+
+extension SMAppService: LoginItemService {}
+
+@MainActor
+@Observable
+final class LoginItemManager {
+    private let service: any LoginItemService
+
+    private(set) var isEnabled = false
+    private(set) var requiresApproval = false
+    private(set) var lastErrorDescription: String?
+
+    init(service: any LoginItemService = SMAppService.mainApp) {
+        self.service = service
+        refresh()
+    }
+
+    func refresh() {
+        let status = service.status
+        isEnabled = status == .enabled
+        requiresApproval = status == .requiresApproval
+    }
+
+    func setEnabled(_ enabled: Bool) {
+        guard enabled != (isEnabled || requiresApproval) else { return }
+        do {
+            if enabled {
+                try service.register()
+            } else {
+                try service.unregister()
+            }
+            lastErrorDescription = nil
+        } catch {
+            lastErrorDescription = error.localizedDescription
+        }
+        refresh()
+    }
+
+    static func openLoginItemsSettings() {
+        SMAppService.openSystemSettingsLoginItems()
+    }
+}

--- a/Sources/OmniWM/UI/SettingsView.swift
+++ b/Sources/OmniWM/UI/SettingsView.swift
@@ -53,11 +53,16 @@ struct GeneralSettingsTab: View {
 
     @State private var selectedGapMonitor: Monitor.ID?
     @State private var connectedMonitors: [Monitor] = Monitor.current()
+    @State private var loginItems = LoginItemManager()
 
     var body: some View {
         let animationsEnabled = Binding(
             get: { controller.motionPolicy.animationsEnabled },
             set: { controller.setAnimationsEnabled($0) }
+        )
+        let startAtLogin = Binding(
+            get: { loginItems.isEnabled || loginItems.requiresApproval },
+            set: { loginItems.setEnabled($0) }
         )
 
         Form {
@@ -95,6 +100,28 @@ struct GeneralSettingsTab: View {
                     }
                     .disabled(!settings.statusBarShowWorkspaceName)
                 SettingsCaption("Shows the active workspace and focused app beside the menu bar icon")
+            }
+
+            Section("Startup") {
+                Toggle("Start at Login", isOn: startAtLogin)
+                    .onReceive(
+                        NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification)
+                    ) { _ in
+                        loginItems.refresh()
+                    }
+                if loginItems.requiresApproval {
+                    Button("Open Login Items Settings...") {
+                        LoginItemManager.openLoginItemsSettings()
+                    }
+                    SettingsCaption(
+                        "macOS needs your approval before OmniWM can start at login. "
+                            + "Approve it under System Settings > General > Login Items."
+                    )
+                }
+                if let loginItemError = loginItems.lastErrorDescription {
+                    SettingsCaption("Could not update the login item: \(loginItemError)")
+                }
+                SettingsCaption("Launches OmniWM automatically when you log in.")
             }
 
             Section("Updates") {

--- a/Tests/OmniWMTests/LoginItemManagerTests.swift
+++ b/Tests/OmniWMTests/LoginItemManagerTests.swift
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: GPL-2.0-only
+// Copyright (C) 2026 BarutSRB — https://github.com/BarutSRB/OmniWM
+
+@testable import OmniWM
+import ServiceManagement
+import XCTest
+
+@MainActor
+final class LoginItemManagerTests: XCTestCase {
+    private struct StubError: LocalizedError {
+        var errorDescription: String? { "registration denied" }
+    }
+
+    private final class FakeLoginItemService: LoginItemService {
+        var status: SMAppService.Status = .notRegistered
+        var registerCalls = 0
+        var unregisterCalls = 0
+        var errorToThrow: Error?
+
+        func register() throws {
+            registerCalls += 1
+            if let errorToThrow { throw errorToThrow }
+            status = .enabled
+        }
+
+        func unregister() throws {
+            unregisterCalls += 1
+            if let errorToThrow { throw errorToThrow }
+            status = .notRegistered
+        }
+    }
+
+    func testInitReflectsCurrentStatus() {
+        let service = FakeLoginItemService()
+        service.status = .enabled
+
+        let manager = LoginItemManager(service: service)
+
+        XCTAssertTrue(manager.isEnabled)
+        XCTAssertFalse(manager.requiresApproval)
+    }
+
+    func testEnablingRegistersAndRefreshes() {
+        let service = FakeLoginItemService()
+        let manager = LoginItemManager(service: service)
+
+        manager.setEnabled(true)
+
+        XCTAssertEqual(service.registerCalls, 1)
+        XCTAssertTrue(manager.isEnabled)
+        XCTAssertNil(manager.lastErrorDescription)
+    }
+
+    func testDisablingUnregistersAndRefreshes() {
+        let service = FakeLoginItemService()
+        service.status = .enabled
+        let manager = LoginItemManager(service: service)
+
+        manager.setEnabled(false)
+
+        XCTAssertEqual(service.unregisterCalls, 1)
+        XCTAssertFalse(manager.isEnabled)
+        XCTAssertNil(manager.lastErrorDescription)
+    }
+
+    func testRedundantToggleDoesNotCallService() {
+        let service = FakeLoginItemService()
+        service.status = .enabled
+        let manager = LoginItemManager(service: service)
+
+        manager.setEnabled(true)
+
+        XCTAssertEqual(service.registerCalls, 0)
+        XCTAssertEqual(service.unregisterCalls, 0)
+    }
+
+    func testPendingApprovalCountsAsRequestedState() {
+        let service = FakeLoginItemService()
+        service.status = .requiresApproval
+        let manager = LoginItemManager(service: service)
+
+        XCTAssertFalse(manager.isEnabled)
+        XCTAssertTrue(manager.requiresApproval)
+
+        manager.setEnabled(true)
+        XCTAssertEqual(service.registerCalls, 0)
+
+        manager.setEnabled(false)
+        XCTAssertEqual(service.unregisterCalls, 1)
+    }
+
+    func testRegistrationFailureIsSurfacedAndStateRefreshed() {
+        let service = FakeLoginItemService()
+        service.errorToThrow = StubError()
+        let manager = LoginItemManager(service: service)
+
+        manager.setEnabled(true)
+
+        XCTAssertEqual(manager.lastErrorDescription, "registration denied")
+        XCTAssertFalse(manager.isEnabled)
+
+        service.errorToThrow = nil
+        manager.setEnabled(true)
+
+        XCTAssertTrue(manager.isEnabled)
+        XCTAssertNil(manager.lastErrorDescription)
+    }
+}


### PR DESCRIPTION
Closes #591

## Problem

There is no in-app way to make OmniWM launch at login. Users have to add it
manually under System Settings > General > Login Items, which is easy to miss
for a window manager that should be running from the moment you log in.

## What changed

- **Settings > General** gains a Startup section with a "Start at Login"
  checkbox, implemented with `SMAppService.mainApp` (the modern login items
  API).
- If macOS gates the registration behind user consent, the section shows a
  caption plus an "Open Login Items Settings..." button, and the pending
  state keeps the checkbox on until approval settles it.
- The checkbox mirrors the live system registration and re-syncs whenever the
  app becomes active, so changes made directly in System Settings are always
  reflected and never fought.
- Registration failures surface as a caption instead of failing silently.
- Deliberately no `settings.toml` key: login item registration is per-machine
  launchd state, not portable configuration, so the checkbox reflects reality
  rather than a stored flag that could drift from it.

## Implementation

- `LoginItemManager` (new, in `App/`) wraps `SMAppService.mainApp` behind a
  small `LoginItemService` protocol so the logic is unit-testable. It exposes
  enabled/pending/error state and treats a pending-approval registration as
  "requested" so toggling does not double-fire.
- `GeneralSettingsTab` gets the Startup section before Updates.
- README setup steps mention the new option.

## Verification

- 7 new unit tests in `LoginItemManagerTests` cover status mapping,
  register/unregister dispatch, redundant-toggle guarding, pending approval,
  and error surfacing plus recovery.
- Full suite run locally: the only failures are two pre-existing
  environment-dependent tests unrelated to this change (a locale sensitive
  formatting test and a reactivation timing test that fail on a pristine
  checkout of main too).
- Manually verified on macOS 26: toggling on adds OmniWM to System Settings >
  General > Login Items, toggling off removes it, and removing the entry
  directly in System Settings syncs the checkbox off when the app becomes
  active again.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a **Start at Login** option in General settings.
  * View the current startup status and open system Login Items settings when approval is required.
  * Startup preferences refresh automatically when the app becomes active, with clear error messaging if changes fail.

* **Documentation**
  * Expanded the Quick Start guide with instructions for enabling automatic launch at login.
  * Renumbered subsequent setup and usage steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->