### PR TITLE
Fix Niri single-window recovery after rapid close

### DIFF
--- a/Sources/OmniWM/Core/Controller/NiriLayoutHandler.swift
+++ b/Sources/OmniWM/Core/Controller/NiriLayoutHandler.swift
@@ -457,6 +457,9 @@ enum StructuralMutationOutcome: Equatable {
         var shouldRequestRelayout = false
 
         controller.workspaceManager.withNiriViewportState(for: workspaceId) { state in
+            let activeColumnIndexBefore = state.activeColumnIndex
+            let viewOffsetBefore = state.viewOffset
+            let rebaseDeltaBefore = state.offsetTransition.rebaseDelta
             activateNode(
                 window,
                 in: workspaceId,
@@ -468,7 +471,11 @@ enum StructuralMutationOutcome: Equatable {
                 )
             )
             shouldStartScrollAnimation = state.hasPendingOffsetAnimation
+            let viewportGeometryChanged = state.activeColumnIndex != activeColumnIndexBefore
+                || state.viewOffset != viewOffsetBefore
+                || state.offsetTransition.rebaseDelta != rebaseDeltaBefore
             shouldRequestRelayout = state.offsetTransition.kind == .jump
+                && viewportGeometryChanged
         }
 
         controller.focusWindow(window.token, origin: .focusFollowsMouse)
@@ -1220,6 +1227,38 @@ enum StructuralMutationOutcome: Equatable {
         state.viewOffsetToRestore = nil
     }
 
+    private func stopMoveAnimationsForSingleWindowFit(pass: NiriLayoutPass) {
+        guard let context = pass.engine.singleWindowLayoutContext(in: pass.wsId) else { return }
+        context.container.moveAnimation = nil
+        context.window.stopMoveAnimations()
+    }
+
+    private func shouldResetViewportForSingleWindowFit(
+        node: NiriNode,
+        workspaceId: WorkspaceDescriptor.ID,
+        engine: NiriLayoutEngine,
+        controller: WMController
+    ) -> Bool {
+        if engine.singleWindowLayoutContext(in: workspaceId) != nil {
+            return true
+        }
+
+        // Focus recovery can run after the window leaves the world model but
+        // before the removal layout pass prunes its stale engine node.
+        guard engine.effectiveSingleWindowFit(in: workspaceId).mode != .containerPrimarySpan,
+              let window = node as? NiriWindow,
+              window.sizingMode == .normal,
+              let column = engine.column(of: window),
+              !column.isTabbed
+        else {
+            return false
+        }
+        let participatingEntries = controller.workspaceManager.tiledEntries(in: workspaceId).filter {
+            !controller.isManagedWindowSuppressedByMacOSHide($0.token)
+        }
+        return participatingEntries.count == 1 && participatingEntries.first?.token == window.token
+    }
+
     private func computeLayoutPlan(
         pass: NiriLayoutPass,
         motion: MotionSnapshot,
@@ -1243,6 +1282,11 @@ enum StructuralMutationOutcome: Equatable {
             viewFrame: snapshot.monitor.frame,
             scale: snapshot.monitor.scale
         )
+
+        let usesSingleWindowFit = pass.engine.singleWindowLayoutContext(in: pass.wsId) != nil
+        if usesSingleWindowFit {
+            stopMoveAnimationsForSingleWindowFit(pass: pass)
+        }
 
         let (frames, hiddenHandles) = pass.engine.calculateCombinedLayoutUsingPools(
             in: pass.wsId,
@@ -1281,16 +1325,21 @@ enum StructuralMutationOutcome: Equatable {
         }
 
         if let removalSeed = snapshot.removalSeed, !removalSeed.oldFrames.isEmpty {
-            let newFrames = pass.engine.captureWindowFrames(
-                in: pass.wsId,
-                excluding: snapshot.excludedTokens
-            )
-            let animationsTriggered = pass.engine.triggerMoveAnimations(
-                in: pass.wsId,
-                oldFrames: removalSeed.oldFrames,
-                newFrames: newFrames,
-                motion: motion
-            )
+            let animationsTriggered: Bool
+            if usesSingleWindowFit {
+                animationsTriggered = false
+            } else {
+                let newFrames = pass.engine.captureWindowFrames(
+                    in: pass.wsId,
+                    excluding: snapshot.excludedTokens
+                )
+                animationsTriggered = pass.engine.triggerMoveAnimations(
+                    in: pass.wsId,
+                    oldFrames: removalSeed.oldFrames,
+                    newFrames: newFrames,
+                    motion: motion
+                )
+            }
             let hasWindowAnimations = pass.engine.hasAnyWindowAnimationsRunning(in: pass.wsId)
             let hasColumnAnimations = pass.engine.hasAnyColumnAnimationsRunning(in: pass.wsId)
             if animationsTriggered || hasWindowAnimations || hasColumnAnimations {
@@ -2114,7 +2163,15 @@ enum StructuralMutationOutcome: Equatable {
 
         state.selectedNodeId = node.id
         controller.workspaceManager.withEngineMutationScope {
-            if !options.ensureVisible, !options.preserveViewportAnchor {
+            let usesSingleWindowFit = shouldResetViewportForSingleWindowFit(
+                node: node,
+                workspaceId: workspaceId,
+                engine: engine,
+                controller: controller
+            )
+            if usesSingleWindowFit {
+                resetViewportForSingleWindowFit(state: &state)
+            } else if !options.ensureVisible, !options.preserveViewportAnchor {
                 rebaseViewportAnchor(to: node, in: workspaceId, state: &state)
             }
 
@@ -2122,7 +2179,10 @@ enum StructuralMutationOutcome: Equatable {
                 engine.activateWindow(node.id, in: workspaceId)
             }
 
-            if options.ensureVisible, let monitor = controller.workspaceManager.monitor(for: workspaceId) {
+            if !usesSingleWindowFit,
+               options.ensureVisible,
+               let monitor = controller.workspaceManager.monitor(for: workspaceId)
+            {
                 let gap = controller.innerGap(for: monitor)
                 let workingFrame = controller.insetWorkingFrame(for: monitor)
                 engine.ensureSelectionVisible(

--- a/Tests/OmniWMTests/NiriSingleWindowRemovalTests.swift
+++ b/Tests/OmniWMTests/NiriSingleWindowRemovalTests.swift
@@ -1,0 +1,304 @@
+// SPDX-License-Identifier: GPL-2.0-only
+// Copyright (C) 2026 BarutSRB — https://github.com/BarutSRB/OmniWM
+
+import ApplicationServices
+import Foundation
+@testable import OmniWM
+import XCTest
+
+@MainActor
+final class NiriSingleWindowRemovalTests: XCTestCase {
+    func testRemovalIntoSingleWindowFitDoesNotSeedStaleMoveOffset() throws {
+        let controller = makeController()
+        controller.settings.niriSingleWindowFit = .fullScreen
+        let workspaceId = try XCTUnwrap(controller.workspaceManager.workspaceId(for: "1", createIfMissing: true))
+        _ = controller.workspaceManager.focusWorkspace(named: "1")
+        controller.niriLayoutHandler.enableNiriLayout()
+
+        let firstToken = addWindow(pid: 891_001, windowId: 891_101, to: workspaceId, controller: controller)
+        let closingToken = addWindow(pid: 891_002, windowId: 891_102, to: workspaceId, controller: controller)
+        let engine = try XCTUnwrap(controller.niriEngine)
+        let firstNode = engine.addWindow(token: firstToken, to: workspaceId, afterSelection: nil)
+        let closingNode = engine.addWindow(
+            token: closingToken,
+            to: workspaceId,
+            afterSelection: firstNode.id,
+            focusedToken: firstToken
+        )
+
+        let monitor = try XCTUnwrap(controller.workspaceManager.monitor(for: workspaceId))
+        let fullscreenFrame = controller.fullscreenLayoutFrame(for: monitor)
+        let halfWidth = fullscreenFrame.width / 2
+        let oldFirstFrame = CGRect(
+            x: fullscreenFrame.minX - halfWidth,
+            y: fullscreenFrame.minY,
+            width: halfWidth,
+            height: fullscreenFrame.height
+        )
+        let oldClosingFrame = CGRect(
+            x: fullscreenFrame.midX,
+            y: fullscreenFrame.minY,
+            width: halfWidth,
+            height: fullscreenFrame.height
+        )
+        firstNode.frame = oldFirstFrame
+        firstNode.renderedFrame = oldFirstFrame
+        closingNode.frame = oldClosingFrame
+        closingNode.renderedFrame = oldClosingFrame
+
+        var state = controller.workspaceManager.niriViewportState(for: workspaceId)
+        state.selectedNodeId = closingNode.id
+        state.activeColumnIndex = 1
+        state.viewOffset = -halfWidth
+        state.activatePrevColumnOnRemoval = 0
+        _ = controller.workspaceManager.applySessionPatch(
+            .init(
+                workspaceId: workspaceId,
+                viewportState: state,
+                rememberedFocusToken: closingToken,
+                plannedSeq: controller.workspaceManager.worldSeq
+            )
+        )
+
+        // A stale engine alone is insufficient: while both windows still
+        // participate in world state, activation must preserve the viewport.
+        var multiWindowFocusState = state
+        controller.niriLayoutHandler.activateNode(
+            firstNode,
+            in: workspaceId,
+            state: &multiWindowFocusState,
+            options: .init(
+                activateWindow: false,
+                ensureVisible: false,
+                preserveViewportAnchor: true,
+                layoutRefresh: false,
+                axFocus: false,
+                startAnimation: false
+            )
+        )
+        XCTAssertEqual(multiWindowFocusState.activeColumnIndex, 1)
+        XCTAssertEqual(multiWindowFocusState.viewOffset, -halfWidth)
+
+        _ = controller.workspaceManager.removeWindow(
+            pid: closingToken.pid,
+            windowId: closingToken.windowId
+        )
+
+        // Focus recovery can happen before the removal layout pass removes the
+        // closing node from the engine. The world model is already authoritative.
+        var preLayoutFocusState = state
+        controller.niriLayoutHandler.activateNode(
+            firstNode,
+            in: workspaceId,
+            state: &preLayoutFocusState,
+            options: .init(
+                layoutRefresh: false,
+                axFocus: false,
+                startAnimation: false
+            )
+        )
+        XCTAssertEqual(preLayoutFocusState.activeColumnIndex, 0)
+        XCTAssertEqual(preLayoutFocusState.viewOffset, 0)
+        XCTAssertFalse(preLayoutFocusState.hasPendingOffsetAnimation)
+        _ = controller.workspaceManager.applySessionPatch(
+            .init(
+                workspaceId: workspaceId,
+                viewportState: preLayoutFocusState,
+                rememberedFocusToken: firstToken,
+                plannedSeq: controller.workspaceManager.worldSeq
+            )
+        )
+
+        let plan = try XCTUnwrap(
+            controller.workspaceManager.withEngineMutationScope {
+                controller.niriLayoutHandler.layoutWithNiriEngine(
+                    activeWorkspaces: [workspaceId],
+                    useScrollAnimationPath: true,
+                    removalSeeds: [
+                        workspaceId: NiriWindowRemovalSeed(
+                            removedNodeIds: [closingNode.id],
+                            oldFrames: [
+                                firstToken: oldFirstFrame,
+                                closingToken: oldClosingFrame
+                            ],
+                            removedColumn: true
+                        )
+                    ]
+                ).first
+            }
+        )
+
+        let remainingNode = try XCTUnwrap(engine.findNode(for: firstToken, in: workspaceId))
+        XCTAssertFalse(remainingNode.hasMoveAnimationsRunning)
+        XCTAssertNil(engine.columns(in: workspaceId).first?.moveAnimation)
+        XCTAssertEqual(plan.sessionPatch.viewportState?.activeColumnIndex, 0)
+        XCTAssertEqual(plan.sessionPatch.viewportState?.viewOffset, 0)
+
+        let frameChange = try XCTUnwrap(plan.diff.frameChanges.first { $0.token == firstToken })
+        XCTAssertEqual(frameChange.frame, fullscreenFrame)
+        XCTAssertFalse(plan.animationDirectives.contains { directive in
+            if case let .startNiriScroll(directiveWorkspaceId) = directive {
+                return directiveWorkspaceId == workspaceId
+            }
+            return false
+        })
+
+        // AX focus confirmation activates the fallback window after removal. It
+        // must not reintroduce a viewport spring for a single-window-fit layout.
+        var focusState = try XCTUnwrap(plan.sessionPatch.viewportState)
+        focusState.viewOffset = -halfWidth
+        focusState.clearOffsetTransition()
+        controller.niriLayoutHandler.activateNode(
+            remainingNode,
+            in: workspaceId,
+            state: &focusState,
+            options: .init(
+                ensureVisible: false,
+                preserveViewportAnchor: true,
+                layoutRefresh: false,
+                axFocus: false,
+                startAnimation: false
+            )
+        )
+        XCTAssertEqual(focusState.activeColumnIndex, 0)
+        XCTAssertEqual(focusState.viewOffset, 0)
+        XCTAssertFalse(focusState.hasPendingOffsetAnimation)
+    }
+
+    func testColumnWidthRemovalRestartsPendingViewportAnimation() throws {
+        let controller = makeController()
+        controller.settings.niriSingleWindowFit = SingleWindowFit(mode: .containerPrimarySpan)
+        let workspaceId = try XCTUnwrap(controller.workspaceManager.workspaceId(for: "1", createIfMissing: true))
+        _ = controller.workspaceManager.focusWorkspace(named: "1")
+        controller.niriLayoutHandler.enableNiriLayout()
+
+        let firstToken = addWindow(pid: 891_011, windowId: 891_111, to: workspaceId, controller: controller)
+        let closingToken = addWindow(pid: 891_012, windowId: 891_112, to: workspaceId, controller: controller)
+        let engine = try XCTUnwrap(controller.niriEngine)
+        let firstNode = engine.addWindow(token: firstToken, to: workspaceId, afterSelection: nil)
+        let closingNode = engine.addWindow(
+            token: closingToken,
+            to: workspaceId,
+            afterSelection: firstNode.id,
+            focusedToken: firstToken
+        )
+
+        let monitor = try XCTUnwrap(controller.workspaceManager.monitor(for: workspaceId))
+        let workingFrame = controller.insetWorkingFrame(for: monitor)
+        let halfWidth = workingFrame.width / 2
+        let oldFirstFrame = workingFrame.offsetBy(dx: -halfWidth, dy: 0)
+        let oldClosingFrame = CGRect(
+            x: workingFrame.midX,
+            y: workingFrame.minY,
+            width: halfWidth,
+            height: workingFrame.height
+        )
+        firstNode.frame = oldFirstFrame
+        firstNode.renderedFrame = oldFirstFrame
+        closingNode.frame = oldClosingFrame
+        closingNode.renderedFrame = oldClosingFrame
+        if let column = engine.column(of: firstNode) {
+            column.width = .proportion(1)
+            column.cachedWidth = workingFrame.width
+            column.hasManualSingleWindowWidthOverride = true
+        }
+
+        var state = controller.workspaceManager.niriViewportState(for: workspaceId)
+        state.selectedNodeId = closingNode.id
+        state.activeColumnIndex = 1
+        state.viewOffset = -halfWidth
+        state.activatePrevColumnOnRemoval = 0
+        _ = controller.workspaceManager.applySessionPatch(
+            .init(
+                workspaceId: workspaceId,
+                viewportState: state,
+                rememberedFocusToken: closingToken,
+                plannedSeq: controller.workspaceManager.worldSeq
+            )
+        )
+        _ = controller.workspaceManager.removeWindow(pid: closingToken.pid, windowId: closingToken.windowId)
+
+        // Container-primary-span remains viewport-driven even while world
+        // membership is ahead of the stale two-column engine topology.
+        var preLayoutFocusState = state
+        controller.niriLayoutHandler.activateNode(
+            firstNode,
+            in: workspaceId,
+            state: &preLayoutFocusState,
+            options: .init(
+                activateWindow: false,
+                ensureVisible: false,
+                preserveViewportAnchor: true,
+                layoutRefresh: false,
+                axFocus: false,
+                startAnimation: false
+            )
+        )
+        XCTAssertEqual(preLayoutFocusState.activeColumnIndex, 1)
+        XCTAssertEqual(preLayoutFocusState.viewOffset, -halfWidth)
+
+        let plan = try XCTUnwrap(
+            controller.workspaceManager.withEngineMutationScope {
+                controller.niriLayoutHandler.layoutWithNiriEngine(
+                    activeWorkspaces: [workspaceId],
+                    useScrollAnimationPath: true,
+                    removalSeeds: [
+                        workspaceId: NiriWindowRemovalSeed(
+                            removedNodeIds: [closingNode.id],
+                            oldFrames: [firstToken: oldFirstFrame, closingToken: oldClosingFrame],
+                            removedColumn: true
+                        )
+                    ]
+                ).first
+            }
+        )
+
+        let viewportState = try XCTUnwrap(plan.sessionPatch.viewportState)
+        XCTAssertTrue(viewportState.hasPendingOffsetAnimation)
+        XCTAssertTrue(plan.animationDirectives.contains { directive in
+            if case let .startNiriScroll(directiveWorkspaceId) = directive {
+                return directiveWorkspaceId == workspaceId
+            }
+            return false
+        })
+    }
+
+    private func makeController() -> WMController {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("OmniWMNiriSingleWindowRemovalTests-\(UUID().uuidString)", isDirectory: true)
+        let settings = SettingsStore(
+            persistence: SettingsFilePersistence(
+                directory: root.appendingPathComponent("config", isDirectory: true),
+                startWatching: false,
+                deferSaves: false
+            ),
+            runtimeState: RuntimeStateStore(
+                directory: root.appendingPathComponent("state", isDirectory: true),
+                deferSaves: false
+            ),
+            autosaveEnabled: false
+        )
+        return WMController(
+            settings: settings,
+            windowFocusOperations: WindowFocusOperations(
+                activateApp: { _ in },
+                focusSpecificWindow: { _, _, _ in },
+                raiseWindow: { _ in }
+            )
+        )
+    }
+
+    private func addWindow(
+        pid: pid_t,
+        windowId: Int,
+        to workspaceId: WorkspaceDescriptor.ID,
+        controller: WMController
+    ) -> WindowToken {
+        controller.workspaceManager.addWindow(
+            AXWindowRef(element: AXUIElementCreateApplication(pid), windowId: windowId),
+            pid: pid,
+            windowId: windowId,
+            to: workspaceId
+        )
+    }
+}

--- a/Tests/OmniWMTests/RuntimeArchitectureTests.swift
+++ b/Tests/OmniWMTests/RuntimeArchitectureTests.swift
@@ -736,6 +736,42 @@ final class RuntimeArchitectureTests: XCTestCase {
         XCTAssertEqual(controller.intentLedger.activeManagedRequest?.origin, .focusFollowsMouse)
     }
 
+    @MainActor
+    func testNiriPointerHoverOnSettledSelectionDoesNotRequestRelayout() throws {
+        let controller = Self.controller()
+        let workspaceId = try XCTUnwrap(controller.workspaceManager.workspaceId(for: "1", createIfMissing: true))
+        _ = controller.workspaceManager.focusWorkspace(named: "1")
+        controller.niriLayoutHandler.enableNiriLayout()
+        let token = controller.workspaceManager.addWindow(
+            AXWindowRef(element: AXUIElementCreateApplication(765_704), windowId: 765_804),
+            pid: 765_704,
+            windowId: 765_804,
+            to: workspaceId
+        )
+        let node = try XCTUnwrap(controller.niriEngine?.addWindow(
+            token: token,
+            to: workspaceId,
+            afterSelection: nil
+        ))
+        controller.workspaceManager.withNiriViewportState(for: workspaceId) { state in
+            state.selectedNodeId = node.id
+            state.activeColumnIndex = 0
+            state.jumpOffset(to: 0)
+        }
+        let refreshController = controller.layoutRefreshController
+        refreshController.resetState()
+        refreshController.beginPerformanceCapture()
+        defer {
+            _ = refreshController.endPerformanceCapture()
+            refreshController.resetState()
+        }
+
+        controller.niriLayoutHandler.activatePointerHoveredWindow(node, in: workspaceId)
+
+        let metrics = try XCTUnwrap(refreshController.performanceSnapshot())
+        XCTAssertEqual(metrics.refreshesEnqueued, 0)
+    }
+
     func testMouseMoveWindowIdPrefersRoutedFieldAndFallsBackToTopmostField() throws {
         let event = try XCTUnwrap(
             CGEvent(


### PR DESCRIPTION
## Summary

- reset Niri viewport state when rapid removal collapses the workspace into single-window fit
- clear stale window and container move animations before the removal layout can seed an offscreen displacement
- avoid scheduling a nonanimated focus-follows-mouse relayout for a no-op viewport jump
- retain animated return behavior for full-width container-primary-span layouts

## Problem

A full-width Niri window can remain displaced after this sequence:

1. Start with one full-width window.
2. Open a neighboring window, moving focus and the viewport to the new column.
3. Close the new window during or immediately after its arrival animation.

Focus recovery can run after the closing window has left world state but before the removal layout pass prunes its stale engine node. The fallback activation then sees the stale two-column topology, preserves a nonzero viewport offset, and seeds a move animation from the old offscreen frame. The remaining single-window-fit window can stay shifted or animate from the wrong origin.

## Root cause

Single-window fit owns the authoritative viewport and final frame, but three paths previously continued to use stale multi-column state:

- pre-layout focus recovery could rebase or animate the viewport while the removed engine node still existed
- removal animation seeding could attach a move animation to the sole surviving window
- the later focus-confirmation activation could reintroduce the stale offset

Resetting that state also produces a no-op `.jump` transition when the viewport is already settled. Focus-follows-mouse must not turn that marker into an unnecessary relayout unless viewport geometry actually changed.

## Fix

- detect single-window fit both from the projected engine context and from authoritative world membership during the short world/engine skew
- reset active column, viewport offset, removal anchor, and selection progress before focus/layout work proceeds
- stop stale window and container move animations for a single-window-fit removal
- skip removal move-animation seeding when single-window fit owns the final frame
- schedule a nonanimated focus-follows-mouse relayout only when active column, view offset, or rebase delta changed

The full-width container-primary-span path remains animated and retains its `startNiriScroll` directive.

## Evidence

The evidence bundle is separate from the product patch. Key results:

| Test | Before | Current patch |
|---|---:|---:|
| `testRemovalIntoSingleWindowFitDoesNotSeedStaleMoveOffset` | Fail | Pass |
| `testNiriFocusFollowsMouseActivationFocusesImmediatelyWhenLayoutRefreshBlocked` | Pass | Pass |
| `testNiriPointerHoverOnSettledSelectionDoesNotRequestRelayout` | N/A | Pass |
| `testColumnWidthRemovalRestartsPendingViewportAnimation` | Pass | Pass |

Before the fix, the single-window trace records:

```text
activeColumn=0 viewOffset=-8.0 pendingOffsetAnimation=true
remainingMoveAnimation=true startsScroll=true
```

With the fix:

```text
activeColumn=0 viewOffset=0.0 pendingOffsetAnimation=false
remainingMoveAnimation=false startsScroll=false
```

The baseline failed ten consecutive deterministic runs, and the fixed test passed ten consecutive runs. Exact logs, instrumentation patches, checksums, and runtime trace provenance are preserved in the transfer package.

## Tests

Passed:

```text
swift test --filter NiriSingleWindowRemovalTests
swift test --filter RuntimeArchitectureTests/testNiriFocusFollowsMouseActivationFocusesImmediatelyWhenLayoutRefreshBlocked
swift test --filter RuntimeArchitectureTests/testNiriPointerHoverOnSettledSelectionDoesNotRequestRelayout
```

The latest full `swift test` executed 2,976 tests with 8 skipped and two unrelated failing test cases (three assertion failures):

```text
PerformanceCaptureTests.testPerformanceCaptureAutomaticallyFinalizesAfterMaximumDuration
SettingsViewTests.testAppReactivationRefreshesDiagnosticsFromGeneralSection
```

The Settings failure reproduces in a pristine upstream full run. The performance-capture test is timing-sensitive: it passed that pristine full run, but failed 5/5 interleaved isolated runs on both pristine upstream and the candidate with identical assertions. Neither failure is attributable to the Niri patch.

`make verify` passes with the repository-pinned SwiftFormat 0.62.1 and SwiftLint 0.65.1 tools.

## Already upstream

The component-aware AX frame ledger already allows a cached-frame restoration to supersede a different pending frame. The full-width scroll-driver behavior also already passes on the upstream baseline. This PR does not claim or reimplement those behaviors; their historical evidence is retained only for provenance and regression context.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved single-window layout behavior when activating or removing windows.
  * Prevented stale movement and viewport animations from affecting window placement.
  * Improved focus recovery during window removal.
  * Reduced unnecessary layout refreshes when hovering over an already-selected window.

* **Tests**
  * Added regression coverage for viewport, focus, animation, and pointer-hover behavior in Niri layouts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->