### PR TITLE
Anchor the Niri viewport to the durable active column during projection

### DIFF
--- a/Sources/OmniWM/Core/Layout/Niri/NiriProjection.swift
+++ b/Sources/OmniWM/Core/Layout/Niri/NiriProjection.swift
@@ -133,6 +133,13 @@ extension NiriLayoutEngine {
     ) -> Int {
         guard !projectedColumns.isEmpty else { return 0 }
 
+        // `viewOffset` is anchored to the durable `activeColumnIndex`; the selection is only a
+        // fallback for when the anchor column is fully excluded from the projection.
+        let durableIndex = state.activeColumnIndex
+        if let exactIndex = projectedColumns.firstIndex(where: { $0.durableIndex == durableIndex }) {
+            return exactIndex
+        }
+
         if let selectedNodeId = state.selectedNodeId,
            let selectedWindow = findNode(by: selectedNodeId, in: workspaceId) as? NiriWindow,
            !isExcludedFromProjection(selectedWindow.token, in: workspaceId),
@@ -140,11 +147,6 @@ extension NiriLayoutEngine {
            let projectedIndex = projectedColumns.firstIndex(where: { $0.column === selectedColumn })
         {
             return projectedIndex
-        }
-
-        let durableIndex = state.activeColumnIndex
-        if let exactIndex = projectedColumns.firstIndex(where: { $0.durableIndex == durableIndex }) {
-            return exactIndex
         }
 
         return projectedColumns.indices.min { lhs, rhs in

--- a/Tests/OmniWMTests/NiriProjectedViewportAnchorTests.swift
+++ b/Tests/OmniWMTests/NiriProjectedViewportAnchorTests.swift
@@ -1,0 +1,124 @@
+// SPDX-License-Identifier: GPL-2.0-only
+// Copyright (C) 2026 BarutSRB — https://github.com/BarutSRB/OmniWM
+
+import CoreGraphics
+import Foundation
+@testable import OmniWM
+import XCTest
+
+@MainActor
+final class NiriProjectedViewportAnchorTests: XCTestCase {
+    /// External focus (mouse click, Cmd+Tab) moves `selectedNodeId` before the viewport math runs.
+    /// With a macOS-hidden column on the workspace that math goes through the projection, whose
+    /// anchor must stay the durable `activeColumnIndex` that `viewOffset` is relative to. Otherwise
+    /// the newly focused left column is drawn one column to the right and the left half is empty.
+    func testExternalFocusWithHiddenColumnKeepsViewOrigin() throws {
+        let engine = NiriLayoutEngine()
+        engine.updateConfiguration(centerFocusedColumn: .never)
+
+        let workspaceId = WorkspaceDescriptor.ID()
+        let gap: CGFloat = 16
+        let workingFrame = CGRect(x: 0, y: 0, width: 2_560, height: 1_440)
+        let monitor = Monitor(
+            id: Monitor.ID(displayId: 7),
+            displayId: 7,
+            frame: workingFrame,
+            visibleFrame: workingFrame,
+            hasNotch: false,
+            name: "Projected anchor"
+        )
+        engine.syncWorkspaceAssignments(
+            [(workspaceId: workspaceId, monitor: monitor)],
+            orientations: [monitor.id: .horizontal]
+        )
+
+        let tokens = (1 ... 3).map { WindowToken(pid: 1, windowId: $0) }
+        for token in tokens {
+            _ = engine.addWindow(token: token, to: workspaceId, afterSelection: nil)
+        }
+        let columnSpan = (workingFrame.width - gap) * 0.5 - gap
+        for column in engine.columns(in: workspaceId) {
+            column.width = .proportion(0.5)
+            column.cachedWidth = columnSpan
+        }
+        // The third column belongs to a macOS-hidden app: still in the tree, excluded from projection.
+        engine.setProjectionExclusions([tokens[2]], in: workspaceId)
+
+        let leftWindow = try XCTUnwrap(engine.findNode(for: tokens[0], in: workspaceId))
+        let rightWindow = try XCTUnwrap(engine.findNode(for: tokens[1], in: workspaceId))
+
+        // Settled on the right column with both visible columns on screen.
+        var state = ViewportState()
+        state.activeColumnIndex = 1
+        state.selectedNodeId = rightWindow.id
+        state.jumpOffset(to: -(columnSpan + gap * 2))
+        let settledFrames = frames(engine: engine, workspaceId: workspaceId, state: state, gap: gap)
+        let settledOrigin = viewOrigin(engine: engine, workspaceId: workspaceId, state: state, gap: gap)
+
+        // Selection moves first (as in NiriLayoutHandler.activateNode); the anchor must not follow yet.
+        state.selectedNodeId = leftWindow.id
+        XCTAssertEqual(
+            engine.projectedActiveColumnIndex(
+                state: state,
+                columns: engine.projectedColumns(in: workspaceId),
+                in: workspaceId
+            ),
+            1
+        )
+        let transitionalFrames = frames(engine: engine, workspaceId: workspaceId, state: state, gap: gap)
+        XCTAssertEqual(transitionalFrames[tokens[0]], settledFrames[tokens[0]])
+        XCTAssertEqual(transitionalFrames[tokens[1]], settledFrames[tokens[1]])
+
+        engine.ensureSelectionVisible(
+            node: leftWindow,
+            in: workspaceId,
+            motion: .disabled,
+            state: &state,
+            workingFrame: workingFrame,
+            gaps: gap,
+            orientation: .horizontal
+        )
+
+        XCTAssertEqual(state.activeColumnIndex, 0)
+        XCTAssertEqual(state.viewOffset, -gap, accuracy: 0.001)
+        XCTAssertEqual(
+            viewOrigin(engine: engine, workspaceId: workspaceId, state: state, gap: gap),
+            settledOrigin,
+            accuracy: 0.001
+        )
+        let focusedFrames = frames(engine: engine, workspaceId: workspaceId, state: state, gap: gap)
+        XCTAssertEqual(focusedFrames[tokens[0]], settledFrames[tokens[0]])
+        XCTAssertEqual(focusedFrames[tokens[1]], settledFrames[tokens[1]])
+    }
+
+    private func frames(
+        engine: NiriLayoutEngine,
+        workspaceId: WorkspaceDescriptor.ID,
+        state: ViewportState,
+        gap: CGFloat
+    ) -> [WindowToken: CGRect] {
+        let monitorFrame = engine.monitorForWorkspace(workspaceId)?.frame ?? .zero
+        return engine.calculateLayout(
+            state: state,
+            workspaceId: workspaceId,
+            monitorFrame: monitorFrame,
+            screenFrame: monitorFrame,
+            gaps: (horizontal: gap, vertical: gap),
+            orientation: .horizontal
+        )
+    }
+
+    private func viewOrigin(
+        engine: NiriLayoutEngine,
+        workspaceId: WorkspaceDescriptor.ID,
+        state: ViewportState,
+        gap: CGFloat
+    ) -> CGFloat {
+        state.containerPosition(
+            at: state.activeColumnIndex,
+            containers: engine.columns(in: workspaceId),
+            gap: gap,
+            sizeKeyPath: \.cachedWidth
+        ) + state.viewOffset
+    }
+}


### PR DESCRIPTION
## Problem

With two Niri columns that both fit on screen, focusing the left window with a mouse click or Cmd+Tab draws that window in the right half of the screen and leaves the left half empty. Keyboard focus commands work fine. It only happens while a macOS-hidden app has a tiled window on the same workspace.

## Cause

`ViewportState.viewOffset` is stored relative to `activeColumnIndex`, but `projectedActiveColumnIndex` resolved the projected anchor from the selected node first and only fell back to `activeColumnIndex`. Every consumer pairs the returned index with `viewOffset` (`calculateLayoutInto`, `ensureProjectedSelectionVisible`, `endProjectedGesture`, `withProjectedViewport`, `projectedViewportAnchor`), so whenever the selection moved to another column before the anchor was rebased, the whole strip rendered shifted by one column width plus gap.

External focus takes exactly that order: `activateNode` records the new selection before `ensureSelectionVisible` runs. With projection exclusions active, `ensureProjectedSelectionVisible` then reads the already-updated selection as the "old" anchor, computes a zero rebase, and the newly focused column lands right-aligned. That geometry is a valid fit, so later relayouts keep it. Keyboard navigation runs the viewport math before touching the selection, which is why it was unaffected.

## Change

- `NiriProjection.projectedActiveColumnIndex`: resolve the durable `activeColumnIndex` first; use the selected node's column only when the anchor column is fully excluded from the projection; keep the nearest-column fallback.
- New `NiriProjectedViewportAnchorTests`: two visible columns plus a hidden third, selection moved before `ensureSelectionVisible` in the external-focus order. Asserts the anchor index, the resulting offset, and that rendered frames match the settled layout.

No behavior change for consistent states (selection column == anchor), which covers every path that rebases before or while updating the selection.

## Verification

- The new test fails on the previous code (left column rendered at x = 1288 instead of 16, offset -1288 instead of -16) and passes with this change.
- `swift test`: full suite green (3152 tests) apart from `GapSettingsTests.testLiveReloadOfDisplayTopGapOverrideMovesNextLayout`, which crashes in `QuakeTerminalController.initializeGhosttyIfNeeded` on my machine because I build against a stub GhosttyKit; the remaining 26 tests in that class pass. Unrelated to this change.
- Manual: two-column workspace with Discord hidden, on a 2560x1080 display. Focus via app activation and via real mouse clicks between the two windows keeps both columns in place; before the change the left column jumped to the right half.
- `make verify` was not run locally (no Swift 6.4 toolchain on this machine); formatting was kept by hand.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved viewport positioning when external focus changes to a hidden or excluded column.
  * The view now remains anchored to the active visible column, preventing unexpected scrolling or layout shifts.

* **Tests**
  * Added coverage verifying stable viewport origins and visible column positions during external focus changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->