### PR TITLE
Fix outer gaps being ignored when a window fills the screen

### DIFF
--- a/Sources/OmniWM/Core/Controller/WMController.swift
+++ b/Sources/OmniWM/Core/Controller/WMController.swift
@@ -730,7 +730,15 @@ final class WMController {
 
     func fullscreenLayoutFrame(for monitor: Monitor) -> CGRect {
         let scale = NSScreen.screens.first(where: { $0.displayId == monitor.displayId })?.backingScaleFactor ?? 2.0
-        let struts = Struts(top: workspaceBarReservedTopInset(for: monitor))
+        // Outer gaps still hold here: an external bar at a screen edge overlaps a
+        // filled single window just as much as a tiled one.
+        let gaps = settings.resolvedGapSettings(for: monitor)
+        let struts = Struts(
+            left: gaps.outerGapLeft,
+            right: gaps.outerGapRight,
+            top: workspaceBarReservedTopInset(for: monitor),
+            bottom: gaps.outerGapBottom
+        )
         return computeWorkingArea(parentArea: monitor.visibleFrame, scale: scale, struts: struts)
     }
 


### PR DESCRIPTION
`fullscreenLayoutFrame` only builds a top strut, so a window that fills the screen ignores the outer gaps. `insetWorkingFrame`, right above it, applies all four.

The effect: an external bar docked to a screen edge gets covered. With sketchybar at the bottom and `gaps.outer.bottom = 45`, windows still extended down to `visibleFrame.minY`.

The patch passes the four outer gaps instead of the top inset alone. Checked on two monitors with the niri layout: windows now stop at `visibleFrame.minY + 45`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fullscreen windows now respect configured outer gaps on all sides while preserving the workspace bar’s reserved top spacing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->