### PR TITLE
Prevent trailing trackpad scroll after workspace swipes

### DIFF
--- a/Sources/OmniWM/Core/Controller/MouseEventHandler.swift
+++ b/Sources/OmniWM/Core/Controller/MouseEventHandler.swift
@@ -11,6 +11,7 @@ private let niriTouchpadGestureRecognitionThreshold: CGFloat = 16.0
 private let macNormalizedTouchPositionToNiriGestureUnits: CGFloat = 500.0
 private let mouseWheelAxisEpsilon: CGFloat = 0.001
 private let niriWheelScrollTickAmount: CGFloat = 120.0
+private let trackpadGestureScrollTailSuppressionDuration: TimeInterval = 0.25
 private let mouseRelevantModifierFlags: CGEventFlags = [
     .maskAlternate,
     .maskShift,
@@ -243,6 +244,7 @@ final class MouseEventHandler {
         var suppressGestureStartUntilAllTouchesLift = false
         var consumeTrackpadScrollUntilAllTouchesLift = false
         var suppressTrackpadMomentumScroll = false
+        var suppressTrackpadScrollUntil: TimeInterval?
         var horizontalWheelTracker = NiriScrollTracker(tick: niriWheelScrollTickAmount)
         var verticalWheelTracker = NiriScrollTracker(tick: niriWheelScrollTickAmount)
     }
@@ -515,6 +517,23 @@ final class MouseEventHandler {
         state.consumeTrackpadScrollUntilAllTouchesLift = false
     }
 
+    private var isTrackpadGestureScrollSuppressed: Bool {
+        if isTrackpadSwipeSessionActive || state.consumeTrackpadScrollUntilAllTouchesLift {
+            return true
+        }
+        guard let deadline = state.suppressTrackpadScrollUntil else { return false }
+        guard CACurrentMediaTime() < deadline else {
+            state.suppressTrackpadScrollUntil = nil
+            return false
+        }
+        return true
+    }
+
+    private func armTrackpadScrollTailSuppression() {
+        state.suppressTrackpadScrollUntil =
+            CACurrentMediaTime() + trackpadGestureScrollTailSuppressionDuration
+    }
+
     func suspendMultitouchForSleep() {
         multitouchSource?.suspendForSleep()
     }
@@ -528,6 +547,7 @@ final class MouseEventHandler {
         state.workspaceSwipeTracker.reset()
         clearGestureLatches()
         state.suppressTrackpadMomentumScroll = false
+        state.suppressTrackpadScrollUntil = nil
     }
 
     func dispatchMouseMoved(
@@ -697,6 +717,7 @@ final class MouseEventHandler {
             state.suppressGestureStartUntilAllTouchesLift = true
             state.consumeTrackpadScrollUntilAllTouchesLift = true
             state.suppressTrackpadMomentumScroll = true
+            armTrackpadScrollTailSuppression()
         }
         resetGestureState(settleViewportGesture: false)
         return true
@@ -710,6 +731,7 @@ final class MouseEventHandler {
         resetMouseWheelTrackers()
         abortActiveGestureIfNeeded()
         clearGestureLatches()
+        state.suppressTrackpadScrollUntil = nil
     }
 
     func handleAppVisibilityChanged() {
@@ -720,6 +742,7 @@ final class MouseEventHandler {
         resetMouseWheelTrackers()
         abortActiveGestureIfNeeded()
         clearGestureLatches()
+        state.suppressTrackpadScrollUntil = nil
     }
 
     func receiveTapMouseMoved(
@@ -821,6 +844,14 @@ final class MouseEventHandler {
         if suppress, MouseTrace.shared.isActive {
             MouseTrace.record("tap: scroll suppressed loc=\(TraceFormat.point(location))")
         }
+        // A phase-less scroll event can be the tail of the same three-finger
+        // gesture. Do not enqueue it for OmniWM's ordinary mouse-wheel path:
+        // the event tap already consumed it, and re-routing it would let a
+        // stale gesture sample act after the workspace switch.
+        if isTrackpadGestureScrollSuppressed {
+            performanceCounters?.droppedTrackpadScrollEvents &+= 1
+            return true
+        }
         if momentumPhase == 0, phase == 0 {
             EventIntake.post(
                 .mouseScroll(
@@ -846,10 +877,14 @@ final class MouseEventHandler {
         phase: UInt32,
         modifiers: CGEventFlags
     ) -> Bool {
+        // Some trackpad scroll-wheel events have no phase or momentum bits.
+        // The raw multitouch session is still authoritative, so consume those
+        // events before falling through to the ordinary mouse-wheel path.
+        if isTrackpadGestureScrollSuppressed {
+            return true
+        }
         let isTrackpad = momentumPhase != 0 || phase != 0
         if isTrackpad {
-            if isTrackpadSwipeSessionActive { return true }
-            if state.consumeTrackpadScrollUntilAllTouchesLift { return true }
             if state.suppressTrackpadMomentumScroll {
                 if momentumPhase != 0 { return true }
                 if phase == CGScrollPhase.ended.rawValue || phase == CGScrollPhase.cancelled.rawValue {
@@ -2311,7 +2346,11 @@ final class MouseEventHandler {
         let activeTouchCount = Self.activeTouchCount(in: snapshot.touches)
 
         if phase == .ended || phase == .cancelled {
+            let hadGestureSession = state.gesturePhase != .idle
             defer {
+                if hadGestureSession {
+                    armTrackpadScrollTailSuppression()
+                }
                 clearGestureLatches()
                 resetGestureState()
             }
@@ -2833,6 +2872,7 @@ final class MouseEventHandler {
         finishCommittedGestureOnRelease(timestamp: timestamp, allowFlick: true)
         state.suppressGestureStartUntilAllTouchesLift = true
         state.consumeTrackpadScrollUntilAllTouchesLift = true
+        armTrackpadScrollTailSuppression()
         resetGestureState()
         state.suppressTrackpadMomentumScroll = true
     }
@@ -2874,6 +2914,7 @@ final class MouseEventHandler {
             }
             state.suppressGestureStartUntilAllTouchesLift = true
             state.consumeTrackpadScrollUntilAllTouchesLift = true
+            armTrackpadScrollTailSuppression()
         }
         resetGestureState()
     }

--- a/Tests/OmniWMTests/TrackpadWorkspaceGestureTests.swift
+++ b/Tests/OmniWMTests/TrackpadWorkspaceGestureTests.swift
@@ -384,6 +384,26 @@ final class TrackpadWorkspaceGestureTests: XCTestCase {
         XCTAssertTrue(scrollVerdict(fixture, momentumPhase: 2, phase: 0))
     }
 
+    func testClaimedSessionConsumesPhaseLessScrollEvents() throws {
+        let fixture = try makeFixture()
+        let handler = fixture.controller.mouseEventHandler
+
+        sendFrame(fixture, phase: .began, fingers: 3, x: 0.5, y: 0.2, at: 100)
+
+        XCTAssertTrue(handler.isTrackpadSwipeSessionActive)
+        XCTAssertTrue(scrollVerdict(fixture, momentumPhase: 0, phase: 0))
+    }
+
+    func testCompletedWorkspaceSwipeConsumesPhaseLessScrollTail() throws {
+        let fixture = try makeFixture()
+        let handler = fixture.controller.mouseEventHandler
+
+        _ = performVerticalSwipe(fixture, totalUnits: 220, startTime: 100)
+
+        XCTAssertFalse(handler.isTrackpadSwipeSessionActive)
+        XCTAssertTrue(scrollVerdict(fixture, momentumPhase: 0, phase: 0))
+    }
+
     func testRapidSuccessiveSwipesRejectStaleFocusHandoff() throws {
         var focusedWindowIds: [UInt32] = []
         let fixture = try makeFixture(


### PR DESCRIPTION
## Summary

- Keep horizontal and vertical three-finger workspace swipes enabled without scrolling the focused application.
- Suppress the phase-less scroll tail that can arrive after a workspace gesture has ended.
- Add regression coverage for phase-less scroll during and immediately after a completed workspace swipe.

## Root cause

The event tap consumed the gesture scroll, but a phase-less tail event could still be posted to OmniWM’s ordinary mouse-wheel path after the multitouch session reset. That event was then delivered to the focused application.

## Validation

- git diff --check origin/main...HEAD
- Local build completed with temporary compatibility workarounds for unavailable SwiftUI/FoundationModels macro plugins; those workarounds are not part of this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved trackpad workspace gestures by filtering out lingering scroll events after a gesture ends.
  * Prevented stale, phase-less trackpad events from triggering unintended actions during or after workspace switches.

* **Tests**
  * Added coverage for phase-less scroll events during active trackpad gestures.
  * Added coverage confirming trailing events are consumed after completed workspace swipes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->