### PR TITLE
Remove tiles for windows that an app closes but does not destroy

### DIFF
--- a/Sources/OmniWM/Core/Controller/AXEventHandler.swift
+++ b/Sources/OmniWM/Core/Controller/AXEventHandler.swift
@@ -3761,6 +3761,10 @@ final class AXEventHandler {
         if let focusedToken = controller.workspaceManager.focusedToken,
            managedWindowToken(focusedToken, matchesObservedPid: pid)
         {
+            // The app stays frontmost with no focused window, so the focused token does
+            // not change and rescanAppThatLostFocus() sees no transition. Read the app's
+            // window list here in case it ordered the window out instead of destroying it.
+            requestTargetedFullRescan(for: [focusedToken.pid])
             return
         }
 

--- a/Sources/OmniWM/Core/Controller/AXEventHandler.swift
+++ b/Sources/OmniWM/Core/Controller/AXEventHandler.swift
@@ -323,7 +323,7 @@ final class AXEventHandler {
     static let postCreateLifecycleVerificationDelay: Duration = .milliseconds(75)
     static let createdWindowRetryLimit = 5
     static let createPlacementContextTTL: TimeInterval = 15
-    private static let activationRetryLimit = 5
+    static let activationRetryLimit = 5
     private static let windowCloseFocusRecoveryDuration: TimeInterval = 0.6
     static let sameAppCloseProbeDelay: Duration = .milliseconds(80)
     static let appTerminationFocusRecoveryTimeout: Duration = .milliseconds(600)
@@ -357,6 +357,7 @@ final class AXEventHandler {
     var terminalFrameFailureStateByWindowId: [Int: TerminalFrameFailureState] = [:]
     var admissionQuarantineByWindowId: [Int: AdmissionQuarantine] = [:]
     var identityAliasesByWindowId: [Int: WindowIdentityAliasHistory] = [:]
+    private var previouslyFocusedManagedToken: WindowToken?
     private var windowCloseFocusRecoveryContext: WindowCloseFocusRecoveryContext?
     private var recentMouseFocusIntent: RecentMouseFocusIntent?
     private var createFocusTrace =
@@ -1563,6 +1564,20 @@ final class AXEventHandler {
         return controller.workspaceManager.activeWorkspace(on: monitorId)?.id == workspaceId
     }
 
+    // Some apps order a window out instead of destroying it on close (Calendar, cmd+w).
+    // macOS sends no destroy notification then, and the window server keeps listing the
+    // window. Losing focus is the first hint, so let a rescan re-read the app's windows.
+    private func rescanAppThatLostFocus() {
+        guard let controller else { return }
+        let focusedToken = controller.workspaceManager.focusedToken
+        defer { previouslyFocusedManagedToken = focusedToken }
+        guard let previousToken = previouslyFocusedManagedToken,
+              previousToken != focusedToken,
+              controller.workspaceManager.entry(for: previousToken) != nil
+        else { return }
+        requestTargetedFullRescan(for: [previousToken.pid])
+    }
+
     @discardableResult
     func handleAppActivation(
         pid: pid_t,
@@ -1705,6 +1720,7 @@ final class AXEventHandler {
                 finishFocusedAdmissionRetryExecution(execution)
             }
         }
+        defer { rescanAppThatLostFocus() }
         guard let controller, controller.hasStartedServices else { return }
         guard facts.observationGeneration == latestActivationObservationGeneration else { return }
         guard facts.appVisibilityGeneration
@@ -3879,6 +3895,11 @@ final class AXEventHandler {
         origin: ActivationCallOrigin
     ) {
         guard let controller else { return }
+
+        // Some apps order a window out instead of destroying it on close (Calendar, cmd+w).
+        // macOS then sends no destroy notification, so focus keeps missing the window.
+        // Let the rescan decide whether the window is really gone.
+        requestTargetedFullRescan(for: [request.token.pid])
 
         _ = controller.intentLedger.cancelManagedRequest(requestId: request.requestId)
         _ = controller.workspaceManager.cancelManagedFocusRequest(

--- a/Sources/OmniWM/Core/Controller/AXEventHandler.swift
+++ b/Sources/OmniWM/Core/Controller/AXEventHandler.swift
@@ -1564,9 +1564,8 @@ final class AXEventHandler {
         return controller.workspaceManager.activeWorkspace(on: monitorId)?.id == workspaceId
     }
 
-    // Some apps order a window out instead of destroying it on close (Calendar, cmd+w).
-    // macOS sends no destroy notification then, and the window server keeps listing the
-    // window. Losing focus is the first hint, so let a rescan re-read the app's windows.
+    // Some apps close a window without destroying it. macOS then sends no notification.
+    // A focus change is the first sign, so re-read the app's window list.
     private func rescanAppThatLostFocus() {
         guard let controller else { return }
         let focusedToken = controller.workspaceManager.focusedToken
@@ -3761,9 +3760,8 @@ final class AXEventHandler {
         if let focusedToken = controller.workspaceManager.focusedToken,
            managedWindowToken(focusedToken, matchesObservedPid: pid)
         {
-            // The app stays frontmost with no focused window, so the focused token does
-            // not change and rescanAppThatLostFocus() sees no transition. Read the app's
-            // window list here in case it ordered the window out instead of destroying it.
+            // This return keeps the focused token, so the focus-change rescan never fires.
+            // The app may have closed its window without destroying it.
             requestTargetedFullRescan(for: [focusedToken.pid])
             return
         }
@@ -3900,9 +3898,7 @@ final class AXEventHandler {
     ) {
         guard let controller else { return }
 
-        // Some apps order a window out instead of destroying it on close (Calendar, cmd+w).
-        // macOS then sends no destroy notification, so focus keeps missing the window.
-        // Let the rescan decide whether the window is really gone.
+        // Repeated focus failures suggest the window is gone. Let the rescan confirm it.
         requestTargetedFullRescan(for: [request.token.pid])
 
         _ = controller.intentLedger.cancelManagedRequest(requestId: request.requestId)

--- a/Sources/OmniWM/Core/Controller/LayoutRefreshController.swift
+++ b/Sources/OmniWM/Core/Controller/LayoutRefreshController.swift
@@ -1656,14 +1656,6 @@ import QuartzCore
                     .map(\.token)
             )
         }
-        if let eligibleKeys {
-            for entry in trackedEntries
-                where eligibleKeys.contains(entry.token)
-                && enumerationSnapshot.windowServerInfoByWindowId[entry.windowId] != nil
-            {
-                seenKeys.insert(entry.token)
-            }
-        }
         let missingCandidateKeys = eligibleKeys ?? Set(trackedEntries.map(\.token))
         let admissionProtectedMissingKeys = permitsMissingRetirement
             ? controller.axEventHandler.protectMissingEntriesDuringUnsettledAdmission(

--- a/Tests/OmniWMTests/OrderedOutWindowRetirementTests.swift
+++ b/Tests/OmniWMTests/OrderedOutWindowRetirementTests.swift
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: GPL-2.0-only
+// Copyright (C) 2026 BarutSRB — https://github.com/BarutSRB/OmniWM
+
+import ApplicationServices
+import Foundation
+@testable import OmniWM
+import XCTest
+
+@MainActor
+final class OrderedOutWindowRetirementTests: XCTestCase {
+    func testExhaustedFocusActivationRescansTheOwningApp() throws {
+        let controller = WindowAdmissionTestSupport.controller()
+        let workspaceId = try XCTUnwrap(
+            controller.workspaceManager.workspaceId(for: "1", createIfMissing: true)
+        )
+        let token = controller.workspaceManager.addWindow(
+            AXWindowRef(element: AXUIElementCreateApplication(913_001), windowId: 913_101),
+            pid: 913_001,
+            windowId: 913_101,
+            to: workspaceId
+        )
+        XCTAssertTrue(
+            controller.workspaceManager.confirmManagedFocus(
+                token,
+                in: workspaceId,
+                activateWorkspaceOnMonitor: false
+            )
+        )
+        let request = controller.intentLedger.beginManagedRequest(token: token, workspaceId: workspaceId)
+        _ = controller.workspaceManager.beginManagedFocusRequest(
+            token,
+            in: workspaceId,
+            requestId: request.requestId
+        )
+        controller.hasStartedServices = true
+        controller.layoutRefreshController.layoutState.activeRefresh = nil
+
+        // The window is gone but the app still runs, so every focus attempt finds no window.
+        for _ in 0 ... AXEventHandler.activationRetryLimit {
+            controller.axEventHandler.handleActivationFactsResolved(
+                ActivationFacts(
+                    pid: token.pid,
+                    source: .focusedWindowChanged,
+                    origin: .retry,
+                    observationGeneration: 0,
+                    requestedAtSeq: UInt64.max,
+                    focusedWindow: nil
+                )
+            )
+        }
+
+        XCTAssertNil(controller.intentLedger.activeManagedRequest)
+        let refresh = try XCTUnwrap(controller.layoutRefreshController.layoutState.activeRefresh)
+        XCTAssertEqual(refresh.kind, .fullRescan)
+        XCTAssertEqual(refresh.rescanScope, .targeted(appPIDs: [token.pid], nativeSpaceIds: []))
+    }
+}

--- a/Tests/OmniWMTests/OrderedOutWindowRetirementTests.swift
+++ b/Tests/OmniWMTests/OrderedOutWindowRetirementTests.swift
@@ -76,7 +76,6 @@ final class OrderedOutWindowRetirementTests: XCTestCase {
         controller.hasStartedServices = true
         controller.layoutRefreshController.layoutState.activeRefresh = nil
 
-        // The app keeps focus and loses its window, so the focused token never changes.
         controller.axEventHandler.handleActivationFactsResolved(
             ActivationFacts(
                 pid: token.pid,

--- a/Tests/OmniWMTests/OrderedOutWindowRetirementTests.swift
+++ b/Tests/OmniWMTests/OrderedOutWindowRetirementTests.swift
@@ -54,4 +54,43 @@ final class OrderedOutWindowRetirementTests: XCTestCase {
         XCTAssertEqual(refresh.kind, .fullRescan)
         XCTAssertEqual(refresh.rescanScope, .targeted(appPIDs: [token.pid], nativeSpaceIds: []))
     }
+
+    func testFrontmostAppLosingItsFocusedWindowRescansThatApp() throws {
+        let controller = WindowAdmissionTestSupport.controller()
+        let workspaceId = try XCTUnwrap(
+            controller.workspaceManager.workspaceId(for: "1", createIfMissing: true)
+        )
+        let token = controller.workspaceManager.addWindow(
+            AXWindowRef(element: AXUIElementCreateApplication(913_002), windowId: 913_102),
+            pid: 913_002,
+            windowId: 913_102,
+            to: workspaceId
+        )
+        XCTAssertTrue(
+            controller.workspaceManager.confirmManagedFocus(
+                token,
+                in: workspaceId,
+                activateWorkspaceOnMonitor: false
+            )
+        )
+        controller.hasStartedServices = true
+        controller.layoutRefreshController.layoutState.activeRefresh = nil
+
+        // The app keeps focus and loses its window, so the focused token never changes.
+        controller.axEventHandler.handleActivationFactsResolved(
+            ActivationFacts(
+                pid: token.pid,
+                source: .focusedWindowChanged,
+                origin: .external,
+                observationGeneration: 0,
+                requestedAtSeq: UInt64.max,
+                focusedWindow: nil
+            )
+        )
+
+        XCTAssertEqual(controller.workspaceManager.focusedToken, token)
+        let refresh = try XCTUnwrap(controller.layoutRefreshController.layoutState.activeRefresh)
+        XCTAssertEqual(refresh.kind, .fullRescan)
+        XCTAssertEqual(refresh.rescanScope, .targeted(appPIDs: [token.pid], nativeSpaceIds: []))
+    }
 }


### PR DESCRIPTION
On some apps e.g. Calendar, Raycast AI, pressing cmd+w to close the last window leaves a tile in the layout. OmniWM is able to move and resize the phantom tile, and it only goes away after quitting the app in question.

It looks like macOS sends no destroy notification for the app when it is closed, and the window server keeps listing the window, so OmniWM never drops it.

## What changed

- OmniWM rescans an app when focus leaves one of its managed windows.
- OmniWM rescans an app when a focus request runs out of retries. This catches a window you go back to that has already gone.
- A targeted rescan reads the accessibility window list to decide whether a
  window is still open. It used to treat the window as open whenever the
  window server listed it.

## Implementation

Both rescan triggers live in `AXEventHandler`. `rescanAppThatLostFocus()` compares the focused token with the previous one and rescans whichever app lost focus. It runs from a `defer` in `handleActivationFactsResolved` so it fires after the new focus has been set, otherwise the check is an activation behind and nothing happens until you switch back to the closed window. `handleActivationRetryExhausted` calls the same rescan on the app it was trying to focus. `activationRetryLimit` goes from private to internal so the test can read it.

I also removed a block in `LayoutRefreshController` that marked a window as still present whenever the window server listed it. That is what kept the phantom tile alive, since the window server is the source that is wrong here. It only ever ran for targeted rescans, full scope rescans skip it and read the accessibility list on their own, so this brings the two into line. `confirmedMissingEntries` still wants two misses in a row before it drops anything. The block came in with 4cf1a64c as a safety net when targeted scoping was added, not for a reported bug.

Tested by hand on macOS 27.0 (26A5421a).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved focus recovery when managed windows are reordered or disappear without standard destruction events.
  - Automatically rescans affected applications after repeated focus-activation failures or when no focused window is detected.
  - Prevented stale windows from being retained during targeted layout rescans.
  - Preserved the active window during isolated external focus events while refreshing the affected application’s layout.

- **Tests**
  - Added coverage confirming that exhausted focus retries clear the active request and trigger an application layout rescan.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->