### PR TITLE
Add a side-by-side dev install with its own bundle identifier

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: format format-check lint lint-fix build run energy-profile test-skylight-live release-check verify check check-tool-versions check-swiftformat-version check-swiftlint-version
+.PHONY: format format-check lint lint-fix build run dev-install use-dev use-release energy-profile test-skylight-live release-check verify check check-tool-versions check-swiftformat-version check-swiftlint-version
 
 SWIFTFORMAT_VERSION = 0.63.0
 SWIFTLINT_VERSION = 0.65.1

--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,17 @@ run:
 	-pkill -x OmniWM
 	open ./dist/OmniWM.app
 
+# Side-by-side dev copy: "/Applications/OmniWM Dev.app" with its own bundle id,
+# so its privacy grants never collide with the release install.
+dev-install:
+	./Scripts/omniwm-dev.sh install
+
+use-dev:
+	./Scripts/omniwm-dev.sh use dev
+
+use-release:
+	./Scripts/omniwm-dev.sh use release
+
 energy-profile:
 	./Scripts/energy-profile.sh
 

--- a/Scripts/omniwm-dev.sh
+++ b/Scripts/omniwm-dev.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# Maintain a side-by-side development copy of OmniWM.
+#
+#   omniwm-dev.sh install        build the current tree as "OmniWM Dev.app",
+#                                install it to /Applications, and switch to it
+#   omniwm-dev.sh use dev        quit the release copy, launch the dev copy
+#   omniwm-dev.sh use release    quit the dev copy, launch the release copy
+#
+# The dev copy has bundle id com.barut.OmniWM.dev, so macOS keeps its
+# Accessibility and Input Monitoring grants separate from the release copy.
+# Grants survive rebuilds only when the signature is stable: create a
+# self-signed "Code Signing" certificate named "OmniWM Dev" in Keychain Access
+# and this script will use it. Without one the build is ad-hoc signed and
+# macOS asks for the grants again after every rebuild.
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+DEV_APP_NAME="${OMNIWM_DEV_APP_NAME:-OmniWM Dev}"
+DEV_BUNDLE_ID="${OMNIWM_DEV_BUNDLE_ID:-com.barut.OmniWM.dev}"
+DEV_IDENTITY="${OMNIWM_SIGNING_IDENTITY:-OmniWM Dev}"
+INSTALL_DIR="${OMNIWM_DEV_INSTALL_DIR:-/Applications}"
+RELEASE_APP="${OMNIWM_RELEASE_APP:-/Applications/OmniWM.app}"
+RELEASE_BUNDLE_ID="com.barut.OmniWM"
+DEV_APP="$INSTALL_DIR/$DEV_APP_NAME.app"
+
+usage() {
+  sed -n '2,15p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+  exit 64
+}
+
+quit_app() {
+  local bundle_id="$1"
+  if ! pgrep -qx OmniWM; then
+    return 0
+  fi
+  osascript -e "tell application id \"$bundle_id\" to quit" >/dev/null 2>&1 || true
+  for _ in $(seq 1 40); do
+    if ! osascript -e "tell application \"System Events\" to (bundle identifier of processes) contains \"$bundle_id\"" 2>/dev/null | grep -q true; then
+      return 0
+    fi
+    sleep 0.25
+  done
+  echo "omniwm-dev: $bundle_id did not quit cleanly, killing it" >&2
+  pkill -f "/Contents/MacOS/OmniWM$" || true
+}
+
+wait_for_no_omniwm() {
+  # The launch conflict checker blocks a second OmniWM process, so make sure
+  # the previous copy is gone before opening the next one.
+  for _ in $(seq 1 40); do
+    pgrep -qx OmniWM || return 0
+    sleep 0.25
+  done
+  echo "omniwm-dev: an OmniWM process is still running; the new copy will wait for it" >&2
+}
+
+install_dev() {
+  if security find-identity -v -p codesigning 2>/dev/null | grep -qF "\"$DEV_IDENTITY\""; then
+    echo "omniwm-dev: signing with \"$DEV_IDENTITY\" (privacy grants will survive rebuilds)"
+  else
+    echo "omniwm-dev: no \"$DEV_IDENTITY\" certificate found; ad-hoc signing (grants reset on every rebuild)" >&2
+  fi
+
+  OMNIWM_APP_NAME="$DEV_APP_NAME" \
+  OMNIWM_BUNDLE_ID="$DEV_BUNDLE_ID" \
+  OMNIWM_SIGNING_IDENTITY="$DEV_IDENTITY" \
+    "$ROOT_DIR/Scripts/package-app.sh" debug dev
+
+  quit_app "$RELEASE_BUNDLE_ID"
+  quit_app "$DEV_BUNDLE_ID"
+  wait_for_no_omniwm
+
+  rm -rf "$DEV_APP"
+  ditto "$ROOT_DIR/dist/$DEV_APP_NAME.app" "$DEV_APP"
+  echo "omniwm-dev: installed $DEV_APP"
+  open "$DEV_APP"
+}
+
+use_copy() {
+  case "${1:-}" in
+    dev)
+      [ -d "$DEV_APP" ] || { echo "omniwm-dev: $DEV_APP is missing; run 'make dev-install' first" >&2; exit 1; }
+      quit_app "$RELEASE_BUNDLE_ID"
+      wait_for_no_omniwm
+      open "$DEV_APP"
+      ;;
+    release)
+      [ -d "$RELEASE_APP" ] || { echo "omniwm-dev: $RELEASE_APP is missing" >&2; exit 1; }
+      quit_app "$DEV_BUNDLE_ID"
+      wait_for_no_omniwm
+      open "$RELEASE_APP"
+      ;;
+    *)
+      usage
+      ;;
+  esac
+}
+
+case "${1:-}" in
+  install) install_dev ;;
+  use) use_copy "${2:-}" ;;
+  *) usage ;;
+esac

--- a/Scripts/omniwm-dev.sh
+++ b/Scripts/omniwm-dev.sh
@@ -24,7 +24,7 @@ RELEASE_BUNDLE_ID="com.barut.OmniWM"
 DEV_APP="$INSTALL_DIR/$DEV_APP_NAME.app"
 
 usage() {
-  sed -n '2,15p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+  sed -n '2,14p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
   exit 64
 }
 

--- a/Scripts/package-app.sh
+++ b/Scripts/package-app.sh
@@ -4,7 +4,12 @@ set -euo pipefail
 CONFIG="${1:-release}"
 SIGN_AND_NOTARIZE="${2:-true}"
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-APP_DIR="$ROOT_DIR/dist/OmniWM.app"
+# A side-by-side dev install sets these so macOS treats it as a separate app
+# (own privacy grants, own login item). The executable stays "OmniWM" because
+# the launch conflict checker and build info key off that name.
+APP_NAME="${OMNIWM_APP_NAME:-OmniWM}"
+BUNDLE_ID="${OMNIWM_BUNDLE_ID:-com.barut.OmniWM}"
+APP_DIR="$ROOT_DIR/dist/$APP_NAME.app"
 GHOSTTY_LIBRARY_DIR="$("$ROOT_DIR/Scripts/ghostty-preflight.sh" print-library-dir)"
 SWIFT_BUILD_ARGS=(-c "$CONFIG" --arch arm64)
 
@@ -38,6 +43,11 @@ cp "$CLI_EXECUTABLE" "$APP_DIR/Contents/MacOS/omniwmctl"
 cp "$ROOT_DIR/Info.plist" "$APP_DIR/Contents/Info.plist"
 if command -v plutil >/dev/null 2>&1; then
   plutil -replace OMNIWMGitHash -string "$(git -C "$ROOT_DIR" rev-parse --short HEAD 2>/dev/null || echo SNAPSHOT)" "$APP_DIR/Contents/Info.plist"
+  if [ "$APP_NAME" != "OmniWM" ] || [ "$BUNDLE_ID" != "com.barut.OmniWM" ]; then
+    plutil -replace CFBundleIdentifier -string "$BUNDLE_ID" "$APP_DIR/Contents/Info.plist"
+    plutil -replace CFBundleName -string "$APP_NAME" "$APP_DIR/Contents/Info.plist"
+    plutil -replace CFBundleDisplayName -string "$APP_NAME" "$APP_DIR/Contents/Info.plist"
+  fi
 fi
 cp "$ROOT_DIR/Resources/AppIcon.icns" "$APP_DIR/Contents/Resources/AppIcon.icns"
 cp -R "$BUILD_DIR/OmniWM_OmniWM.bundle" "$APP_DIR/Contents/Resources/"


### PR DESCRIPTION
Testing a local build next to the Homebrew install was painful because both copies shared the bundle id `com.barut.OmniWM`. macOS keys the Accessibility and Input Monitoring grants on that id, so they landed on whichever copy LaunchServices resolved, and switching between the two meant resetting and re-granting each time.

This adds a contributor workflow for keeping a dev copy installed alongside the release:

- `Scripts/package-app.sh` takes `OMNIWM_APP_NAME` and `OMNIWM_BUNDLE_ID` overrides that rewrite the bundle name, display name, and identifier. Defaults are unchanged, so release packaging and `make run` behave as before. The executable stays `OmniWM` because the launch conflict checker and build info key off that name.
- `Scripts/omniwm-dev.sh` packages the tree as `OmniWM Dev.app` with bundle id `com.barut.OmniWM.dev`, installs it to `/Applications`, and switches between the two copies. It quits one copy before opening the other, since the conflict checker refuses to start while another OmniWM process is running.
- Makefile targets `make dev-install`, `make use-dev`, and `make use-release` wrap it.

Grants only survive rebuilds when the signature is stable, so the script signs with a self-signed "OmniWM Dev" certificate when one exists and warns that it falls back to ad-hoc signing otherwise.

Both copies share `~/.config/omniwm`. UserDefaults and the login item are per bundle id, and the IPC socket path is unchanged, so `omniwmctl` talks to whichever copy is running.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for installing a separate development version of the app alongside the release version on macOS.
  - Added commands to install development builds and switch between development and release configurations.
  - Development builds can use distinct names and identifiers to prevent conflicts with release installations.
  - Improved handling of running app instances during installation and configuration switching.
  - Added validation and guidance for unsupported development-app commands.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->