### PR TITLE
Keep menu bar extra menus open on workspaces that have windows

### DIFF
--- a/Sources/OmniWM/Core/Controller/AXEventHandler+WindowContext.swift
+++ b/Sources/OmniWM/Core/Controller/AXEventHandler+WindowContext.swift
@@ -30,6 +30,11 @@ extension AXEventHandler {
     func rescanAppThatLostFocus() {
         guard let controller else { return }
         let focusedToken = controller.workspaceManager.focusedToken
+        // Focus that landed on no tracked window went to a foreign front process, such as a
+        // menu bar extra showing its menu. That is not the ordered-out signal, and the
+        // rescan's focus recovery would front the tile and cancel that menu. Returning
+        // before the memo update keeps the rescan pending for the next real focus change.
+        guard focusedToken != nil else { return }
         defer { previouslyFocusedManagedToken = focusedToken }
         guard let previousToken = previouslyFocusedManagedToken,
               previousToken != focusedToken,

--- a/Tests/OmniWMTests/OrderedOutWindowRetirementTests.swift
+++ b/Tests/OmniWMTests/OrderedOutWindowRetirementTests.swift
@@ -91,4 +91,46 @@ final class OrderedOutWindowRetirementTests: XCTestCase {
         XCTAssertEqual(refresh.kind, .fullRescan)
         XCTAssertEqual(refresh.rescanScope, .targeted(appPIDs: [token.pid], nativeSpaceIds: []))
     }
+
+    func testWindowlessForeignAppTakingFrontDoesNotRescanTheFocusedApp() throws {
+        let controller = WindowAdmissionTestSupport.controller()
+        let workspaceId = try XCTUnwrap(
+            controller.workspaceManager.workspaceId(for: "1", createIfMissing: true)
+        )
+        let token = controller.workspaceManager.addWindow(
+            AXWindowRef(element: AXUIElementCreateApplication(913_003), windowId: 913_103),
+            pid: 913_003,
+            windowId: 913_103,
+            to: workspaceId
+        )
+        XCTAssertTrue(
+            controller.workspaceManager.confirmManagedFocus(
+                token,
+                in: workspaceId,
+                activateWorkspaceOnMonitor: false
+            )
+        )
+        controller.hasStartedServices = true
+        controller.layoutRefreshController.layoutState.activeRefresh = nil
+        controller.axEventHandler.previouslyFocusedManagedToken = token
+
+        // A menu bar extra owns no window, so its activation must not be read as the
+        // focused app losing a window. The rescan would re-front the tile and close the menu.
+        controller.axEventHandler.handleActivationFactsResolved(
+            ActivationFacts(
+                pid: 913_903,
+                source: .cgsFrontAppChanged,
+                origin: .external,
+                observationGeneration: 0,
+                requestedAtSeq: UInt64.max,
+                focusedWindow: nil
+            )
+        )
+
+        XCTAssertNil(controller.layoutRefreshController.layoutState.activeRefresh)
+        XCTAssertNil(controller.layoutRefreshController.layoutState.pendingRefresh)
+        // Deferred, not dropped: the next real focus change still rescans the app that
+        // may have ordered a window out while the menu was up.
+        XCTAssertEqual(controller.axEventHandler.previouslyFocusedManagedToken, token)
+    }
 }


### PR DESCRIPTION
## Problem

On 0.6.4, clicking a third-party menu bar extra (Amphetamine, and any other windowless agent app) opens its menu and dismisses it again immediately. It only stays open when the active workspace has no managed windows, so the workaround is to switch to an empty workspace first.

Repro: put at least one window on the active workspace, click any menu bar extra's icon.

## Cause

A menu bar extra takes the front process with no accessibility window, so `handleAppActivation` enters non-managed focus and clears `focusedToken` (`AXEventHandler.swift:1650`).

`rescanAppThatLostFocus()` — added in f7b0e1f4 to retire tiles for windows an app orders out instead of destroying — reads that cleared token as a managed window losing focus and requests a targeted full rescan. Every full rescan sets `focusValidationWorkspaceIds` for the active workspace (`LayoutRefreshController.swift:1806`), and `shouldSuppressManagedFocusRecovery` is false here because non-managed focus is active with no target token. So `ensureFocusedTokenValid` picks a tile and `focusWindow` fronts its app, which cancels the agent's menu tracking.

On an empty workspace `resolveAndSetWorkspaceFocusToken` finds no candidate, nothing is fronted, and the menu survives — which is exactly the reported workaround.

## Fix

One guard in `rescanAppThatLostFocus()`: focus that landed on no tracked window went to a foreign front process, which is not the ordered-out signal the heuristic is looking for.

The guard sits before the memo update on purpose, so `previouslyFocusedManagedToken` survives and the rescan is deferred to the next real focus change rather than dropped. A window an app ordered out while a menu was up is still retired then.

The two behaviors f7b0e1f4 and da350d6a added are unaffected: an app that stays frontmost after losing its focused window still rescans through the `handleMissingFocusedWindow` branch, focus moving to another tracked window still rescans the app it left, and the retry-exhaustion rescan is untouched.

## Verification

- `swift test`: 2948 tests, 0 failures, 8 skipped. The new test fails on both added assertions with the guard removed.
- Manual: ran a dev build with at least one window on the active workspace and opened several menu bar extra menus — they stay open now, and still open on an empty workspace.
- New test `testWindowlessForeignAppTakingFrontDoesNotRescanTheFocusedApp` sits next to the two existing cases in `OrderedOutWindowRetirementTests`, and asserts both that no rescan is scheduled and that the memo survives, so the deferred-not-dropped property is pinned.

One caveat on my local run: my GhosttyKit archive predates the pin bumped in 6c39fb26, so I temporarily reverted the QuakeTerminal sources to build and test. That is unrelated to this change, which touches neither Ghostty nor the Quake terminal.

## Also covered: transient popups of the focused app

The same mechanism dismisses Chrome's download bubble, and any other popup that the `transientWidgetSurface` rule rejects as a non-renderable surface. A trace captured on 0.6.4 shows the sequence: the bubble becomes Chrome's AX focused window → `admission_ignored` with reason `non_renderable_transient_surface` → non-managed focus is entered with no target token, which clears `focusedToken` → a Chrome-only `enumeration_started` (the targeted rescan from `rescanAppThatLostFocus`) → `managed_focus_observed focusedWindowChanged` back on the main browser window → `cgs_destroyed` for the bubble. Same guard, same outcome: `focusedToken` is nil at that point, so the rescan no longer fires and nothing is fronted over the popup.
