### PR TITLE
fix: omit hands-off surfaces from Overview and Command Palette

### DIFF
--- a/Sources/OmniWM/Core/Overview/OverviewController.swift
+++ b/Sources/OmniWM/Core/Overview/OverviewController.swift
@@ -60,23 +60,49 @@ struct OverviewEnvironment {
 }
 
 struct DwindleOverviewWorkspaceProjection {
+    let eligibleTokens: Set<WindowToken>
     let inactiveTokens: Set<WindowToken>
     let frames: [WindowToken: CGRect]
     let groupCountByToken: [WindowToken: Int]
 
-    init(engine: DwindleLayoutEngine, workspaceId: WorkspaceDescriptor.ID) {
-        inactiveTokens = engine.inactiveGroupTokens(in: workspaceId)
-        frames = engine.currentFrames(in: workspaceId)
+    init(
+        engine: DwindleLayoutEngine,
+        workspaceId: WorkspaceDescriptor.ID,
+        eligibleTokens: Set<WindowToken>
+    ) {
+        self.eligibleTokens = eligibleTokens
+
+        var inactiveTokens = engine.inactiveGroupTokens(in: workspaceId)
+        var frames = engine.currentFrames(in: workspaceId)
 
         var groupCounts: [WindowToken: Int] = [:]
         for snapshot in engine.groupedTileSnapshots(in: workspaceId) {
-            groupCounts[snapshot.activeToken] = snapshot.members.count
+            let eligibleMembers = snapshot.members.filter { eligibleTokens.contains($0.token) }
+            let representative = eligibleMembers.first { $0.token == snapshot.activeToken }
+                ?? eligibleMembers.first
+            let frame = frames[snapshot.activeToken] ?? snapshot.contentFrame ?? snapshot.tileFrame
+
+            inactiveTokens.formUnion(snapshot.members.map(\.token))
+            for member in snapshot.members {
+                frames.removeValue(forKey: member.token)
+            }
+
+            guard let representative else { continue }
+            inactiveTokens.remove(representative.token)
+            if let frame {
+                frames[representative.token] = frame
+            }
+            if eligibleMembers.count > 1 {
+                groupCounts[representative.token] = eligibleMembers.count
+            }
         }
+        self.inactiveTokens = inactiveTokens
+        self.frames = frames
         groupCountByToken = groupCounts
     }
 
     func includes(_ token: WindowToken) -> Bool {
-        !inactiveTokens.contains(token)
+        eligibleTokens.contains(token) && !inactiveTokens.contains(token)
     }
 }
 
@@ -828,11 +854,7 @@ final class OverviewController {
                     overviewSnapshot.niriSnapshotsByWorkspace.removeValue(forKey: workspaceId)
                 }
             case .dwindle:
-                if let engine = wmController.dwindleEngine {
-                    let projection = DwindleOverviewWorkspaceProjection(
-                        engine: engine,
-                        workspaceId: workspaceId
-                    )
+                if let projection = dwindleOverviewProjection(for: workspaceId) {
                     dwindleProjections[workspaceId] = projection
                     engineFrames.merge(projection.frames) { _, new in new }
                 }
@@ -907,7 +929,16 @@ final class OverviewController {
         else {
             return nil
         }
-        return DwindleOverviewWorkspaceProjection(engine: engine, workspaceId: workspaceId)
+        let eligibleTokens = Set(
+            wmController.workspaceManager.entries(in: workspaceId).lazy
+                .filter { isOverviewEligible($0, workspaceManager: wmController.workspaceManager) }
+                .map(\.token)
+        )
+        return DwindleOverviewWorkspaceProjection(
+            engine: engine,
+            workspaceId: workspaceId,
+            eligibleTokens: eligibleTokens
+        )
     }
 
     private func reconcileDwindleOverviewProjection(

--- a/Sources/OmniWM/Core/Overview/OverviewController.swift
+++ b/Sources/OmniWM/Core/Overview/OverviewController.swift
@@ -753,8 +753,7 @@ final class OverviewController {
                 let dwindleProjection = dwindleOverviewProjection(for: ws.id)
 
                 for entry in workspaceManager.entries(in: ws.id) {
-                    guard entry.layoutReason == .standard,
-                          !workspaceManager.isAppHidden(pid: entry.pid),
+                    guard isOverviewEligible(entry, workspaceManager: workspaceManager),
                           dwindleProjection?.includes(entry.token) != false,
                           let handle = workspaceManager.handle(for: entry.token)
                     else {
@@ -920,8 +919,7 @@ final class OverviewController {
         var desiredHandles: Set<WindowHandle> = []
 
         for entry in workspaceManager.entries(in: workspaceId) {
-            guard entry.layoutReason == .standard,
-                  !workspaceManager.isAppHidden(pid: entry.pid),
+            guard isOverviewEligible(entry, workspaceManager: workspaceManager),
                   projection.includes(entry.token),
                   let handle = workspaceManager.handle(for: entry.token)
             else {
@@ -975,8 +973,7 @@ final class OverviewController {
         var desiredHandles: Set<WindowHandle> = []
 
         for entry in workspaceManager.entries(in: workspaceId) {
-            guard entry.layoutReason == .standard,
-                  !workspaceManager.isAppHidden(pid: entry.pid),
+            guard isOverviewEligible(entry, workspaceManager: workspaceManager),
                   let handle = workspaceManager.handle(for: entry.token)
             else {
                 continue
@@ -1037,11 +1034,20 @@ final class OverviewController {
         guard let workspaceManager = wmController?.workspaceManager,
               workspaceManager.handle(for: handle.id) === handle,
               let entry = workspaceManager.entry(for: handle),
-              !workspaceManager.isAppHidden(pid: entry.pid)
+              isOverviewEligible(entry, workspaceManager: workspaceManager)
         else {
             return nil
         }
         return entry
+    }
+
+    private func isOverviewEligible(
+        _ entry: WindowState,
+        workspaceManager: WorkspaceManager
+    ) -> Bool {
+        entry.layoutReason == .standard
+            && !entry.interactionPolicy.isHandsOff
+            && !workspaceManager.isAppHidden(pid: entry.pid)
     }
 
     private func cachedNiriSnapshot(
@@ -1049,9 +1055,13 @@ final class OverviewController {
     ) -> NiriOverviewWorkspaceSnapshot? {
         let columns = snapshot.columns.compactMap { column -> NiriOverviewColumnSnapshot? in
             let tiles = column.tiles.filter { tile in
-                guard let workspaceManager = wmController?.workspaceManager else { return false }
-                return workspaceManager.workspace(for: tile.token) == snapshot.workspaceId
-                    && !workspaceManager.isAppHidden(tile.token)
+                guard let workspaceManager = wmController?.workspaceManager,
+                      let entry = workspaceManager.entry(for: tile.token)
+                else {
+                    return false
+                }
+                return entry.workspaceId == snapshot.workspaceId
+                    && isOverviewEligible(entry, workspaceManager: workspaceManager)
             }
             guard !tiles.isEmpty else { return nil }
             return NiriOverviewColumnSnapshot(

--- a/Sources/OmniWM/UI/CommandPalette/CommandPaletteController.swift
+++ b/Sources/OmniWM/UI/CommandPalette/CommandPaletteController.swift
@@ -639,6 +639,7 @@ final class CommandPaletteController: NSObject, NSWindowDelegate {
 
         for entry in entries {
             guard entry.layoutReason == .standard,
+                  !entry.interactionPolicy.isHandsOff,
                   let handle = wmController.workspaceManager.handle(for: entry.token) else { continue }
 
             let title = AXWindowService.titlePreferFast(windowId: UInt32(entry.windowId)) ?? ""

--- a/Tests/OmniWMTests/CommandPaletteControllerTests.swift
+++ b/Tests/OmniWMTests/CommandPaletteControllerTests.swift
@@ -130,6 +130,16 @@ final class CommandPaletteControllerTests: XCTestCase {
         XCTAssertFalse(CommandPaletteController.allowsSummonRight(items[1]))
     }
 
+    func testHandsOffSurfacesAreExcludedFromWindowItems() throws {
+        let (wmController, visibleToken, hiddenToken) = try makeWindowFixture()
+        wmController.workspaceManager.setInteractionPolicy(.handsOffSurface, for: visibleToken)
+        let palette = CommandPaletteController(
+            motionPolicy: MotionPolicy(animationsEnabled: false)
+        )
+
+        XCTAssertEqual(palette.buildWindowItems(from: wmController).map(\.id), [hiddenToken])
+    }
+
     func testWindowStatusTextDescribesSelectedHiddenWindowPrimaryAction() throws {
         let (wmController, _, hiddenToken) = try makeWindowFixture()
         let palette = CommandPaletteController(

--- a/Tests/OmniWMTests/OverviewBehaviorTests.swift
+++ b/Tests/OmniWMTests/OverviewBehaviorTests.swift
@@ -1460,6 +1460,34 @@ final class OverviewBehaviorTests: XCTestCase {
         XCTAssertEqual(frameReads, 1)
     }
 
+    func testOverviewSnapshotExcludesHandsOffSurfaces() throws {
+        var titleReads = 0
+        var frameReads = 0
+        var fixture = try makeRuntimeOverviewFixture(windowCount: 2)
+        fixture.environment.windowTitle = { _ in
+            titleReads += 1
+            return "Window"
+        }
+        fixture.environment.windowFrame = { _ in
+            frameReads += 1
+            return CGRect(x: 10, y: 10, width: 500, height: 400)
+        }
+        let handsOffToken = fixture.handles[0].id
+        let visibleToken = fixture.handles[1].id
+        fixture.controller.workspaceManager.setInteractionPolicy(.handsOffSurface, for: handsOffToken)
+        let overview = OverviewController(
+            wmController: fixture.controller,
+            motionPolicy: fixture.controller.motionPolicy,
+            environment: fixture.environment
+        )
+
+        overview.prepareOpenState()
+
+        XCTAssertEqual(overview.selectedWindowHandle?.id, visibleToken)
+        XCTAssertEqual(titleReads, 1)
+        XCTAssertEqual(frameReads, 1)
+    }
+
     func testCachedProjectionRemovesAndRestoresHiddenNiriWindow() throws {
         var titleReads = 0
         var fixture = try makeRuntimeOverviewFixture(windowCount: 2)
@@ -1498,6 +1526,39 @@ final class OverviewBehaviorTests: XCTestCase {
         )
 
         XCTAssertEqual(overview.selectedWindowHandle, hiddenHandle)
+        XCTAssertEqual(titleReads, 1)
+    }
+
+    func testCachedProjectionRemovesAndRestoresHandsOffNiriWindow() throws {
+        var titleReads = 0
+        var fixture = try makeRuntimeOverviewFixture(windowCount: 2)
+        fixture.environment.windowTitle = { _ in
+            titleReads += 1
+            return "Window"
+        }
+        let overview = OverviewController(
+            wmController: fixture.controller,
+            motionPolicy: fixture.controller.motionPolicy,
+            environment: fixture.environment
+        )
+        overview.prepareOpenState()
+        overview.onAnimationComplete(state: .open)
+        let handsOffHandle = try XCTUnwrap(overview.selectedWindowHandle)
+
+        titleReads = 0
+        fixture.controller.workspaceManager.setInteractionPolicy(.handsOffSurface, for: handsOffHandle.id)
+        overview.refreshCachedOverviewProjection(affectedWorkspaceIds: [fixture.workspaceId])
+
+        XCTAssertNotEqual(overview.selectedWindowHandle, handsOffHandle)
+        XCTAssertEqual(titleReads, 0)
+
+        fixture.controller.workspaceManager.setInteractionPolicy(.full, for: handsOffHandle.id)
+        overview.refreshCachedOverviewProjection(
+            affectedWorkspaceIds: [fixture.workspaceId],
+            selectedHandle: handsOffHandle
+        )
+
+        XCTAssertEqual(overview.selectedWindowHandle, handsOffHandle)
         XCTAssertEqual(titleReads, 1)
     }
 

--- a/Tests/OmniWMTests/OverviewDwindleProjectionTests.swift
+++ b/Tests/OmniWMTests/OverviewDwindleProjectionTests.swift
@@ -14,7 +14,8 @@ final class OverviewDwindleProjectionTests: XCTestCase {
         let fixture = makeGroupedFixture()
         let projection = DwindleOverviewWorkspaceProjection(
             engine: fixture.engine,
-            workspaceId: fixture.workspaceId
+            workspaceId: fixture.workspaceId,
+            eligibleTokens: [fixture.first, fixture.second, fixture.standalone]
         )
 
         XCTAssertFalse(projection.includes(fixture.first))
@@ -32,7 +33,8 @@ final class OverviewDwindleProjectionTests: XCTestCase {
 
         let projection = DwindleOverviewWorkspaceProjection(
             engine: fixture.engine,
-            workspaceId: fixture.workspaceId
+            workspaceId: fixture.workspaceId,
+            eligibleTokens: [fixture.first, fixture.second, fixture.standalone]
         )
 
         XCTAssertTrue(projection.includes(fixture.first))
@@ -52,12 +54,42 @@ final class OverviewDwindleProjectionTests: XCTestCase {
         _ = fixture.engine.calculateLayout(for: fixture.workspaceId, screen: screen)
         let projection = DwindleOverviewWorkspaceProjection(
             engine: fixture.engine,
-            workspaceId: fixture.workspaceId
+            workspaceId: fixture.workspaceId,
+            eligibleTokens: [fixture.first, fixture.second, fixture.standalone]
         )
 
         XCTAssertEqual(removed, [fixture.second])
         XCTAssertTrue(projection.includes(fixture.first))
         XCTAssertEqual(Set(projection.frames.keys), [fixture.first, fixture.standalone])
+        XCTAssertTrue(projection.groupCountByToken.isEmpty)
+    }
+
+    func testProjectionPromotesEligibleMemberWhenActiveMemberIsIneligible() {
+        let fixture = makeGroupedFixture()
+        let projection = DwindleOverviewWorkspaceProjection(
+            engine: fixture.engine,
+            workspaceId: fixture.workspaceId,
+            eligibleTokens: [fixture.first, fixture.standalone]
+        )
+
+        XCTAssertTrue(projection.includes(fixture.first))
+        XCTAssertFalse(projection.includes(fixture.second))
+        XCTAssertTrue(projection.includes(fixture.standalone))
+        XCTAssertEqual(Set(projection.frames.keys), [fixture.first, fixture.standalone])
+        XCTAssertTrue(projection.groupCountByToken.isEmpty)
+    }
+
+    func testProjectionExcludesIneligibleInactiveMemberFromGroupCount() {
+        let fixture = makeGroupedFixture()
+        let projection = DwindleOverviewWorkspaceProjection(
+            engine: fixture.engine,
+            workspaceId: fixture.workspaceId,
+            eligibleTokens: [fixture.second, fixture.standalone]
+        )
+
+        XCTAssertFalse(projection.includes(fixture.first))
+        XCTAssertTrue(projection.includes(fixture.second))
+        XCTAssertEqual(Set(projection.frames.keys), [fixture.second, fixture.standalone])
         XCTAssertTrue(projection.groupCountByToken.isEmpty)
     }
 
@@ -167,6 +199,105 @@ final class OverviewDwindleProjectionTests: XCTestCase {
         )
 
         XCTAssertEqual(overview.selectedWindowHandle?.id, first)
+    }
+
+    @MainActor
+    func testOverviewPromotesEligibleGroupedMemberForInitialAndCachedProjections() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("OmniWMOverviewDwindleEligibilityTests-\(UUID().uuidString)", isDirectory: true)
+        let settings = SettingsStore(
+            persistence: SettingsFilePersistence(
+                directory: root.appendingPathComponent("config", isDirectory: true),
+                startWatching: false,
+                deferSaves: false
+            ),
+            runtimeState: RuntimeStateStore(
+                directory: root.appendingPathComponent("state", isDirectory: true),
+                deferSaves: false
+            ),
+            autosaveEnabled: false
+        )
+        let controller = WMController(
+            settings: settings,
+            windowFocusOperations: WindowFocusOperations(
+                activateApp: { _ in },
+                focusSpecificWindow: { _, _, _ in },
+                raiseWindow: { _ in }
+            )
+        )
+        controller.settings.workspaceConfigurations.append(
+            WorkspaceConfiguration(name: "98", layoutType: .dwindle)
+        )
+        let monitor = Monitor(
+            id: .init(displayId: 92_002),
+            displayId: 92_002,
+            frame: screen,
+            visibleFrame: screen,
+            hasNotch: false,
+            name: "Overview Dwindle Eligibility"
+        )
+        controller.workspaceManager.applyMonitorConfigurationChange([monitor])
+        controller.workspaceManager.applySettings()
+        let workspaceId = try XCTUnwrap(controller.workspaceManager.workspaceId(named: "98"))
+        controller.workspaceManager.assignWorkspaceToMonitor(workspaceId, monitorId: monitor.id)
+        XCTAssertTrue(controller.workspaceManager.setActiveWorkspace(workspaceId, on: monitor.id))
+
+        let first = controller.workspaceManager.addWindow(
+            AXWindowRef(element: AXUIElementCreateApplication(92_103), windowId: 92_203),
+            pid: 92_103,
+            windowId: 92_203,
+            to: workspaceId
+        )
+        let second = controller.workspaceManager.addWindow(
+            AXWindowRef(element: AXUIElementCreateApplication(92_104), windowId: 92_204),
+            pid: 92_104,
+            windowId: 92_204,
+            to: workspaceId
+        )
+        let engine = DwindleLayoutEngine()
+        controller.dwindleEngine = engine
+        controller.workspaceManager.withEngineMutationScope {
+            _ = engine.addWindow(token: first, to: workspaceId, activeWindowFrame: nil)
+            _ = engine.addWindow(token: second, to: workspaceId, activeWindowFrame: nil)
+            _ = engine.calculateLayout(for: workspaceId, screen: screen)
+            _ = engine.groupWindow(direction: .left, in: workspaceId)
+            _ = engine.calculateLayout(for: workspaceId, screen: screen)
+        }
+        controller.workspaceManager.setInteractionPolicy(.handsOffSurface, for: second)
+
+        var titleReads = 0
+        var environment = OverviewEnvironment()
+        environment.windowTitle = { _ in
+            titleReads += 1
+            return "Window"
+        }
+        environment.windowFrame = { _ in .zero }
+        let overview = OverviewController(
+            wmController: controller,
+            motionPolicy: controller.motionPolicy,
+            environment: environment
+        )
+
+        overview.prepareOpenState()
+
+        XCTAssertEqual(overview.selectedWindowHandle?.id, first)
+        XCTAssertEqual(titleReads, 1)
+
+        overview.onAnimationComplete(state: .open)
+        controller.workspaceManager.setInteractionPolicy(.full, for: second)
+        overview.refreshCachedOverviewProjection(
+            affectedWorkspaceIds: [workspaceId],
+            selectedHandle: controller.workspaceManager.handle(for: second)
+        )
+
+        XCTAssertEqual(overview.selectedWindowHandle?.id, second)
+        XCTAssertEqual(titleReads, 2)
+
+        controller.workspaceManager.setInteractionPolicy(.handsOffSurface, for: second)
+        overview.refreshCachedOverviewProjection(affectedWorkspaceIds: [workspaceId])
+
+        XCTAssertEqual(overview.selectedWindowHandle?.id, first)
+        XCTAssertEqual(titleReads, 2)
     }
 
     private func makeGroupedFixture() -> (


### PR DESCRIPTION
## Summary

- reuse the existing hands-off interaction policy to exclude helper surfaces from Overview and Command Palette window results
- apply the same eligibility check to initial Overview snapshots and cached Niri/Dwindle reconciliation
- add regression coverage for initial projection and live policy changes

Fixes #616

## Testing

- `make format-check`
- `make lint` (passes with existing non-serious repository warnings)
- `swift test --filter HandsOff` (27 tests passed using disposable Swift 6.3 compatibility edits; no compatibility edits are included in this PR)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Windows marked as hands-off are consistently excluded from Overview snapshots, projections, and command palette window lists.
  * Hidden or non-interactive windows no longer appear as selectable or visible entries in these views.
  * Grouped Overview layouts now select eligible windows correctly when some members are unavailable.
  * Windows reappear in Overview and command palette results when their interaction policy is restored.
  * Window selection and displayed metadata remain accurate as visibility changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->