### PR TITLE
Fix Quake terminal grid scale when tabs move between displays

### DIFF
--- a/Sources/OmniWM/QuakeTerminal/GhosttySurfaceView.swift
+++ b/Sources/OmniWM/QuakeTerminal/GhosttySurfaceView.swift
@@ -177,18 +177,22 @@ final class GhosttySurfaceView: NSView, @preconcurrency NSTextInputClient {
 
     init(ghosttyApp: ghostty_app_t, callbackContext: GhosttySurfaceCallbackContext) {
         super.init(frame: NSRect(x: 0, y: 0, width: 800, height: 400))
-        wantsLayer = true
-        layerContentsRedrawPolicy = .duringViewResize
 
         callbackContext.view = self
         let retainedContext = Unmanaged.passRetained(callbackContext)
+
+        // libghostty installs its own IOSurface-backed CALayer on this view
+        // (making it layer-hosting) and seeds that layer's contentsScale from
+        // scale_factor. We have no window yet, so this is only a guess; the
+        // authoritative scale is pushed from the window in updateDisplayState.
+        let initialScale = NSScreen.main?.backingScaleFactor ?? 1.0
 
         var config = ghostty_surface_config_new()
         config.platform_tag = GHOSTTY_PLATFORM_MACOS
         config.platform = ghostty_platform_u(macos: ghostty_platform_macos_s(
             nsview: Unmanaged.passUnretained(self).toOpaque()
         ))
-        config.scale_factor = Double(NSScreen.main?.backingScaleFactor ?? 1.0)
+        config.scale_factor = Double(initialScale)
         config.userdata = retainedContext.toOpaque()
 
         guard let surface = ghostty_surface_new(ghosttyApp, &config) else {
@@ -198,13 +202,8 @@ final class GhosttySurfaceView: NSView, @preconcurrency NSTextInputClient {
         }
         self.ghosttySurface = surface
         self.retainedCallbackContext = retainedContext
+        lastAppliedContentScale = initialScale
         updateSurfaceOcclusion()
-
-        if let layer {
-            let scale = layer.contentsScale
-            ghostty_surface_set_content_scale(surface, scale, scale)
-            lastAppliedContentScale = scale
-        }
 
         let trackingArea = NSTrackingArea(
             rect: .zero,
@@ -229,17 +228,6 @@ final class GhosttySurfaceView: NSView, @preconcurrency NSTextInputClient {
     isolated deinit {
         NotificationCenter.default.removeObserver(self)
         releaseSurface()
-    }
-
-    override func makeBackingLayer() -> CALayer {
-        let metalLayer = CAMetalLayer()
-        metalLayer.contentsScale = window?.backingScaleFactor ?? NSScreen.main?.backingScaleFactor ?? 1.0
-        metalLayer.autoresizingMask = [.layerWidthSizable, .layerHeightSizable]
-        if let displayId, let surface = ghosttySurface {
-            ghostty_surface_set_display_id(surface, displayId)
-            lastAppliedDisplayId = displayId
-        }
-        return metalLayer
     }
 
     private var displayId: UInt32? {
@@ -286,6 +274,16 @@ final class GhosttySurfaceView: NSView, @preconcurrency NSTextInputClient {
 
     @objc private func windowDidChangeScreen(_ notification: Notification) {
         updateDisplayState()
+        // The window's backing scale can lag the screen change by a turn of
+        // the run loop. Re-check once it has settled, as Ghostty's own view does.
+        DispatchQueue.main.async { [weak self] in
+            self?.updateDisplayState()
+        }
+    }
+
+    override func viewDidChangeBackingProperties() {
+        super.viewDidChangeBackingProperties()
+        updateDisplayState()
     }
 
     @objc private func windowDidChangeOcclusionState(_ notification: Notification) {
@@ -301,10 +299,23 @@ final class GhosttySurfaceView: NSView, @preconcurrency NSTextInputClient {
         }
     }
 
+    /// Pushes the window's backing scale, display, and pixel size to Ghostty.
+    ///
+    /// Ghostty sizes its render target from `layer.bounds * layer.contentsScale`
+    /// and its grid from `ghostty_surface_set_size`, so the layer scale, the
+    /// content scale, and the pixel size must all come from the same window.
+    /// Without a window there is no authoritative scale, so nothing is pushed;
+    /// `viewDidMoveToWindow` runs this again once one is available.
     private func updateDisplayState() {
-        guard let metalLayer = layer as? CAMetalLayer, let surface = ghosttySurface else { return }
-        let scale = window?.backingScaleFactor ?? NSScreen.main?.backingScaleFactor ?? 1.0
-        metalLayer.contentsScale = scale
+        guard let surface = ghosttySurface, let window else { return }
+        let scale = window.backingScaleFactor
+
+        if let layer, layer.contentsScale != scale {
+            CATransaction.begin()
+            CATransaction.setDisableActions(true)
+            layer.contentsScale = scale
+            CATransaction.commit()
+        }
 
         if let displayId, displayId != lastAppliedDisplayId {
             ghostty_surface_set_display_id(surface, displayId)
@@ -370,8 +381,11 @@ final class GhosttySurfaceView: NSView, @preconcurrency NSTextInputClient {
     }
 
     func syncGhosttySurfaceSize(backingScale explicitBackingScale: CGFloat? = nil) {
-        let scale = explicitBackingScale ?? window?.backingScaleFactor ?? 1.0
         guard let surface = ghosttySurface else { return }
+        // A detached view has no trustworthy scale. Pushing the point size at
+        // 1x would hand Ghostty a half-size grid on a Retina window, so wait
+        // for viewDidMoveToWindow to resync instead.
+        guard let scale = explicitBackingScale ?? window?.backingScaleFactor else { return }
         let surfaceSize = ghostty_surface_size(surface)
 
         let pixelSize = GhosttySurfacePixelSizeNormalizer.normalize(


### PR DESCRIPTION
Opening a new Quake terminal tab on an external display sometimes drew the grid in only the top-left quadrant of the window. A tab created on the external display and then used on the built-in one had its bottom rows clipped, hiding the prompt.

libghostty 1.2+ replaces the surface view's layer with its own IOSurface-backed `CALayer` subclass, so the `layer as? CAMetalLayer` guard in `updateDisplayState` never matched a live surface. Display id, content scale, layer scale, and the corrected pixel size were never pushed after creation, and the earlier cross-monitor reveal fix (#438) was a no-op through the same guard. The layer's `contentsScale` stayed at whatever `NSScreen.main` reported at creation, while the grid was pushed at the window's scale, or at 1x while the view was detached during tab setup. On a display with a different backing scale the two disagreed.

This lets libghostty install its layer, drives whatever layer is present, and pushes layer scale, content scale, display id, and pixel size from the same window. Detached views no longer push a 1x size and instead resync in `viewDidMoveToWindow`. Adds `viewDidChangeBackingProperties` and a deferred re-check after a screen change, mirroring Ghostty's own AppKit view.

Verified on a MacBook built-in display plus an external display with a different backing scale: new tabs on the external, tabs created on one display and used on the other in both directions, hidden-then-revealed after unplugging, and switching between tabs from both displays.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved display scaling when moving terminal windows between screens with different resolutions.
  - Updated rendering behavior to respond more reliably to changes in window backing properties.
  - Prevented incorrect sizing when the window or display scale is not yet available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->