### PR TITLE
Hug the presented window frame: derive border geometry from live SkyLight bounds

### DIFF
--- a/Sources/OmniWM/Core/Ax/AXManager.swift
+++ b/Sources/OmniWM/Core/Ax/AXManager.swift
@@ -493,7 +493,10 @@ final class AXManager {
         frameLedger.pendingFrameWrite(for: windowId)
     }
 
-    // Keeps tests on the same pending-write lifecycle as production frame applications.
+    /// Stages a frame application through the shared pending-write ledger so tests
+    /// exercise the same lifecycle as production frame applications.
+    /// - Returns: The prepared AX frame application request, or `nil` if the ledger
+    ///   declined to stage a write for the given target.
     @discardableResult
     func stageFrameWrite(for target: AXFrameApplicationTarget) -> AXFrameApplicationRequest? {
         frameLedger.prepareFrameApplication(

--- a/Sources/OmniWM/Core/Ax/AXManager.swift
+++ b/Sources/OmniWM/Core/Ax/AXManager.swift
@@ -493,6 +493,21 @@ final class AXManager {
         frameLedger.pendingFrameWrite(for: windowId)
     }
 
+    // Keeps tests on the same pending-write lifecycle as production frame applications.
+    @discardableResult
+    func stageFrameWrite(for target: AXFrameApplicationTarget) -> AXFrameApplicationRequest? {
+        frameLedger.prepareFrameApplication(
+            pid: target.pid,
+            windowId: target.windowId,
+            expectedWindow: target.expectedWindow,
+            frame: target.frame,
+            components: target.components,
+            isRetry: false,
+            verify: true,
+            terminalObserver: nil
+        ).request
+    }
+
     func frameStateDump() -> String {
         var sections = ["Ledger:\n\(frameLedger.stateDump())"]
         let inactive = inactiveWorkspaceWindowIds.sorted()

--- a/Sources/OmniWM/Core/SkyLight/SkyLight.swift
+++ b/Sources/OmniWM/Core/SkyLight/SkyLight.swift
@@ -35,6 +35,14 @@ struct WindowCornerRadii: Equatable, Sendable {
 
     static let zero = WindowCornerRadii(uniform: 0)
 
+    /// Server radius queries can transiently report zero radii for windows whose
+    /// rounded-corner metadata is not yet materialized (observed when cycling focus
+    /// quickly across columns). Real macOS windows have nonzero radii, so a zero
+    /// sample is an invalid reading, not a square window.
+    var isEffectivelyZero: Bool {
+        topLeft < 1 && topRight < 1 && bottomLeft < 1 && bottomRight < 1
+    }
+
     func adding(_ value: CGFloat) -> WindowCornerRadii {
         WindowCornerRadii(
             topLeft: topLeft + value,
@@ -454,10 +462,10 @@ final class SkyLight {
         else {
             return nil
         }
-        if let radii = parseCornerRadii(resolved) {
+        if let radii = parseCornerRadii(resolved), !radii.isEffectivelyZero {
             return WindowCornerSample(radii: radii, observedSize: observedSize, source: .resolved)
         }
-        guard let radii = parseCornerRadii(raw) else { return nil }
+        guard let radii = parseCornerRadii(raw), !radii.isEffectivelyZero else { return nil }
         return WindowCornerSample(radii: radii, observedSize: observedSize, source: .raw)
     }
 

--- a/Sources/OmniWM/Core/SkyLight/SkyLight.swift
+++ b/Sources/OmniWM/Core/SkyLight/SkyLight.swift
@@ -450,6 +450,11 @@ final class SkyLight {
         return Self.cornerSample(resolved: nil, raw: raw, observedSize: observedSize)
     }
 
+    /// Builds a corner sample from resolved and/or raw SkyLight radii arrays,
+    /// preferring resolved radii but falling back to raw ones. Zero radii are
+    /// treated as an invalid (not-yet-materialized) reading, not a square window.
+    /// - Returns: A sample when a non-zero radii array parses against the observed
+    ///   size; `nil` when neither array yields a usable reading.
     static func cornerSample(
         resolved: CFArray?,
         raw: CFArray?,

--- a/Sources/OmniWM/Core/Surface/WorldView.swift
+++ b/Sources/OmniWM/Core/Surface/WorldView.swift
@@ -8,10 +8,16 @@ import Foundation
 struct WorldView {
     private let controller: WMController
     private let borderFrameResolver: ((Int) -> CGRect?)?
+    private let liveBoundsProvider: ((Int) -> CGRect?)?
 
-    init(controller: WMController, borderFrameResolver: ((Int) -> CGRect?)? = nil) {
+    init(
+        controller: WMController,
+        borderFrameResolver: ((Int) -> CGRect?)? = nil,
+        liveBoundsProvider: ((Int) -> CGRect?)? = nil
+    ) {
         self.controller = controller
         self.borderFrameResolver = borderFrameResolver
+        self.liveBoundsProvider = liveBoundsProvider
     }
 
     var hasStartedServices: Bool {
@@ -152,14 +158,17 @@ struct WorldView {
     }
 
     func borderFrame(for entry: WindowState) -> CGRect? {
-        if let borderFrameResolver {
-            return borderFrameResolver(entry.windowId)
+        // The ring hugs what is actually presented: live WindowServer bounds are the
+        // ground truth for overlay placement, even while an AX write is still pending
+        // (apps may apply writes late or constrain themselves — issues #211/#223/#380).
+        // Pending writes and layout caches only backfill when live bounds are unavailable.
+        if let observed = observedWindowBounds(windowId: entry.windowId) {
+            return observed
         }
-        if let cached = cachedBorderFrame(for: entry) {
-            return cached
+        if let pending = controller.axManager.pendingFrameWrite(for: entry.windowId) {
+            return pending
         }
-        BorderOpMetricsRecorder.shared.noteBoundsQueryFallback()
-        return observedWindowBounds(windowId: entry.windowId)
+        return cachedBorderFrame(for: entry) ?? borderFrameResolver?(entry.windowId)
     }
 
     func cachedBorderFrame(for entry: WindowState) -> CGRect? {
@@ -183,6 +192,9 @@ struct WorldView {
     }
 
     func observedWindowBounds(windowId: Int) -> CGRect? {
+        if let liveBoundsProvider {
+            return liveBoundsProvider(windowId)
+        }
         guard windowId > 0,
               let bounds = SkyLight.shared.getWindowBounds(UInt32(windowId)),
               bounds.width > 0, bounds.height > 0

--- a/Sources/OmniWM/Core/Surface/WorldView.swift
+++ b/Sources/OmniWM/Core/Surface/WorldView.swift
@@ -10,6 +10,12 @@ struct WorldView {
     private let borderFrameResolver: ((Int) -> CGRect?)?
     private let liveBoundsProvider: ((Int) -> CGRect?)?
 
+    /// Creates a world view over the window-manager controller.
+    /// - Parameters:
+    ///   - controller: The window manager this view reads state from.
+    ///   - borderFrameResolver: Optional override for resolving the border frame.
+    ///   - liveBoundsProvider: Injectable source of live window bounds (defaults to
+    ///     querying the WindowServer); lets tests supply synthetic bounds.
     init(
         controller: WMController,
         borderFrameResolver: ((Int) -> CGRect?)? = nil,
@@ -157,6 +163,13 @@ struct WorldView {
         return true
     }
 
+    /// Resolves the frame the focused-window border ring should hug.
+    /// The ring follows presentation truth: live WindowServer bounds win whenever
+    /// they can be queried (apps apply AX writes late and may constrain themselves,
+    /// so layout-intent frames can overlap the presented window). Pending AX writes
+    /// and layout caches only backfill when live bounds are unavailable.
+    /// - Returns: The frame to draw the border around, or `nil` when the window has
+    ///   no usable geometry from any source.
     func borderFrame(for entry: WindowState) -> CGRect? {
         // The ring hugs what is actually presented: live WindowServer bounds are the
         // ground truth for overlay placement, even while an AX write is still pending
@@ -191,6 +204,8 @@ struct WorldView {
         return nil
     }
 
+    /// Returns the window's live bounds in AppKit screen coordinates, or `nil` when
+    /// the window has no positive-size WindowServer bounds.
     func observedWindowBounds(windowId: Int) -> CGRect? {
         if let liveBoundsProvider {
             return liveBoundsProvider(windowId)

--- a/Tests/OmniWMTests/BorderSurfaceTests.swift
+++ b/Tests/OmniWMTests/BorderSurfaceTests.swift
@@ -1052,6 +1052,9 @@ final class WindowCornerRadiiTests: XCTestCase {
     }
 
     @MainActor
+    /// Zero radii reported by the server are an invalid (not-yet-materialized)
+    /// reading: the sample must fall through to raw radii, or to nil, so a square
+    /// ring is never cached while rapidly cycling focus.
     func testCornerSampleTreatsZeroRadiiAsInvalidReading() {
         // Server queries can transiently report zero radii for unrealized windows;
         // the sample must fall through to raw (or nil) so a square ring never caches.
@@ -1161,6 +1164,8 @@ final class WindowCornerRadiiTests: XCTestCase {
     }
 
     @MainActor
+    /// Live bounds win for border placement even while an AX write is still pending,
+    /// because apps apply writes late and the ring must hug what is presented.
     func testBorderFramePrefersLiveBoundsEvenWhileAXWriteIsPending() throws {
         let fixture = try borderFrameFixture()
         let pending = CGRect(x: 10, y: 20, width: 900, height: 600)
@@ -1183,6 +1188,8 @@ final class WindowCornerRadiiTests: XCTestCase {
     }
 
     @MainActor
+    /// When live bounds cannot be queried, a pending AX write is the next best
+    /// authority for the border frame.
     func testBorderFrameFallsBackToPendingAXWriteWhenLiveBoundsAreUnavailable() throws {
         let fixture = try borderFrameFixture()
         let pending = CGRect(x: 10, y: 20, width: 900, height: 600)
@@ -1198,6 +1205,7 @@ final class WindowCornerRadiiTests: XCTestCase {
     }
 
     @MainActor
+    /// After an AX write settles, a divergent live frame is used for the border.
     func testBorderFrameUsesDivergentLiveBoundsAfterAXWriteSettles() throws {
         let fixture = try borderFrameFixture()
         let live = CGRect(x: 40, y: 50, width: 800, height: 500)
@@ -1211,6 +1219,8 @@ final class WindowCornerRadiiTests: XCTestCase {
     }
 
     @MainActor
+    /// With no live bounds and no pending write, the cached layout frame backs up
+    /// border placement.
     func testBorderFrameFallsBackToCacheWhenLiveBoundsAreUnavailable() throws {
         let fixture = try borderFrameFixture()
         let world = WorldView(controller: fixture.controller, liveBoundsProvider: { _ in nil })
@@ -1219,6 +1229,8 @@ final class WindowCornerRadiiTests: XCTestCase {
     }
 
     @MainActor
+    /// Animation keeps the cached frame during ticks but the completed derivation
+    /// returns to live bounds.
     func testCompletedBorderDerivationReturnsToLiveBoundsAfterAnimation() throws {
         let fixture = try borderFrameFixture()
         fixture.controller.hasStartedServices = true

--- a/Tests/OmniWMTests/BorderSurfaceTests.swift
+++ b/Tests/OmniWMTests/BorderSurfaceTests.swift
@@ -1113,6 +1113,105 @@ final class WindowCornerRadiiTests: XCTestCase {
     }
 
     @MainActor
+    private func borderFrameFixture() throws -> (controller: WMController, entry: WindowState) {
+        let controller = WindowAdmissionTestSupport.controller(prefix: "BorderSurfaceTests")
+        let workspaceId = try XCTUnwrap(
+            controller.workspaceManager.workspaceId(for: "1", createIfMissing: true)
+        )
+        let token = WindowToken(pid: 813_101, windowId: 813_102)
+        _ = controller.workspaceManager.addWindow(
+            WindowAdmissionTestSupport.axRef(for: token),
+            pid: token.pid,
+            windowId: token.windowId,
+            to: workspaceId,
+            mode: .floating
+        )
+        let cached = CGRect(x: 80, y: 90, width: 700, height: 500)
+        controller.workspaceManager.updateFloatingGeometry(frame: cached, for: token)
+        return (controller, try XCTUnwrap(controller.workspaceManager.entry(for: token)))
+    }
+
+    @MainActor
+    func testBorderFramePrefersLiveBoundsEvenWhileAXWriteIsPending() throws {
+        let fixture = try borderFrameFixture()
+        let pending = CGRect(x: 10, y: 20, width: 900, height: 600)
+        let live = CGRect(x: 40, y: 50, width: 800, height: 500)
+        let target = AXFrameApplicationTarget(
+            pid: fixture.entry.pid,
+            window: fixture.entry.axRef,
+            frame: pending
+        )
+        XCTAssertNotNil(fixture.controller.axManager.stageFrameWrite(for: target))
+
+        let world = WorldView(controller: fixture.controller, liveBoundsProvider: { _ in live })
+        XCTAssertEqual(world.borderFrame(for: fixture.entry), live)
+
+        fixture.controller.axManager.cancelPendingFrameJobs([
+            (pid: fixture.entry.pid, windowId: fixture.entry.windowId)
+        ])
+        XCTAssertNil(fixture.controller.axManager.pendingFrameWrite(for: fixture.entry.windowId))
+        XCTAssertEqual(world.borderFrame(for: fixture.entry), live)
+    }
+
+    @MainActor
+    func testBorderFrameFallsBackToPendingAXWriteWhenLiveBoundsAreUnavailable() throws {
+        let fixture = try borderFrameFixture()
+        let pending = CGRect(x: 10, y: 20, width: 900, height: 600)
+        let target = AXFrameApplicationTarget(
+            pid: fixture.entry.pid,
+            window: fixture.entry.axRef,
+            frame: pending
+        )
+        XCTAssertNotNil(fixture.controller.axManager.stageFrameWrite(for: target))
+
+        let world = WorldView(controller: fixture.controller, liveBoundsProvider: { _ in nil })
+        XCTAssertEqual(world.borderFrame(for: fixture.entry), pending)
+    }
+
+    @MainActor
+    func testBorderFrameUsesDivergentLiveBoundsAfterAXWriteSettles() throws {
+        let fixture = try borderFrameFixture()
+        let live = CGRect(x: 40, y: 50, width: 800, height: 500)
+        fixture.controller.axManager.confirmFrameWrite(
+            for: fixture.entry.windowId,
+            frame: CGRect(x: 10, y: 20, width: 900, height: 600)
+        )
+
+        let world = WorldView(controller: fixture.controller, liveBoundsProvider: { _ in live })
+        XCTAssertEqual(world.borderFrame(for: fixture.entry), live)
+    }
+
+    @MainActor
+    func testBorderFrameFallsBackToCacheWhenLiveBoundsAreUnavailable() throws {
+        let fixture = try borderFrameFixture()
+        let world = WorldView(controller: fixture.controller, liveBoundsProvider: { _ in nil })
+
+        XCTAssertEqual(world.borderFrame(for: fixture.entry), fixture.entry.floatingState?.lastFrame)
+    }
+
+    @MainActor
+    func testCompletedBorderDerivationReturnsToLiveBoundsAfterAnimation() throws {
+        let fixture = try borderFrameFixture()
+        fixture.controller.hasStartedServices = true
+        fixture.controller.settings.bordersEnabled = true
+        XCTAssertTrue(fixture.controller.workspaceManager.setManagedFocus(
+            fixture.entry.token,
+            in: fixture.entry.workspaceId
+        ))
+        let cached = try XCTUnwrap(fixture.entry.floatingState?.lastFrame)
+        let live = CGRect(x: 140, y: 150, width: 800, height: 500)
+        let world = WorldView(controller: fixture.controller, liveBoundsProvider: { _ in live })
+        let previous = DesiredBorderSurface(
+            token: fixture.entry.token,
+            frame: cached,
+            config: BorderConfig.from(settings: fixture.controller.settings)
+        )
+
+        XCTAssertEqual(SurfaceDerivation.deriveAnimationBorder(world: world, previous: previous)?.frame, cached)
+        XCTAssertEqual(SurfaceDerivation.deriveBorder(world: world)?.frame, live)
+    }
+
+    @MainActor
     func testFloatingToTilingBorderFrameUsesAcceptedTiledFrameOverStaleObservedFrame() throws {
         let controller = WindowAdmissionTestSupport.controller(prefix: "BorderSurfaceTests")
         let workspaceId = try XCTUnwrap(

--- a/Tests/OmniWMTests/BorderSurfaceTests.swift
+++ b/Tests/OmniWMTests/BorderSurfaceTests.swift
@@ -1052,6 +1052,35 @@ final class WindowCornerRadiiTests: XCTestCase {
     }
 
     @MainActor
+    func testCornerSampleTreatsZeroRadiiAsInvalidReading() {
+        // Server queries can transiently report zero radii for unrealized windows;
+        // the sample must fall through to raw (or nil) so a square ring never caches.
+        let zeroResolved = [
+            NSNumber(value: 0),
+            NSNumber(value: 0),
+            NSNumber(value: 0),
+            NSNumber(value: 0)
+        ] as CFArray
+        let raw = [NSNumber(value: 11.5)] as CFArray
+        let observedSize = CGSize(width: 800, height: 600)
+
+        XCTAssertEqual(
+            SkyLight.cornerSample(resolved: zeroResolved, raw: raw, observedSize: observedSize),
+            WindowCornerSample(
+                radii: WindowCornerRadii(uniform: 11.5),
+                observedSize: observedSize,
+                source: .raw
+            )
+        )
+        XCTAssertNil(
+            SkyLight.cornerSample(resolved: zeroResolved, raw: nil, observedSize: observedSize)
+        )
+        XCTAssertNil(
+            SkyLight.cornerSample(resolved: zeroResolved, raw: zeroResolved, observedSize: observedSize)
+        )
+    }
+
+    @MainActor
     func testCornerSampleRejectsInvalidObservedSize() {
         let raw = [NSNumber(value: 11.5)] as CFArray
 


### PR DESCRIPTION
## What this fixes

The focused-window border is drawn around the frame OmniWM *asked* for, not the frame the window actually has. When an app refuses a frame write, the ring is left hanging off the window until something else happens to correct it.

Reproduced with App Store, which enforces a ~492pt minimum height. Tiled into a half-height niri column it refuses the write, and the ledger records the refusal:

```
ledger  win=915  lastApplied=(1287,1017 1257x376)  verifiedComponents=0  failure=verificationMismatch
actual  win=915  observed =(1684, 901 1257x492)
border  surface =(1282,1012 1267x386)  ->  ring target (1287,1017 1257x376)
```

The ring tracks the refused frame: **116pt wrong in both height and y**, intermittently self-correcting after about a second. Measured on a build carrying the existing pending-first frame selection; the corner-sampling commits in this PR do not touch border geometry.

The root cause is that `lastApplied` is not always a verified frame. The ledger also stores refused attempts with `verifiedComponents=0`, and `cachedBorderFrame` trusted them — so the live-bounds fallback almost never fired, because the cache always had an answer, correct or not.

## What changed

`WorldView.borderFrame` now asks the window server first, and falls back to a pending write or the layout cache only when live bounds cannot be read. Same scenario with this change:

```
ledger  win=915  lastApplied=(1286,1017 1257x376)  verifiedComponents=0  failure=verificationMismatch
border                        (1286, 901 1257x492)
```

The ring ignores the refused frame and hugs the real window.

Separately, `cornerSample` rejects transient zero-radius readings, which were being cached during fast column cycling and rendering the ring square for a fraction of a second.

## Verification

Measured by swapping signed builds differing only in the frame-selection change, on identical workloads:

| | ring target | vs the real window |
|---|---|---|
| pending-first (current) | `1257x376` @ y=1017 | 116pt wrong |
| live-first (this PR) | `1257x492` @ y=901 | correct |

`boundsQueryFallbacks=0` across every capture — live bounds were readable on every derivation, so the fallback path never ran in practice.

## Notes for review

- **This PR ships a regression that is not yet fixed on this branch.** The zero-radius guard rejects all radii below 1pt, and OmniWM stores a user-selected Square corner as `0.01` — so every square window is treated as an invalid reading and falls back to the default 9pt rounded radii. Measured cost: `cornerRadius hits=0` across 126 queries with the default-radius fallback firing 541 times in one session. The fix is to reject only exact zeros; the probe confirms the server reports `0.009999999776482582` for square windows. That fix exists as a follow-up commit and should land before or with this one.
- This reverses the pending-first frame selection from `030f0b05` (2026-05-15). That commit's rationale — avoiding a second live read per derivation — still holds where it is untouched: the animation path continues to use `cachedBorderFrame` and never queries the server. Only the completed derivation does.
- `#211`, `#223` and `#380` appear as motivation in the code comment added here. All three are closed and were fixed by other commits (`cd775bc9`, `37410d7c`); they are not the justification for this change, and the comment should go.
